### PR TITLE
CHET-119: Time FS migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,12 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -125,6 +125,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
             logger.error("Failed to traverse home directory for S3 transfer", e);
             report.setStatus(FAILED);
         } finally {
+            // FIXME: the uploader will continue uploading until the queue is empty even though we probably need to abort in this scenario as it's indeterminate whether all files have been uploaded or not (should we try fix this now or create a bug and follow up?)
             isDoneCrawling.set(true);
         }
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -25,12 +25,12 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
 
     private Instant startTime;
     private Instant completeTime;
-    private FilesystemMigrationStatus status;
+    private FilesystemMigrationStatus currentStatus;
 
     public DefaultFileSystemMigrationReport(FileSystemMigrationErrorReport errorReport, FileSystemMigrationProgress progress) {
         this.errorReport = errorReport;
         this.progress = progress;
-        this.status = NOT_STARTED;
+        this.currentStatus = NOT_STARTED;
         this.clock = Clock.systemUTC();
     }
 
@@ -42,12 +42,12 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
             completeTime = Instant.now(clock);
         }
 
-        this.status = status;
+        this.currentStatus = status;
     }
 
     @Override
     public FilesystemMigrationStatus getStatus() {
-        return status;
+        return currentStatus;
     }
 
     @Override
@@ -60,7 +60,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     private boolean isRunning() {
-        return status == RUNNING;
+        return currentStatus == RUNNING;
     }
 
     @Override
@@ -87,16 +87,16 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
         this.clock = clock;
     }
 
