### PR TITLE
Fix fs migration reporting

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -71,7 +71,7 @@ public class S3Uploader implements Uploader {
                 final String errorMessage = String.format("Error when uploading {} to S3, {}", operation.path, evaluatedResponse.sdkHttpResponse().statusText());
                 addFailedFile(operation.path, errorMessage);
             } else {
-                progress.reportFileMigrated(operation.path);
+                progress.reportFileMigrated();
             }
         } catch (InterruptedException | ExecutionException e) {
             addFailedFile(operation.path, e.getMessage());

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class DefaultFileSystemMigrationErrorReport implements FileSystemMigrationErrorReport {
 
-    private final ConcurrentHashMap<FailedFileMigration, Void> failedMigrations;
+    private final ConcurrentHashMap<FailedFileMigration, Boolean> failedMigrations;
 
     public DefaultFileSystemMigrationErrorReport() {
         this.failedMigrations = new ConcurrentHashMap<>();
@@ -32,7 +32,7 @@ public class DefaultFileSystemMigrationErrorReport implements FileSystemMigratio
         if (failedMigrations.size() >= 100) {
             return;
         }
-        failedMigrations.put(failedFileMigration, null);
+        failedMigrations.put(failedFileMigration, true);
     }
 
     /**

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -2,13 +2,10 @@ package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Manages files which have had an error throughout the file migration
@@ -17,10 +14,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class DefaultFileSystemMigrationErrorReport implements FileSystemMigrationErrorReport {
 
-    private final ConcurrentHashMap<FailedFileMigration, Boolean> failedMigrations;
+    private final Set<FailedFileMigration> failedMigrations;
 
     public DefaultFileSystemMigrationErrorReport() {
-        this.failedMigrations = new ConcurrentHashMap<>();
+        this.failedMigrations = ConcurrentHashMap.newKeySet();
     }
 
     /**
@@ -32,7 +29,7 @@ public class DefaultFileSystemMigrationErrorReport implements FileSystemMigratio
         if (failedMigrations.size() >= 100) {
             return;
         }
-        failedMigrations.put(failedFileMigration, true);
+        failedMigrations.add(failedFileMigration);
     }
 
     /**
@@ -40,6 +37,6 @@ public class DefaultFileSystemMigrationErrorReport implements FileSystemMigratio
      * is not backed by the underlying collection so will not be updated as other producers add to it.
      */
     public Set<FailedFileMigration> getFailedFiles() {
-        return ImmutableSet.copyOf(failedMigrations.keySet());
+        return ImmutableSet.copyOf(failedMigrations);
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReport.java
@@ -3,8 +3,11 @@ package com.atlassian.migration.datacenter.core.fs.reporting;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -14,10 +17,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class DefaultFileSystemMigrationErrorReport implements FileSystemMigrationErrorReport {
 
-    private final ConcurrentLinkedQueue<FailedFileMigration> failedMigrations;
+    private final ConcurrentHashMap<FailedFileMigration, Void> failedMigrations;
 
     public DefaultFileSystemMigrationErrorReport() {
-        this.failedMigrations = new ConcurrentLinkedQueue<>();
+        this.failedMigrations = new ConcurrentHashMap<>();
     }
 
     /**
@@ -29,14 +32,14 @@ public class DefaultFileSystemMigrationErrorReport implements FileSystemMigratio
         if (failedMigrations.size() >= 100) {
             return;
         }
-        failedMigrations.add(failedFileMigration);
+        failedMigrations.put(failedFileMigration, null);
     }
 
     /**
      * @return an immutable copy of the FailedFileMigrations in this report. Note the returned value
      * is not backed by the underlying collection so will not be updated as other producers add to it.
      */
-    public List<FailedFileMigration> getFailedFiles() {
-        return ImmutableList.copyOf(failedMigrations);
+    public Set<FailedFileMigration> getFailedFiles() {
+        return ImmutableSet.copyOf(failedMigrations.keySet());
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -6,7 +6,6 @@ import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationPr
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
 
-import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -95,13 +94,13 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public Set<Path> getMigratedFiles() {
+    public Long getMigratedFiles() {
         return progress.getMigratedFiles();
     }
 
     @Override
-    public void reportFileMigrated(Path path) {
-        progress.reportFileMigrated(path);
+    public void reportFileMigrated() {
+        progress.reportFileMigrated();
     }
 
     public void setClock(Clock clock) {
@@ -124,7 +123,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     public String toString() {
         return String.format("Filesystem migration report = { status: %s, migratedFiles: %d, erroredFiles: %d }",
                 currentStatus,
-                progress.getMigratedFiles().size(),
+                progress.getMigratedFiles(),
                 errorReport.getFailedFiles().size()
         );
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
+import java.util.Set;
 
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
@@ -65,7 +65,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public List<FailedFileMigration> getFailedFiles() {
+    public Set<FailedFileMigration> getFailedFiles() {
         return errorReport.getFailedFiles();
     }
 
@@ -95,7 +95,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public List<Path> getMigratedFiles() {
+    public Set<Path> getMigratedFiles() {
         return progress.getMigratedFiles();
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -63,6 +63,35 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
         return currentStatus == RUNNING;
     }
 
+    public void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    private boolean isStartingMigration(FilesystemMigrationStatus toStatus) {
+        return this.currentStatus != RUNNING && toStatus == RUNNING;
+    }
+
+    private boolean isEndingMigration(FilesystemMigrationStatus toStatus) {
+        return this.currentStatus == RUNNING && isTerminalState(toStatus);
+    }
+
+    private boolean isTerminalState(FilesystemMigrationStatus toStatus) {
+        return toStatus == DONE || toStatus == FAILED;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Filesystem migration report = { status: %s, migratedFiles: %d, erroredFiles: %d }",
+                currentStatus,
+                progress.getCountOfMigratedFiles(),
+                errorReport.getFailedFiles().size()
+        );
+    }
+
+    /*
+    DELEGATED METHODS FOLLOW
+     */
+
     @Override
     public Set<FailedFileMigration> getFailedFiles() {
         return errorReport.getFailedFiles();
@@ -94,38 +123,13 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public Long getMigratedFiles() {
-        return progress.getMigratedFiles();
+    public Long getCountOfMigratedFiles() {
+        return progress.getCountOfMigratedFiles();
     }
 
     @Override
     public void reportFileMigrated() {
         progress.reportFileMigrated();
-    }
-
-    public void setClock(Clock clock) {
-        this.clock = clock;
-    }
-
-    private boolean isStartingMigration(FilesystemMigrationStatus toStatus) {
-        return this.currentStatus != RUNNING && toStatus == RUNNING;
-    }
-
-    private boolean isEndingMigration(FilesystemMigrationStatus toStatus) {
-        return this.currentStatus == RUNNING && isTerminalState(toStatus);
-    }
-
-    private boolean isTerminalState(FilesystemMigrationStatus toStatus) {
-        return toStatus == DONE || toStatus == FAILED;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("Filesystem migration report = { status: %s, migratedFiles: %d, erroredFiles: %d }",
-                currentStatus,
-                progress.getMigratedFiles(),
-                errorReport.getFailedFiles().size()
-        );
     }
 }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -1,15 +1,16 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
+import com.google.common.collect.ImmutableSet;
 
 import java.nio.file.Path;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
-    private List<Path> migratedFiles = new LinkedList<>();
+    private ConcurrentHashMap<Path, Void> migratedFiles = new ConcurrentHashMap<>();
 
     private AtomicLong filesFound = new AtomicLong(0);
 
@@ -36,13 +37,13 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     }
 
     @Override
-    public List<Path> getMigratedFiles() {
-        return migratedFiles;
+    public Set<Path> getMigratedFiles() {
+        return ImmutableSet.copyOf(migratedFiles.keySet());
     }
 
     @Override
     public void reportFileMigrated(Path path) {
-        migratedFiles.add(path);
+        migratedFiles.put(path, null);
         filesInFlight.decrementAndGet();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
-    private ConcurrentHashMap<Path, Void> migratedFiles = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<Path, Boolean> migratedFiles = new ConcurrentHashMap<>();
 
     private AtomicLong filesFound = new AtomicLong(0);
 
@@ -43,7 +43,7 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
 
     @Override
     public void reportFileMigrated(Path path) {
-        migratedFiles.put(path, null);
+        migratedFiles.put(path, true);
         filesInFlight.decrementAndGet();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -33,7 +33,7 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     }
 
     @Override
-    public Long getMigratedFiles() {
+    public Long getCountOfMigratedFiles() {
         return numFilesMigrated.get();
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -1,16 +1,12 @@
 package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
-import com.google.common.collect.ImmutableSet;
 
-import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
-    private ConcurrentHashMap<Path, Boolean> migratedFiles = new ConcurrentHashMap<>();
+    private AtomicLong numFilesMigrated = new AtomicLong(0);
 
     private AtomicLong filesFound = new AtomicLong(0);
 
@@ -37,13 +33,13 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     }
 
     @Override
-    public Set<Path> getMigratedFiles() {
-        return ImmutableSet.copyOf(migratedFiles.keySet());
+    public Long getMigratedFiles() {
+        return numFilesMigrated.get();
     }
 
     @Override
-    public void reportFileMigrated(Path path) {
-        migratedFiles.put(path, true);
+    public void reportFileMigrated() {
         filesInFlight.decrementAndGet();
+        numFilesMigrated.incrementAndGet();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FailedFileMigration.java
@@ -25,4 +25,14 @@ public class FailedFileMigration {
     public String getReason() {
         return reason;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof FailedFileMigration) {
+            FailedFileMigration that = (FailedFileMigration) obj;
+
+            return this.filePath.equals(that.filePath) && this.reason.equals(that.reason);
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationErrorReport.java
@@ -2,7 +2,7 @@ package com.atlassian.migration.datacenter.spi.fs.reporting;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * Represents the error status of a file system migration
@@ -10,8 +10,15 @@ import java.util.List;
 @JsonSerialize(as = FileSystemMigrationErrorReport.class)
 public interface FileSystemMigrationErrorReport {
 
-    List<FailedFileMigration> getFailedFiles();
+    /**
+     * Retrieves a set containing the files which have failed to migrate.
+     */
+    Set<FailedFileMigration> getFailedFiles();
 
+    /**
+     * Reports that a file has failed to migrate. Implementers should be careful that the underlying
+     * collection is thread safe as this may be called from multiple file upload threads.
+     */
     void reportFileNotMigrated(FailedFileMigration failedFileMigration);
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Tracks the progress of the file system migration
@@ -28,7 +28,14 @@ public interface FileSystemMigrationProgress {
 
     void reportFileInFlight();
 
-    List<Path> getMigratedFiles();
+    /**
+     * Retrieves a Set containing the files which were successfully migrated
+     */
+    Set<Path> getMigratedFiles();
 
+    /**
+     * Reports that a file was migrated successfully. Implementers should be careful that the underlying
+     * collection is thread safe as this may be called from multiple file upload threads.
+     */
     void reportFileMigrated(Path path);
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -28,6 +28,7 @@ public interface FileSystemMigrationProgress {
     /**
      * Gets the number of files which have been successfully migrated
      */
+    @JsonProperty("migratedFiles")
     Long getCountOfMigratedFiles();
 
     /**

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -28,7 +28,7 @@ public interface FileSystemMigrationProgress {
     /**
      * Gets the number of files which have been successfully migrated
      */
-    Long getMigratedFiles();
+    Long getCountOfMigratedFiles();
 
     /**
      * Reports that a file was migrated successfully. Implementers should be careful that the underlying

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -3,9 +3,6 @@ package com.atlassian.migration.datacenter.spi.fs.reporting;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import java.nio.file.Path;
-import java.util.Set;
-
 /**
  * Tracks the progress of the file system migration
  */
@@ -29,13 +26,13 @@ public interface FileSystemMigrationProgress {
     void reportFileInFlight();
 
     /**
-     * Retrieves a Set containing the files which were successfully migrated
+     * Gets the number of files which have been successfully migrated
      */
-    Set<Path> getMigratedFiles();
+    Long getMigratedFiles();
 
     /**
      * Reports that a file was migrated successfully. Implementers should be careful that the underlying
      * collection is thread safe as this may be called from multiple file upload threads.
      */
-    void reportFileMigrated(Path path);
+    void reportFileMigrated();
 }

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import javax.ws.rs.core.Response;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -55,7 +54,7 @@ public class FileSystemMigrationProgressEndpointTest {
         failedFiles.add(failedFileMigration);
         when(report.getFailedFiles()).thenReturn(failedFiles);
 
-        when(report.getMigratedFiles()).thenReturn(1L);
+        when(report.getCountOfMigratedFiles()).thenReturn(1L);
 
         final Response response = endpoint.getFilesystemMigrationStatus();
 

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -19,6 +19,8 @@ import javax.ws.rs.core.Response;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,11 +51,15 @@ public class FileSystemMigrationProgressEndpointTest {
         final String testReason = "test reason";
         final Path testFile = Paths.get("file");
         final FailedFileMigration failedFileMigration = new FailedFileMigration(testFile, testReason);
-        when(report.getFailedFiles()).thenReturn(Collections.singletonList(failedFileMigration));
+        final Set<FailedFileMigration> failedFiles = new HashSet<>();
+        failedFiles.add(failedFileMigration);
+        when(report.getFailedFiles()).thenReturn(failedFiles);
 
         final String successFileName = "success_file.txt";
         final Path successFile = Paths.get(successFileName);
-        when(report.getMigratedFiles()).thenReturn(Collections.singletonList(successFile));
+        final Set<Path> succeededFiles = new HashSet<>();
+        succeededFiles.add(successFile);
+        when(report.getMigratedFiles()).thenReturn(succeededFiles);
 
         final Response response = endpoint.getFilesystemMigrationStatus();
 

--- a/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.java
@@ -55,11 +55,7 @@ public class FileSystemMigrationProgressEndpointTest {
         failedFiles.add(failedFileMigration);
         when(report.getFailedFiles()).thenReturn(failedFiles);
 
-        final String successFileName = "success_file.txt";
-        final Path successFile = Paths.get(successFileName);
-        final Set<Path> succeededFiles = new HashSet<>();
-        succeededFiles.add(successFile);
-        when(report.getMigratedFiles()).thenReturn(succeededFiles);
+        when(report.getMigratedFiles()).thenReturn(1L);
 
         final Response response = endpoint.getFilesystemMigrationStatus();
 
@@ -75,12 +71,12 @@ public class FileSystemMigrationProgressEndpointTest {
         final String responseReason = tree.at("/failedFiles/0/reason").asText();
         final String responseFailedFile = tree.at("/failedFiles/0/filePath").asText();
 
-        final String responseSuccessFile = tree.at("/migratedFiles/0").asText();
+        final Long responseSuccessFileCount = tree.at("/migratedFiles").asLong();
 
         assertEquals(RUNNING.name(), responseStatus);
         assertEquals(testReason, responseReason);
         assertEquals(testFile.toUri().toString(), responseFailedFile);
-        assertEquals(successFile.toUri().toString(), responseSuccessFile);
+        assertEquals(1, responseSuccessFileCount);
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
@@ -105,7 +105,7 @@ class S3UploaderIT {
                                                 failedMigration.getReason()), (acc, partial) -> acc + "\n" + partial)));
         assertEquals(objectSummaries.size(), 1);
         assertEquals(objectSummaries.get(0).getKey(), tempDir.relativize(file).toString());
-        assertTrue(progress.getMigratedFiles().contains(file));
+        assertEquals(1, progress.getMigratedFiles());
     }
 
     Path addFileToQueue(String fileName) throws IOException {

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
@@ -105,7 +105,7 @@ class S3UploaderIT {
                                                 failedMigration.getReason()), (acc, partial) -> acc + "\n" + partial)));
         assertEquals(objectSummaries.size(), 1);
         assertEquals(objectSummaries.get(0).getKey(), tempDir.relativize(file).toString());
-        assertEquals(1, progress.getMigratedFiles());
+        assertEquals(1, progress.getCountOfMigratedFiles());
     }
 
     Path addFileToQueue(String fileName) throws IOException {

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -109,7 +109,7 @@ class S3UploaderTest {
         });
 
         submit.get();
-        assertEquals(1, progress.getMigratedFiles());
+        assertEquals(1, progress.getCountOfMigratedFiles());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -109,7 +109,7 @@ class S3UploaderTest {
         });
 
         submit.get();
-        assertTrue(progress.getMigratedFiles().contains(testPath));
+        assertEquals(1, progress.getMigratedFiles());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationErrorReportTest.java
@@ -32,9 +32,6 @@ public class DefaultFileSystemMigrationErrorReportTest {
 
         assertEquals(1, sut.getFailedFiles().size());
 
-        final FailedFileMigration failedFileMigration = sut.getFailedFiles().get(0);
-
-        assertEquals(testFile, failedFileMigration.getFilePath());
-        assertEquals(testReason, failedFileMigration.getReason());
+        assertTrue(sut.getFailedFiles().contains(new FailedFileMigration(testFile, testReason)));
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -20,7 +20,7 @@ public class DefaultFileSystemMigrationProgressTest {
 
     @Test
     void shouldBeInitialisedWithNoCompleteFiles() {
-        assertEquals(0, sut.getMigratedFiles());
+        assertEquals(0, sut.getCountOfMigratedFiles());
     }
 
     @Test
@@ -28,7 +28,7 @@ public class DefaultFileSystemMigrationProgressTest {
         final Path testFile = Paths.get("file");
         sut.reportFileMigrated();
 
-        assertEquals(1, sut.getMigratedFiles());
+        assertEquals(1, sut.getCountOfMigratedFiles());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -30,8 +30,7 @@ public class DefaultFileSystemMigrationProgressTest {
 
         assertEquals(1, sut.getMigratedFiles().size());
 
-        final Path migratedFile = sut.getMigratedFiles().get(0);
-        assertEquals(testFile, migratedFile);
+        assertTrue(sut.getMigratedFiles().contains(testFile));
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -20,17 +20,15 @@ public class DefaultFileSystemMigrationProgressTest {
 
     @Test
     void shouldBeInitialisedWithNoCompleteFiles() {
-        assertTrue(sut.getMigratedFiles().isEmpty(), "expected migrated files list of new progress to be empty");
+        assertEquals(0, sut.getMigratedFiles());
     }
 
     @Test
     void shouldAddMigratedFileToMigratedFiles() {
         final Path testFile = Paths.get("file");
-        sut.reportFileMigrated(testFile);
+        sut.reportFileMigrated();
 
-        assertEquals(1, sut.getMigratedFiles().size());
-
-        assertTrue(sut.getMigratedFiles().contains(testFile));
+        assertEquals(1, sut.getMigratedFiles());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,7 +26,6 @@ public class DefaultFileSystemMigrationProgressTest {
 
     @Test
     void shouldAddMigratedFileToMigratedFiles() {
-        final Path testFile = Paths.get("file");
         sut.reportFileMigrated();
 
         assertEquals(1, sut.getCountOfMigratedFiles());
@@ -52,8 +52,16 @@ public class DefaultFileSystemMigrationProgressTest {
 
         assertEquals(2, sut.getNumberOfFilesInFlight());
 
-        sut.reportFileMigrated(Paths.get("test"));
+        sut.reportFileMigrated();
 
         assertEquals(1, sut.getNumberOfFilesInFlight());
+    }
+
+    @Test
+    void shouldHandleLargeNumberOfMigratedFiles() {
+        int numFilesToMigrate = 1000000;
+        IntStream.range(0, numFilesToMigrate).forEach(i -> sut.reportFileMigrated());
+
+        assertEquals(numFilesToMigrate, sut.getCountOfMigratedFiles());
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -79,9 +79,9 @@ public class DefaultFileSystemMigrationReportTest {
 
         verify(progress).reportFileMigrated();
 
-        sut.getMigratedFiles();
+        sut.getCountOfMigratedFiles();
 
-        verify(progress).getMigratedFiles();
+        verify(progress).getCountOfMigratedFiles();
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
@@ -133,13 +134,11 @@ public class DefaultFileSystemMigrationReportTest {
 
     @Test
     void testToString() {
-        final List migratedList = mock(List.class);
-        final int successfullyMigrated = 888;
+        final long successfullyMigrated = 888L;
         final int failedFiles = 666;
-        when(migratedList.size()).thenReturn(successfullyMigrated);
-        when(progress.getMigratedFiles()).thenReturn(migratedList);
+        when(progress.getCountOfMigratedFiles()).thenReturn(successfullyMigrated);
 
-        final List errorList = mock(List.class);
+        final Set errorList = mock(Set.class);
         when(errorList.size()).thenReturn(failedFiles);
         when(errors.getFailedFiles()).thenReturn(errorList);
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -75,9 +75,9 @@ public class DefaultFileSystemMigrationReportTest {
     @Test
     void shouldDelegateToWrappedProgress() {
         final Path path = Paths.get("file");
-        sut.reportFileMigrated(path);
+        sut.reportFileMigrated();
 
-        verify(progress).reportFileMigrated(path);
+        verify(progress).reportFileMigrated();
 
         sut.getMigratedFiles();
 


### PR DESCRIPTION
We were getting `ConcurrentModificationException` because the `migratedFiles` data structure wasn't thread-safe. I fixed that and then the data strucute was too big to be serialised sensibly. I've just refactored the migrated files property to be a count of migrated files.