### PR TITLE
CHET-128: Cloudformation State Candidate Implementation

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/CfnApi.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/CfnApi.java
@@ -55,6 +55,11 @@ public class CfnApi {
         return client;
     }
 
+    /**
+     * Gets the status of the supplied stack. If there is no stack with this name a runtime exception will be
+     * thrown.
+     * @param stackName the name of the stack the get the status of
+     */
     public StackStatus getStatus(String stackName) {
         Optional<Stack> stack = getStack(stackName);
         if (!stack.isPresent()) {

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/AWSMigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/AWSMigrationContext.java
@@ -1,0 +1,47 @@
+package com.atlassian.migration.datacenter.core.statemachine;
+
+import net.java.ao.Entity;
+
+import java.util.Map;
+
+public interface AWSMigrationContext extends Entity {
+
+    /**
+     * AppStackName is the property used to determine the name of the AWS Cloudformation Stack
+     * used to run the target application
+     * @return the AppStackName
+     */
+    String getAppStackName();
+
+    /**
+     * @see AWSMigrationContext#getAppStackName()
+     */
+    void setAppStackName(String appStackName);
+
+    /**
+     * AppTemplateURL is the property used as the URL of the Cloudformation template which
+     * deploys the target application
+     * @return the AppTemplateURL
+     */
+    String getAppTemplateURL();
+
+    /**
+     * @see AWSMigrationContext#getAppTemplateURL()
+     */
+    void setAppTemplateURL(String appTemplateURL);
+
+    /**
+     * AppTemplateParameters is the property used to fill the template parameters
+     * for the App Cloudformation Template. The key should be the Cloudformation Parameter
+     * name and the value should be a string representation of the parameter value.
+     * @see AWSMigrationContext#getAppTemplateURL()
+     * @return the AppTemplateParameters
+     */
+    Map<String, String> getAppTemplateParameters();
+
+    /**
+     * @see AWSMigrationContext#getAppTemplateParameters()
+     */
+    void setAppTemplateParameters(Map<String, String> parameters);
+
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
@@ -25,7 +25,7 @@ public class DeployCloudformation implements State {
 
     @Override
     public boolean readyToTransition() {
-        cloudformationApi.getStatus(context.getAppStackName());
-        return true;
+        return cloudformationApi.getStack(context.getAppStackName()).isPresent();
+
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
@@ -1,11 +1,21 @@
 package com.atlassian.migration.datacenter.core.statemachine;
 
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.spi.statemachine.State;
 
 public class DeployCloudformation implements State {
+
+    private final AWSMigrationContext context;
+    private final CfnApi cloudformationApi;
+
+    public DeployCloudformation(AWSMigrationContext context, CfnApi cloudformationApi) {
+        this.context = context;
+        this.cloudformationApi = cloudformationApi;
+    }
+
     @Override
     public void run() {
-
+        cloudformationApi.provisionStack(context.getAppTemplateURL(), context.getAppStackName(), context.getAppTemplateParameters());
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
@@ -1,0 +1,20 @@
+package com.atlassian.migration.datacenter.core.statemachine;
+
+import com.atlassian.migration.datacenter.spi.statemachine.State;
+
+public class DeployCloudformation implements State {
+    @Override
+    public void run() {
+
+    }
+
+    @Override
+    public State nextState() {
+        return new WaitCloudformation();
+    }
+
+    @Override
+    public boolean readyToTransition() {
+        return false;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
@@ -25,6 +25,7 @@ public class DeployCloudformation implements State {
 
     @Override
     public boolean readyToTransition() {
-        return false;
+        cloudformationApi.getStatus(context.getAppStackName());
+        return true;
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformation.java
@@ -25,9 +25,7 @@ public class DeployCloudformation implements State {
     public State nextState() throws NoValidTransitionException {
         StackStatus status = safeGetStackStatus();
 
-        if (status == null) {
-            throw new NoValidTransitionException(this, "Can only transition when stack deployment has completed");
-        }
+        throwNoValidTransitionIfStatusIsNull(status);
 
         switch (status) {
             case CREATE_COMPLETE:
@@ -36,6 +34,12 @@ public class DeployCloudformation implements State {
                 return new ErrorState();
             default:
                 throw new NoValidTransitionException(this, "Can only transition when stack deployment has completed");
+        }
+    }
+
+    private void throwNoValidTransitionIfStatusIsNull(StackStatus status) throws NoValidTransitionException {
+        if (status == null) {
+            throw new NoValidTransitionException(this, "Can only transition when stack deployment has completed");
         }
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployMigrationStack.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/DeployMigrationStack.java
@@ -1,17 +1,16 @@
 package com.atlassian.migration.datacenter.core.statemachine;
 
+import com.atlassian.migration.datacenter.spi.statemachine.NoValidTransitionException;
 import com.atlassian.migration.datacenter.spi.statemachine.State;
 
-public class WaitCloudformation implements State {
-
-
+public class DeployMigrationStack implements State {
     @Override
     public void run() {
 
     }
 
     @Override
-    public State nextState() {
+    public State nextState() throws NoValidTransitionException {
         return null;
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/ErrorState.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/ErrorState.java
@@ -1,0 +1,21 @@
+package com.atlassian.migration.datacenter.core.statemachine;
+
+import com.atlassian.migration.datacenter.spi.statemachine.NoValidTransitionException;
+import com.atlassian.migration.datacenter.spi.statemachine.State;
+
+public class ErrorState implements State {
+    @Override
+    public void run() {
+
+    }
+
+    @Override
+    public State nextState() throws NoValidTransitionException {
+        return null;
+    }
+
+    @Override
+    public boolean readyToTransition() {
+        return false;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/statemachine/WaitCloudformation.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/statemachine/WaitCloudformation.java
@@ -1,0 +1,22 @@
+package com.atlassian.migration.datacenter.core.statemachine;
+
+import com.atlassian.migration.datacenter.spi.statemachine.State;
+
+public class WaitCloudformation implements State {
+
+
+    @Override
+    public void run() {
+
+    }
+
+    @Override
+    public State nextState() {
+        return null;
+    }
+
+    @Override
+    public boolean readyToTransition() {
+        return false;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/statemachine/NoValidTransitionException.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/statemachine/NoValidTransitionException.java
@@ -1,0 +1,23 @@
+package com.atlassian.migration.datacenter.spi.statemachine;
+
+/**
+ * This exception should be thrown when a state is asked to supply its next state but there is no valid transition
+ * available currently.
+ * @see State#nextState()
+ * @see State#readyToTransition()
+ */
+public class NoValidTransitionException extends Exception {
+
+    private State source;
+    private String reason;
+
+    public NoValidTransitionException(State source, String reason) {
+        this.source = source;
+        this.reason = reason;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Unable to transition from state %s: %s", source, reason);
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/statemachine/State.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/statemachine/State.java
@@ -12,7 +12,7 @@ public interface State {
      */
     void run();
 
-    State nextState();
+    State nextState() throws NoValidTransitionException;
 
     boolean readyToTransition();
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/statemachine/State.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/statemachine/State.java
@@ -8,12 +8,22 @@ package com.atlassian.migration.datacenter.spi.statemachine;
 public interface State {
 
     /**
-     * Runs this step of the migration.
+     * Runs this step of the migration. Is called when entering this state
      */
     void run();
 
+    /**
+     * Determines the next state to transition to. Should do any checks required to verify a valid transition
+     * can occur. Can also be used as a hook for actions to take when exiting a state.
+     * @return the state that should follow this one.
+     * @throws NoValidTransitionException when the conditions are not valid for any transition or an error
+     * occurs while processing the on-exit hook.
+     */
     State nextState() throws NoValidTransitionException;
 
+    /**
+     * Can be used to determine if now is a valid time to request a transition to the next state.
+     */
     boolean readyToTransition();
 
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
@@ -1,0 +1,24 @@
+package com.atlassian.migration.datacenter.core.statemachine;
+
+import com.atlassian.migration.datacenter.spi.statemachine.State;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DeployCloudformationTest {
+    private DeployCloudformation sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new DeployCloudformation();
+    }
+
+    @Test
+    void shouldTransitionToCloudformationWaiting() {
+        State nextState = sut.nextState();
+
+        assertEquals(WaitCloudformation.class, nextState.getClass());
+    }
+
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
@@ -1,17 +1,34 @@
 package com.atlassian.migration.datacenter.core.statemachine;
 
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.spi.statemachine.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class DeployCloudformationTest {
+
     private DeployCloudformation sut;
+
+    @Mock
+    CfnApi mockCfnApi;
+
+    @Mock
+    AWSMigrationContext mockMigrationContext;
 
     @BeforeEach
     void setUp() {
-        sut = new DeployCloudformation();
+        sut = new DeployCloudformation(mockMigrationContext, mockCfnApi);
     }
 
     @Test
@@ -19,6 +36,22 @@ class DeployCloudformationTest {
         State nextState = sut.nextState();
 
         assertEquals(WaitCloudformation.class, nextState.getClass());
+    }
+
+    @Test
+    void shouldInitiateDeploymentWhenRun() {
+        final Map<String, String> params = new HashMap<>();
+        params.put("Parameter1", "value");
+        final String stackName = "stack name";
+        final String templateUrl = "s3://bucket/template.yml";
+
+        when(mockMigrationContext.getAppStackName()).thenReturn(stackName);
+        when(mockMigrationContext.getAppTemplateURL()).thenReturn(templateUrl);
+        when(mockMigrationContext.getAppTemplateParameters()).thenReturn(params);
+
+        sut.run();
+
+        verify(mockCfnApi).provisionStack(templateUrl, stackName, params);
     }
 
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +44,7 @@ class DeployCloudformationTest {
     void shouldInitiateDeploymentWhenRun() {
         final Map<String, String> params = new HashMap<>();
         params.put("Parameter1", "value");
-        final String stackName = "stack name";
+        final String stackName = "stack-name";
         final String templateUrl = "s3://bucket/template.yml";
 
         when(mockMigrationContext.getAppStackName()).thenReturn(stackName);
@@ -52,6 +54,16 @@ class DeployCloudformationTest {
         sut.run();
 
         verify(mockCfnApi).provisionStack(templateUrl, stackName, params);
+    }
+
+    @Test
+    void shouldIndicateReadyToTransitionWhenStackHasStartedToDeploy() {
+        final String stackName = "stack-name";
+        when(mockMigrationContext.getAppStackName()).thenReturn(stackName);
+
+        when(mockCfnApi.getStatus(stackName)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
+
+        assertTrue(sut.readyToTransition());
     }
 
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/statemachine/DeployCloudformationTest.java
@@ -7,15 +7,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.cloudformation.model.StackStatus;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.services.cloudformation.model.StackStatus.CREATE_IN_PROGRESS;
 
 @ExtendWith(MockitoExtension.class)
 class DeployCloudformationTest {
@@ -61,9 +64,18 @@ class DeployCloudformationTest {
         final String stackName = "stack-name";
         when(mockMigrationContext.getAppStackName()).thenReturn(stackName);
 
-        when(mockCfnApi.getStatus(stackName)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
+        when(mockCfnApi.getStack(stackName)).thenReturn(Optional.of(Stack.builder().build()));
 
         assertTrue(sut.readyToTransition());
     }
 
+    @Test
+    void shouldNotIndicateReadyToTransitionWhenStackIsNotDeploying() {
+        final String stackName = "stack-name";
+        when(mockMigrationContext.getAppStackName()).thenReturn(stackName);
+
+        when(mockCfnApi.getStack(stackName)).thenReturn(Optional.empty());
+
+        assertFalse(sut.readyToTransition());
+    }
 }


### PR DESCRIPTION
# Summary

This PR has a candidate implementation for the State pattern. It shows how we could implement the following state sequence

`STACK_FORM -> STACK_DEPLOY -> MIGRATION_STACK_DEPLOY`
and
`STACK_FORM -> STACK_DEPLOY -> ERROR`

The assumed flow with this implementation is:

1. User has filled out the quick start form
2. User clicks "Deploy"
3. UI calls out to `MigrationService` and requests to move to transition to the next state. It includes the stack parameters in the request
4. The stack parameters are added to a `MigrationContext`
5. The `STACK_FORM` state checks whether it is able to transition to the next stage
6. The `STACK_FORM` state approves the transition and sets the state on the migration service
to `STACK_DEPLOY`
7. The `MigrationService` calls `run()` on the new `State` (asynchronously)
8. The request from (3) returns to the UI with the new state as the response body
9. The UI renders the appropriate screen for `STACK_DEPLOY`
10. -problem- how do we get feedback on the stack deployment here without leaking abstraction into the state machine

This is more of a request for feedback than a true contribution. After wrapping my head around it for the better part of a day, I'm not sold that the state pattern is actually best for us. Here are my key concerns

* It is difficult to get user-input into the state machine and maintain type-safety
* The actions of each state are quite different, this makes it difficult to have one State interface
    * Some do something right away
    * Some are polling states
    * Some do nothing and wait for a user to submit something
* It is difficult to get progress when the only thing the user interacts with is the state machine (you don't want the UI to interact directly with the currently acting service as this goes around the state management)
* It would be near-impossible to re-use the state machine for any purpose other than migrating to AWS.

# Alternative
I think perhaps it would be best to leave the state pattern behind and try to avoid such a generic approach. Instead of the entire process being managed by a StateMachineService, each component of the migration is managed by its own service (i.e. our current implementation). This would be backed up by a very lightweight state management system which exists purely to ensure all actions are taken in the correct order.

Consider the previous example with this different architecture.

1. The user has filled out the quick start form
2. User clicks "Deploy"
3. UI calls out to `QuickStartService` and requests to provision a new stack
4. The `QuickStartService` checks the `MigrationState` is equal to `STACK_FORM` (the only state where a quick start can be deployed)
5. The `QuickStartService` initiates deployment.
6. The `QuickStartService` sets the `MigrationState` to `STACK_DEPLOY`
7. The request from (3) returns
8. The UI goes to the next page: waiting for stack to finish deploying
9. The UI polls the stack status from the backend until the migration is complete
10. Once the migration is completed, the backend sets its state to `MIGRATION_STACK_DEPLOY`
...

The downside of this approach is that the state machine is less strictly enforced. Services have to check with the state machine that they can run rather than the state machine calling the services when it is their turn.
The benefit is each service is completely independent of the others. It doesn't matter what the implementation of each stage of the migration is, it only matters that there is an implementation for that state. There is no enforcing on when a state transition can occur (either automatically or by user action).

I'm personally more fond of the alternative approach as it has a greatly reduced complexity at the cost of reduced type-safety and a bit of boiler-plate (which can probably be eliminated with inheritance).