-    private boolean isStartingMigration(FilesystemMigrationStatus status) {
-        return this.status != RUNNING && status == RUNNING;
+    private boolean isStartingMigration(FilesystemMigrationStatus toStatus) {
+        return this.currentStatus != RUNNING && toStatus == RUNNING;
     }
 
-    private boolean isEndingMigration(FilesystemMigrationStatus status) {
-        return this.status == RUNNING && isTerminalState(status);
+    private boolean isEndingMigration(FilesystemMigrationStatus toStatus) {
+        return this.currentStatus == RUNNING && isTerminalState(toStatus);
     }
 
-    private boolean isTerminalState(FilesystemMigrationStatus status) {
-        return status == DONE || status == FAILED;
+    private boolean isTerminalState(FilesystemMigrationStatus toStatus) {
+        return toStatus == DONE || toStatus == FAILED;
     }
 }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -38,9 +38,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     public void setStatus(FilesystemMigrationStatus status) {
         if (isStartingMigration(status)) {
             startTime = Instant.now(clock);
-        }
-
-        if (isendingMigration(status)) {
+        } else if (isEndingMigration(status)) {
             completeTime = Instant.now(clock);
         }
 
@@ -93,7 +91,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
         return this.status != RUNNING && status == RUNNING;
     }
 
-    private boolean isendingMigration(FilesystemMigrationStatus status) {
+    private boolean isEndingMigration(FilesystemMigrationStatus status) {
         return this.status == RUNNING && isTerminalState(status);
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -6,31 +6,47 @@ import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationRe
 import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
 
 import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
 
 public class DefaultFileSystemMigrationReport implements FileSystemMigrationReport {
+
+    private Clock clock;
 
     private final FileSystemMigrationErrorReport errorReport;
     private final FileSystemMigrationProgress progress;
 
+    private Instant startTime;
     private FilesystemMigrationStatus status;
 
     public DefaultFileSystemMigrationReport(FileSystemMigrationErrorReport errorReport, FileSystemMigrationProgress progress) {
         this.errorReport = errorReport;
         this.progress = progress;
         this.status = NOT_STARTED;
+        this.clock = Clock.systemUTC();
     }
 
     @Override
     public void setStatus(FilesystemMigrationStatus status) {
+        if (isStartingMigration(status)) {
+            startTime = Instant.now(clock);
+        }
         this.status = status;
     }
 
     @Override
     public FilesystemMigrationStatus getStatus() {
         return status;
+    }
+
+    @Override
+    public Duration getElapsedTime() {
+        return Duration.between(startTime, Instant.now(clock));
     }
 
     @Override
@@ -51,6 +67,14 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     @Override
     public void reportFileMigrated(Path path) {
         progress.reportFileMigrated(path);
+    }
+
+    public void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    private boolean isStartingMigration(FilesystemMigrationStatus status) {
+        return this.status != RUNNING && status == RUNNING;
     }
 }
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationReport.java
@@ -1,9 +1,13 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
+import java.time.Duration;
+
 public interface FileSystemMigrationReport extends FileSystemMigrationErrorReport, FileSystemMigrationProgress {
 
     void setStatus(FilesystemMigrationStatus status);
 
     FilesystemMigrationStatus getStatus();
+
+    Duration getElapsedTime();
 
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -92,7 +92,23 @@ public class DefaultFileSystemMigrationReportTest {
         sut.setClock(Clock.offset(testClock, Duration.ofDays(1).plusSeconds(5)));
 
         assertEquals(1L, sut.getElapsedTime().toDays());
-        assertEquals(5L, sut.getElapsedTime().minusDays(1).getSeconds());
+    }
+
+    @Test
+    void shouldNotRestartTimerWhenTransitioningFromRunningToRunning() {
+        Clock testClock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
+        sut.setClock(testClock);
+
+        sut.setStatus(RUNNING);
+
+        sut.setClock(Clock.offset(testClock, Duration.ofSeconds(10)));
+        assertEquals(10L, sut.getElapsedTime().getSeconds());
+
+        sut.setStatus(RUNNING);
+        assertEquals(10L, sut.getElapsedTime().getSeconds());
+
+        sut.setClock(Clock.offset(testClock, Duration.ofSeconds(20)));
+        assertEquals(20L, sut.getElapsedTime().getSeconds());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -3,9 +3,12 @@ package com.atlassian.migration.datacenter.core.fs.reporting;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -92,8 +95,9 @@ public class DefaultFileSystemMigrationReportTest {
         assertEquals(5L, sut.getElapsedTime().minusDays(1).getSeconds());
     }
 
-    @Test
-    void shouldNotIncrementElapsedTimeAfterMigrationEnds() {
+    @ParameterizedTest
+    @EnumSource(value = FilesystemMigrationStatus.class, names = {"DONE", "FAILED"})
+    void shouldNotIncrementElapsedTimeAfterMigrationEnds(FilesystemMigrationStatus status) {
         Clock testClock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
         sut.setClock(testClock);
 
@@ -102,7 +106,7 @@ public class DefaultFileSystemMigrationReportTest {
         sut.setClock(Clock.offset(testClock, Duration.ofSeconds(10)));
         assertEquals(10L, sut.getElapsedTime().getSeconds());
 
-        sut.setStatus(DONE);
+        sut.setStatus(status);
         sut.setClock(Clock.offset(testClock, Duration.ofSeconds(20)));
         assertEquals(10L, sut.getElapsedTime().getSeconds());
     }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
@@ -89,5 +90,20 @@ public class DefaultFileSystemMigrationReportTest {
 
         assertEquals(1L, sut.getElapsedTime().toDays());
         assertEquals(5L, sut.getElapsedTime().minusDays(1).getSeconds());
+    }
+
+    @Test
+    void shouldNotIncrementElapsedTimeAfterMigrationEnds() {
+        Clock testClock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
+        sut.setClock(testClock);
+
+        sut.setStatus(RUNNING);
+
+        sut.setClock(Clock.offset(testClock, Duration.ofSeconds(10)));
+        assertEquals(10L, sut.getElapsedTime().getSeconds());
+
+        sut.setStatus(DONE);
+        sut.setClock(Clock.offset(testClock, Duration.ofSeconds(20)));
+        assertEquals(10L, sut.getElapsedTime().getSeconds());
     }
 }


### PR DESCRIPTION
# Summary
* Use `java.time.Instant` to capture elapsed time of FS migration
* Stop "timing" the migration when it reaches terminal state (`DONE` or `FAILED`)
* Time migration based on when migration enters `RUNNING` state from non-`RUNNING` state
* Test with mocked clock