### PR TITLE
CHET-128: Implement alternative state management strategy

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/api/ProvisionAppEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/ProvisionAppEndpoint.java
@@ -1,0 +1,31 @@
+package com.atlassian.migration.datacenter.api;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.infrastructure.AppProvisioningService;
+import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/migration/provision/app")
+public class ProvisionAppEndpoint {
+
+    AppProvisioningService appProvisioningService;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response deployAppStack(ProvisioningConfig config) {
+        try {
+            appProvisioningService.provisionApp(config);
+            return Response.ok().build();
+        } catch (InvalidMigrationStageError invalidMigrationStageError) {
+            return Response
+                    .status(Response.Status.CONFLICT)
+                    .entity(invalidMigrationStageError.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -73,6 +73,11 @@ public class AWSMigrationService implements MigrationService {
         return getMigration().getStage();
     }
 
+    @Override
+    public void setStage(MigrationStage appStackDeploy) {
+        // Update the migration in AO
+    }
+
     private Migration getMigration() {
         if (migration == null) {
             Migration[] migrations = ao.find(Migration.class);

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/deployment/QuickStartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/deployment/QuickStartDeploymentService.java
@@ -1,0 +1,74 @@
+package com.atlassian.migration.datacenter.core.aws.deployment;
+
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.atlassian.migration.datacenter.spi.infrastructure.AppProvisioningService;
+import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.cloudformation.model.StackStatus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.atlassian.migration.datacenter.spi.MigrationStage.APP_STACK_FORM;
+
+@Component
+public class QuickStartDeploymentService implements AppProvisioningService {
+
+    private CfnApi cloudformation;
+    private MigrationService migrationService;
+
+    private String currentStack;
+
+    public QuickStartDeploymentService(CfnApi cloudformation, MigrationService migrationService) {
+        this.cloudformation = cloudformation;
+        this.migrationService = migrationService;
+    }
+
+    @Override
+    public void provisionApp(ProvisioningConfig provisioningConfig) throws InvalidMigrationStageError {
+        if (!migrationService.getMigrationStage().equals(APP_STACK_FORM)) {
+            throw new InvalidMigrationStageError(String.format("must be in %s to provision app", APP_STACK_FORM));
+        } else {
+            // Do the action for this state
+            migrationService.setStage(MigrationStage.APP_STACK_DEPLOY);
+
+            // We would drop the template URL from provisioning config
+            cloudformation.provisionStack("https://aws-quickstart/<the quickstart url", provisioningConfig.getStackName(), provisioningConfig.getParams());
+            currentStack = provisioningConfig.getStackName();
+
+            // Wait for stack to finish deploying
+            ExecutorService service = Executors.newFixedThreadPool(1);
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            service.submit(() -> {
+                while (Double.compare(getProvisioningProgress(), 1d) < 0) {
+                    try {
+                        Thread.sleep(1000 * 60);
+                    } catch (InterruptedException e) {
+                        future.complete(false);
+                    }
+                }
+                future.complete(true);
+            });
+
+            future.thenAccept(success -> {
+                if (success) {
+                    migrationService.setStage(MigrationStage.MIGRATION_STACK_DEPLOY);
+                } else {
+                    migrationService.setStage(MigrationStage.PROVISIONING_ERROR);
+                }
+            });
+        }
+    }
+
+    @Override
+    public double getProvisioningProgress() {
+        if (cloudformation.getStatus(currentStack).equals(StackStatus.CREATE_COMPLETE) || cloudformation.getStatus(currentStack).equals(StackStatus.CREATE_FAILED)) {
+            return 1d;
+        }
+        return 0d;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
@@ -27,6 +27,11 @@ public interface MigrationService {
     MigrationStage getMigrationStage();
 
     /**
+     * Updates the stage of the migration
+     * @param appStackDeploy
+     */
+    void setStage(MigrationStage appStackDeploy);
+    /**
      * Provisions a CloudFormation stack.
      *
      * @param provisioningConfig contains information required to provision a stack
@@ -37,4 +42,5 @@ public interface MigrationService {
     Optional<String> getInfrastructureProvisioningStatus(String stackId);
 
     boolean startFilesystemMigration();
+
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -4,9 +4,9 @@ package com.atlassian.migration.datacenter.spi;
  * Represents all possible states of an on-premise to cloud migration.
  */
 public enum MigrationStage {
-    NOT_STARTED(""), STARTED("started"),
+    NOT_STARTED(""), STARTED("started"), APP_STACK_FORM("app_stack_form"), APP_STACK_DEPLOY("app_stack_deploy"),
     READY_TO_PROVISION("ready_to_provision"), PROVISIONING_IN_PROGRESS("provisioning_in_progress"), PROVISIONING_COMPLETE("provisioning_complete"), PROVISIONING_ERROR("provisioning_error"),
-    READY_FS_MIGRATION("ready_fs_migration"), FS_MIGRATION("fs_migration");
+    READY_FS_MIGRATION("ready_fs_migration"), FS_MIGRATION("fs_migration"), MIGRATION_STACK_DEPLOY("migration_stack_deploy");
 
     private String key;
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/AppProvisioningService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/AppProvisioningService.java
@@ -1,0 +1,11 @@
+package com.atlassian.migration.datacenter.spi.infrastructure;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+
+public interface AppProvisioningService {
+
+    void provisionApp(ProvisioningConfig provisioningConfig) throws InvalidMigrationStageError;
+
+    double getProvisioningProgress();
+
+}


### PR DESCRIPTION
This is the alternative strategy outlined in: #29 

> I think perhaps it would be best to leave the state pattern behind and try to avoid such a generic approach. Instead of the entire process being managed by a StateMachineService, each component of the migration is managed by its own service (i.e. our current implementation). This would be backed up by a very lightweight state management system which exists purely to ensure all actions are taken in the correct order.
Consider the previous example with this different architecture.

    The user has filled out the quick start form
    User clicks "Deploy"
    UI calls out to QuickStartService and requests to provision a new stack
    The QuickStartService checks the MigrationState is equal to STACK_FORM (the only state where a quick start can be deployed)
    The QuickStartService initiates deployment.
    The QuickStartService sets the MigrationState to STACK_DEPLOY
    The request from (3) returns
    The UI goes to the next page: waiting for the stack to finish deploying
    The UI polls the stack status from the backend until the migration is complete
    Once the migration is completed, the backend sets its state to MIGRATION_STACK_DEPLOY

> The downside of this approach is that the state machine is less strictly enforced. Services have to check with the state machine that they can run rather than the state machine calling the services when it is their turn.
The benefit is each service is completely independent of the others. It doesn't matter what the implementation of each stage of the migration is, it only matters that there is an implementation for that state. There is no enforcing on when a state transition can occur (either automatically or by user action).