### PR TITLE
CHET-86: Create new type to manage file migration error

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/Crawler.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/Crawler.java
@@ -1,11 +1,11 @@
 package com.atlassian.migration.datacenter.core.fs;
 
-import com.atlassian.migration.datacenter.spi.FailableOperation;
+import com.atlassian.migration.datacenter.spi.fs.FailableFileOperation;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-public interface Crawler extends FailableOperation {
+public interface Crawler extends FailableFileOperation {
     void crawlDirectory(Path start, ConcurrentLinkedQueue<Path> queue) throws IOException;
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -40,7 +40,7 @@ public class DirectoryStreamCrawler implements Crawler {
     }
 
     @Override
-    public FailedFileMigrationReport getFailed() {
+    public FailedFileMigrationReport getFileMigrationFailureReport() {
         return failedPaths;
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -64,7 +64,7 @@ public class S3Uploader implements Uploader {
     }
 
     @Override
-    public FailedFileMigrationReport getFailed() {
+    public FailedFileMigrationReport getFileMigrationFailureReport() {
         return failedFiles;
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -1,5 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs;
 
+import com.atlassian.migration.datacenter.spi.fs.FailedFileMigrationReport;
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -23,7 +25,7 @@ public class S3Uploader implements Uploader {
     private static final Logger logger = LoggerFactory.getLogger(S3Uploader.class);
     private static final int MS_TO_WAIT_FOR_CRAWLER = 500; // ms
 
-    private final Map<String, Exception> failedFiles = new HashMap<>();
+    private final FailedFileMigrationReport failedFiles = new FailedFileMigrationReport();
     private final Queue<S3UploadOperation> responsesQueue = new LinkedList<>();
     private final S3UploadConfig config;
 
@@ -40,7 +42,7 @@ public class S3Uploader implements Uploader {
                     Thread.sleep(MS_TO_WAIT_FOR_CRAWLER);
                 } catch (InterruptedException e) {
                     logger.error("Interrupted S3 upload, adding all remaining files to failed collection");
-                    queue.forEach(p -> addFailedFile(p, e));
+                    queue.forEach(p -> addFailedFile(p, e.getMessage()));
                 }
             } else {
                 if (Files.exists(path)) {
@@ -54,30 +56,32 @@ public class S3Uploader implements Uploader {
 
                     responsesQueue.add(uploadOperation);
                 } else {
-                    addFailedFile(path, new FileNotFoundException(String.format("File doesn't exist: %s", path)));
+                    addFailedFile(path, String.format("File doesn't exist: %s", path));
                 }
             }
         }
-        responsesQueue.forEach(operation -> {
-            try {
-                final PutObjectResponse evaluatedResponse = operation.response.get();
-                if (!evaluatedResponse.sdkHttpResponse().isSuccessful()) {
-                    final String errorMessage = String.format("Error when uploading to S3, %s", evaluatedResponse.sdkHttpResponse().statusText());
-                    addFailedFile(operation.path, S3Exception.builder().message(errorMessage).build());
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                addFailedFile(operation.path, e);
-            }
-        });
+        responsesQueue.forEach(this::handlePutObjectResponse);
     }
 
     @Override
-    public Map<String, Exception> getFailed() {
-        return Collections.unmodifiableMap(failedFiles);
+    public FailedFileMigrationReport getFailed() {
+        return failedFiles;
     }
 
-    private void addFailedFile(Path path, Exception reason) {
-        failedFiles.put(path.toString(), reason);
+    private void handlePutObjectResponse(S3UploadOperation operation) {
+        try {
+            final PutObjectResponse evaluatedResponse = operation.response.get();
+            if (!evaluatedResponse.sdkHttpResponse().isSuccessful()) {
+                final String errorMessage = String.format("Error when uploading to S3, %s", evaluatedResponse.sdkHttpResponse().statusText());
+                addFailedFile(operation.path, errorMessage);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            addFailedFile(operation.path, e.getMessage());
+        }
+    }
+
+    private void addFailedFile(Path path, String reason) {
+        failedFiles.reportFileNotMigrated(path, reason);
     }
 
     private static class S3UploadOperation {

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/Uploader.java
@@ -1,11 +1,11 @@
 package com.atlassian.migration.datacenter.core.fs;
 
-import com.atlassian.migration.datacenter.spi.FailableOperation;
+import com.atlassian.migration.datacenter.spi.fs.FailableFileOperation;
 
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public interface Uploader extends FailableOperation {
+public interface Uploader extends FailableFileOperation {
     void upload(ConcurrentLinkedQueue<Path> queue, AtomicBoolean isCrawlDone);
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/FailableOperation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/FailableOperation.java
@@ -1,7 +1,0 @@
-package com.atlassian.migration.datacenter.spi;
-
-import java.util.Map;
-
-public interface FailableOperation {
-    Map<String, Exception> getFailed();
-}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailableFileOperation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailableFileOperation.java
@@ -3,5 +3,5 @@ package com.atlassian.migration.datacenter.spi.fs;
 import java.util.Map;
 
 public interface FailableFileOperation {
-    FailedFileMigrationReport getFailed();
+    FailedFileMigrationReport getFileMigrationFailureReport();
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailableFileOperation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailableFileOperation.java
@@ -1,0 +1,7 @@
+package com.atlassian.migration.datacenter.spi.fs;
+
+import java.util.Map;
+
+public interface FailableFileOperation {
+    FailedFileMigrationReport getFailed();
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailedFileMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailedFileMigrationReport.java
@@ -18,7 +18,7 @@ public class FailedFileMigrationReport {
         failedMigrations.add(new FailedFileMigration(path, reason));
     }
 
-    public List<FailedFileMigration> getFailedMigrations() {
+    public List<FailedFileMigration> getFailedFiles() {
         return ImmutableList.copyOf(failedMigrations);
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailedFileMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/FailedFileMigrationReport.java
@@ -1,0 +1,43 @@
+package com.atlassian.migration.datacenter.spi.fs;
+
+import com.google.common.collect.ImmutableList;
+
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.List;
+
+public class FailedFileMigrationReport {
+
+    private final List<FailedFileMigration> failedMigrations;
+
+    public FailedFileMigrationReport() {
+        this.failedMigrations = new LinkedList<>();
+    }
+
+    public void reportFileNotMigrated(Path path, String reason) {
+        failedMigrations.add(new FailedFileMigration(path, reason));
+    }
+
+    public List<FailedFileMigration> getFailedMigrations() {
+        return ImmutableList.copyOf(failedMigrations);
+    }
+
+    private class FailedFileMigration {
+        private final Path filePath;
+
+        private final String reason;
+
+        public FailedFileMigration(Path filePath, String reason) {
+            this.filePath = filePath;
+            this.reason = reason;
+        }
+
+        public Path getFilePath() {
+            return filePath;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+    }
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
@@ -58,6 +58,6 @@ class DirectoryStreamCrawlerTest {
 
         directoryStreamCrawler.crawlDirectory(tempDir, queue);
 
-        assertEquals(directoryStreamCrawler.getFailed().size(), 1);
+        assertEquals(directoryStreamCrawler.getFileMigrationFailureReport().getFailedFiles().size(), 1);
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -82,7 +82,7 @@ class S3UploaderTest {
         // upload should finish and there shouldn't be more paths to process
         assertTrue(submit.isDone());
         assertTrue(queue.isEmpty());
-        assertTrue(uploader.getFailed().isEmpty());
+        assertTrue(uploader.getFileMigrationFailureReport().getFailedFiles().isEmpty());
     }
 
     @Test
@@ -93,7 +93,7 @@ class S3UploaderTest {
 
         uploader.upload(queue, isCrawlDone);
 
-        assertEquals(uploader.getFailed().size(), 1);
+        assertEquals(uploader.getFileMigrationFailureReport().getFailedFiles().size(), 1);
     }
 
     Path addFileToQueue(String fileName) throws IOException {


### PR DESCRIPTION
I've refactored the file migration error handling to only store a string, not the whole exception. I also created some neater types to manage errors. This is a precursor to presenting the errors to the user by incorporating them into the FileSystemMigrationStatus.

I tried to incorporate @theghostwhoforks 's feedback about using CompletableFuture chaining into the S3Uploader but it proved too difficult to do this correctly, elegantly and while preserving all information required to construct the FileOperationError.