### PR TITLE
CHET-120: FS migration progress rest endpoint

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
@@ -45,27 +45,13 @@ public class FileSystemMigrationProgressEndpoint {
 
     static class FSMigrationProgressWebObject {
         public String status;
-        public List<FailedFileMigrationWebObject> failedFileMigrations;
+        public List<FailedFileMigration> failedFileMigrations;
         public List<String> migratedFiles;
 
         FSMigrationProgressWebObject(String status, List<FailedFileMigration> failedFileMigrations, List<String> migratedFiles) {
             this.status = status;
+            this.failedFileMigrations = failedFileMigrations;
             this.migratedFiles = migratedFiles;
-
-            this.failedFileMigrations = failedFileMigrations
-                    .stream()
-                    .map(failedFileMigration -> new FailedFileMigrationWebObject(failedFileMigration.getFilePath().toString(), failedFileMigration.getReason()))
-                    .collect(Collectors.toList());
-        }
-    }
-
-    static class FailedFileMigrationWebObject {
-        public String path;
-        public String reason;
-
-        public FailedFileMigrationWebObject(String path, String reason) {
-            this.path = path;
-            this.reason = reason;
         }
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
@@ -1,0 +1,36 @@
+package com.atlassian.migration.datacenter.api.fs;
+
+import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/migration/fs")
+public class FileSystemMigrationProgressEndpoint {
+
+    private final FilesystemMigrationService migrationService;
+
+    public FileSystemMigrationProgressEndpoint(FilesystemMigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Response getFilesystemMigrationStatus() {
+        FileSystemMigrationReport report = migrationService.getReport();
+        if (report == null) {
+            return Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity("no file system migration exists")
+                    .build();
+        }
+        return Response
+                .ok(report)
+                .build();
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
@@ -1,9 +1,7 @@
 package com.atlassian.migration.datacenter.api.fs;
 
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,8 +11,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -37,43 +33,11 @@ public class FileSystemMigrationProgressEndpoint {
                     .entity("no file system migration exists")
                     .build();
         }
-        final FSMigrationProgressWebObject progress = new FSMigrationProgressWebObject(
-                report.getStatus().name(),
-                report.getFailedFiles(),
-                report.getMigratedFiles().stream().map(java.nio.file.Path::toString).collect(Collectors.toList())
-        );
-
         ObjectMapper mapper = new ObjectMapper();
-        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+        mapper.setVisibility(PropertyAccessor.ALL, Visibility.ANY);
 
         return Response
-                .ok(mapper.writeValueAsString(progress))
+                .ok(mapper.writeValueAsString(report))
                 .build();
-    }
-
-    @JsonAutoDetect
-    public static class FSMigrationProgressWebObject {
-        public String status;
-        public List<FailedFileMigration> failedFileMigrations;
-
-        public String getStatus() {
-            return status;
-        }
-
-        public List<FailedFileMigration> getFailedFileMigrations() {
-            return failedFileMigrations;
-        }
-
-        public List<String> getMigratedFiles() {
-            return migratedFiles;
-        }
-
-        public List<String> migratedFiles;
-
-        FSMigrationProgressWebObject(String status, List<FailedFileMigration> failedFileMigrations, List<String> migratedFiles) {
-            this.status = status;
-            this.failedFileMigrations = failedFileMigrations;
-            this.migratedFiles = migratedFiles;
-        }
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
@@ -1,10 +1,8 @@
 package com.atlassian.migration.datacenter.api.fs;
 
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
@@ -25,7 +25,7 @@ public class FileSystemMigrationProgressEndpoint {
 
     @GET
     @Produces(APPLICATION_JSON)
-    public Response getFilesystemMigrationStatus() throws JsonProcessingException {
+    public Response getFilesystemMigrationStatus() {
         FileSystemMigrationReport report = migrationService.getReport();
         if (report == null) {
             return Response
@@ -36,8 +36,15 @@ public class FileSystemMigrationProgressEndpoint {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setVisibility(PropertyAccessor.ALL, Visibility.ANY);
 
-        return Response
-                .ok(mapper.writeValueAsString(report))
-                .build();
+        try {
+            return Response
+                    .ok(mapper.writeValueAsString(report))
+                    .build();
+        } catch (JsonProcessingException e) {
+            return Response
+                    .serverError()
+                    .entity(String.format("Unable to get file system status. Please contact support and show them this error: %s", e.getMessage()))
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpoint.java
@@ -1,12 +1,17 @@
 package com.atlassian.migration.datacenter.api.fs;
 
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -29,8 +34,40 @@ public class FileSystemMigrationProgressEndpoint {
                     .entity("no file system migration exists")
                     .build();
         }
+        final FSMigrationProgressWebObject progress = new FSMigrationProgressWebObject(
+                report.getStatus().name(),
+                report.getFailedFiles(),
+                report.getMigratedFiles().stream().map(java.nio.file.Path::toString).collect(Collectors.toList())
+        );
+
         return Response
-                .ok(report)
+                .ok(progress)
                 .build();
+    }
+
+    static class FSMigrationProgressWebObject {
+        public String status;
+        public List<FailedFileMigrationWebObject> failedFileMigrations;
+        public List<String> migratedFiles;
+
+        FSMigrationProgressWebObject(String status, List<FailedFileMigration> failedFileMigrations, List<String> migratedFiles) {
+            this.status = status;
+            this.migratedFiles = migratedFiles;
+
+            this.failedFileMigrations = failedFileMigrations
+                    .stream()
+                    .map(failedFileMigration -> new FailedFileMigrationWebObject(failedFileMigration.getFilePath().toString(), failedFileMigration.getReason()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    static class FailedFileMigrationWebObject {
+        public String path;
+        public String reason;
+
+        public FailedFileMigrationWebObject(String path, String reason) {
+            this.path = path;
+            this.reason = reason;
+        }
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -1,7 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs;
 
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -1,7 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -89,6 +89,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
 
     private void initialiseMigration() {
         report = new DefaultFileSystemMigrationReport(new DefaultFileSystemMigrationErrorReport(), new DefaultFilesystemMigrationProgress());
+        report.setStatus(RUNNING);
         isDoneCrawling = new AtomicBoolean(false);
         uploadQueue = new ConcurrentLinkedQueue<>();
         S3AsyncClient s3AsyncClient = buildS3Client();

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -7,7 +7,6 @@ import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFileSystemMig
 import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFilesystemMigrationProgress;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -1,7 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -1,7 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs;
 
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -1,6 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * This class is threadsafe and is intended to be added to by any agents which
  * are a part of the file system migration
  */
+@JsonAutoDetect
 public class DefaultFileSystemMigrationErrorReport implements FileSystemMigrationErrorReport {
 
     private final ConcurrentLinkedQueue<FailedFileMigration> failedMigrations;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -1,5 +1,6 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.google.common.collect.ImmutableList;
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -1,7 +1,6 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -12,7 +11,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * This class is threadsafe and is intended to be added to by any agents which
  * are a part of the file system migration
  */
-@JsonAutoDetect
 public class DefaultFileSystemMigrationErrorReport implements FileSystemMigrationErrorReport {
 
     private final ConcurrentLinkedQueue<FailedFileMigration> failedMigrations;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -20,7 +20,15 @@ public class DefaultFileSystemMigrationErrorReport implements FileSystemMigratio
         this.failedMigrations = new ConcurrentLinkedQueue<>();
     }
 
+    /**
+     * tries to report a failed file migration. If 100 files have failed already the report will be dropped to save memory.
+     * In this scenario it is likely the migration will fail and that the lost errors will have the same cause.
+     * @param failedFileMigration the failed file migration to report
+     */
     public void reportFileNotMigrated(FailedFileMigration failedFileMigration) {
+        if (failedMigrations.size() >= 100) {
+            return;
+        }
         failedMigrations.add(failedFileMigration);
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -1,5 +1,6 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -4,7 +4,6 @@ import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationEr
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 import java.nio.file.Path;
 import java.time.Clock;
@@ -17,7 +16,6 @@ import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigr
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
 
-@JsonAutoDetect
 public class DefaultFileSystemMigrationReport implements FileSystemMigrationReport {
 
     private Clock clock;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -4,6 +4,7 @@ import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationEr
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 import java.nio.file.Path;
 import java.time.Clock;
@@ -16,6 +17,7 @@ import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigr
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
 
+@JsonAutoDetect
 public class DefaultFileSystemMigrationReport implements FileSystemMigrationReport {
 
     private Clock clock;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -1,13 +1,11 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 
-@JsonAutoDetect
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
     private List<Path> migratedFiles = new LinkedList<>();

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -1,11 +1,13 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 
+@JsonAutoDetect
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
     private List<Path> migratedFiles = new LinkedList<>();

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 import java.nio.file.Path;
 
-@JsonAutoDetect()
+@JsonAutoDetect
 public class FailedFileMigration {
 
     private Path filePath;

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -1,12 +1,8 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.nio.file.Path;
-
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
 @JsonAutoDetect()
 public class FailedFileMigration {

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
-@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonAutoDetect()
 public class FailedFileMigration {
 
     private Path filePath;
@@ -28,13 +28,5 @@ public class FailedFileMigration {
 
     public String getReason() {
         return reason;
-    }
-
-    public void setFilePath(Path filePath) {
-        this.filePath = filePath;
-    }
-
-    public void setReason(String reason) {
-        this.reason = reason;
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -1,13 +1,16 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.nio.file.Path;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonSerialize
 public class FailedFileMigration {
+
     private Path filePath;
 
     private String reason;
@@ -23,5 +26,13 @@ public class FailedFileMigration {
 
     public String getReason() {
         return reason;
+    }
+
+    public void setFilePath(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -1,6 +1,7 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.nio.file.Path;
@@ -8,12 +9,13 @@ import java.nio.file.Path;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
-@JsonSerialize
 public class FailedFileMigration {
 
     private Path filePath;
 
     private String reason;
+
+    public FailedFileMigration(){};
 
     public FailedFileMigration(Path filePath, String reason) {
         this.filePath = filePath;

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -1,0 +1,27 @@
+package com.atlassian.migration.datacenter.spi.fs.reporting;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import java.nio.file.Path;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+public class FailedFileMigration {
+    private Path filePath;
+
+    private String reason;
+
+    public FailedFileMigration(Path filePath, String reason) {
+        this.filePath = filePath;
+        this.reason = reason;
+    }
+
+    public Path getFilePath() {
+        return filePath;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
@@ -1,8 +1,5 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
-import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFileSystemMigrationErrorReport;
-
-import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -12,24 +9,6 @@ public interface FileSystemMigrationErrorReport {
 
     List<FailedFileMigration> getFailedFiles();
 
-    void reportFileNotMigrated(DefaultFileSystemMigrationErrorReport.FailedFileMigration failedFileMigration);
+    void reportFileNotMigrated(FailedFileMigration failedFileMigration);
 
-    class FailedFileMigration {
-        private Path filePath;
-
-        private String reason;
-
-        public FailedFileMigration(Path filePath, String reason) {
-            this.filePath = filePath;
-            this.reason = reason;
-        }
-
-        public Path getFilePath() {
-            return filePath;
-        }
-
-        public String getReason() {
-            return reason;
-        }
-    }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
@@ -15,9 +15,9 @@ public interface FileSystemMigrationErrorReport {
     void reportFileNotMigrated(DefaultFileSystemMigrationErrorReport.FailedFileMigration failedFileMigration);
 
     class FailedFileMigration {
-        private final Path filePath;
+        private Path filePath;
 
-        private final String reason;
+        private String reason;
 
         public FailedFileMigration(Path filePath, String reason) {
             this.filePath = filePath;

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
@@ -1,10 +1,13 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import java.util.List;
 
 /**
  * Represents the error status of a file system migration
  */
+@JsonSerialize(as = FileSystemMigrationErrorReport.class)
 public interface FileSystemMigrationErrorReport {
 
     List<FailedFileMigration> getFailedFiles();

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -1,11 +1,14 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import java.nio.file.Path;
 import java.util.List;
 
 /**
  * Tracks the progress of the file system migration
  */
+@JsonSerialize(as = FileSystemMigrationProgress.class)
 public interface FileSystemMigrationProgress {
 
     List<Path> getMigratedFiles();

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationReport.java
@@ -2,6 +2,9 @@ package com.atlassian.migration.datacenter.spi.fs.reporting;
 
 import java.time.Duration;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(as = FileSystemMigrationReport.class)
 public interface FileSystemMigrationReport extends FileSystemMigrationErrorReport, FileSystemMigrationProgress {
 
     void setStatus(FilesystemMigrationStatus status);

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -56,10 +56,10 @@ public class FileSystemMigrationProgressEndpointTest {
 
         assertEquals(RUNNING.name(), returnedReport.status);
         assertEquals(1, returnedReport.failedFileMigrations.size());
-        assertEquals(testReason, returnedReport.failedFileMigrations.get(0).reason);
-        assertEquals(testFile.toString(), returnedReport.failedFileMigrations.get(0).path);
+        assertEquals(testReason, returnedReport.failedFileMigrations.get(0).getReason());
+        assertEquals(testFile, returnedReport.failedFileMigrations.get(0).getFilePath());
         assertEquals(1, returnedReport.migratedFiles.size());
-        assertEquals(successFileName, returnedReport.migratedFiles.get(0));
+        assertEquals(successFileName, returnedReport.migratedFiles.get(0).toString());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -1,0 +1,73 @@
+package com.atlassian.migration.datacenter.api.fs;
+
+import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.ws.rs.core.Response;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FileSystemMigrationProgressEndpointTest {
+
+    @Mock
+    private FilesystemMigrationService migrationService;
+
+    @Mock
+    private FileSystemMigrationReport report;
+
+    private FileSystemMigrationProgressEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        endpoint = new FileSystemMigrationProgressEndpoint(migrationService);
+    }
+
+    @Test
+    void shouldReturnReportWhenMigrationExists() {
+        when(migrationService.getReport()).thenReturn(report);
+
+        when(report.getStatus()).thenReturn(RUNNING);
+
+        final String testReason = "test reason";
+        final Path testFile = Paths.get("file");
+        final FailedFileMigration failedFileMigration = new FailedFileMigration(testFile, testReason);
+        when(report.getFailedFiles()).thenReturn(Collections.singletonList(failedFileMigration));
+
+        final String successFileName = "success_file.txt";
+        final Path successFile = Paths.get(successFileName);
+        when(report.getMigratedFiles()).thenReturn(Collections.singletonList(successFile));
+
+        final Response response = endpoint.getFilesystemMigrationStatus();
+
+        final FileSystemMigrationReport returnedReport = (FileSystemMigrationReport) response.getEntity();
+
+        assertEquals(RUNNING, returnedReport.getStatus());
+        assertEquals(1, returnedReport.getFailedFiles().size());
+        assertEquals(testReason, returnedReport.getFailedFiles().get(0).getReason());
+        assertEquals(testFile.toString(), returnedReport.getFailedFiles().get(0).getFilePath().toString());
+        assertEquals(1, returnedReport.getMigratedFiles().size());
+        assertEquals(successFileName, returnedReport.getMigratedFiles().get(0).toString());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenNoReportExists() {
+        when(migrationService.getReport()).thenReturn(null);
+
+        final Response response = endpoint.getFilesystemMigrationStatus();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("no file system migration exists", response.getEntity());
+    }
+}

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -1,6 +1,5 @@
 package com.atlassian.migration.datacenter.api.fs;
 
-import com.atlassian.migration.datacenter.api.fs.FileSystemMigrationProgressEndpoint.FSMigrationProgressWebObject;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
@@ -52,7 +51,7 @@ public class FileSystemMigrationProgressEndpointTest {
 
         final Response response = endpoint.getFilesystemMigrationStatus();
 
-        final FSMigrationProgressWebObject returnedReport = (FSMigrationProgressWebObject) response.getEntity();
+        final FileSystemMigrationProgressEndpoint.FSMigrationProgressWebObject returnedReport = (FileSystemMigrationProgressEndpoint.FSMigrationProgressWebObject) response.getEntity();
 
         assertEquals(RUNNING.name(), returnedReport.status);
         assertEquals(1, returnedReport.failedFileMigrations.size());

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -2,7 +2,7 @@ package com.atlassian.migration.datacenter.api.fs;
 
 import com.atlassian.migration.datacenter.api.fs.FileSystemMigrationProgressEndpoint.FSMigrationProgressWebObject;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -1,5 +1,6 @@
 package com.atlassian.migration.datacenter.api.fs;
 
+import com.atlassian.migration.datacenter.api.fs.FileSystemMigrationProgressEndpoint.FSMigrationProgressWebObject;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
@@ -51,14 +52,14 @@ public class FileSystemMigrationProgressEndpointTest {
 
         final Response response = endpoint.getFilesystemMigrationStatus();
 
-        final FileSystemMigrationReport returnedReport = (FileSystemMigrationReport) response.getEntity();
+        final FSMigrationProgressWebObject returnedReport = (FSMigrationProgressWebObject) response.getEntity();
 
-        assertEquals(RUNNING, returnedReport.getStatus());
-        assertEquals(1, returnedReport.getFailedFiles().size());
-        assertEquals(testReason, returnedReport.getFailedFiles().get(0).getReason());
-        assertEquals(testFile.toString(), returnedReport.getFailedFiles().get(0).getFilePath().toString());
-        assertEquals(1, returnedReport.getMigratedFiles().size());
-        assertEquals(successFileName, returnedReport.getMigratedFiles().get(0).toString());
+        assertEquals(RUNNING.name(), returnedReport.status);
+        assertEquals(1, returnedReport.failedFileMigrations.size());
+        assertEquals(testReason, returnedReport.failedFileMigrations.get(0).reason);
+        assertEquals(testFile.toString(), returnedReport.failedFileMigrations.get(0).path);
+        assertEquals(1, returnedReport.migratedFiles.size());
+        assertEquals(successFileName, returnedReport.migratedFiles.get(0));
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -3,6 +3,7 @@ package com.atlassian.migration.datacenter.api.fs;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,7 @@ public class FileSystemMigrationProgressEndpointTest {
     }
 
     @Test
-    void shouldReturnReportWhenMigrationExists() {
+    void shouldReturnReportWhenMigrationExists() throws JsonProcessingException {
         when(migrationService.getReport()).thenReturn(report);
 
         when(report.getStatus()).thenReturn(RUNNING);
@@ -62,7 +63,7 @@ public class FileSystemMigrationProgressEndpointTest {
     }
 
     @Test
-    void shouldReturnBadRequestWhenNoReportExists() {
+    void shouldReturnBadRequestWhenNoReportExists() throws JsonProcessingException {
         when(migrationService.getReport()).thenReturn(null);
 
         final Response response = endpoint.getFilesystemMigrationStatus();

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReportTest.java
@@ -1,6 +1,6 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -1,7 +1,7 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport.FailedFileMigration;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -20,7 +19,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 
-import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;


### PR DESCRIPTION
# Summary

* Able to get full status of FS migration
    * status
    * completed files
    * failed files
* Fixes bug where migration is not set to running after starting

## Note
If there is a large number of errors then the response can get very large. I had a migration fail completely (local jira with amps:run) and the API response was 1.2MB. We may want to have a separate endpoint for the errors and implement pagination. Thoughts?