### PR TITLE
FS progress report in flight files

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -2,6 +2,7 @@ package com.atlassian.migration.datacenter.core.fs;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,11 +16,13 @@ public class DirectoryStreamCrawler implements Crawler {
     private static final Logger logger = LoggerFactory.getLogger(DirectoryStreamCrawler.class);
 
     private FileSystemMigrationErrorReport report;
+    private FileSystemMigrationProgress progress;
 
     private long totalFilesCrawled = 0L;
 
-    public DirectoryStreamCrawler(FileSystemMigrationErrorReport report) {
+    public DirectoryStreamCrawler(FileSystemMigrationErrorReport report, FileSystemMigrationProgress progress) {
         this.report = report;
+        this.progress = progress;
     }
 
     @Override
@@ -41,6 +44,7 @@ public class DirectoryStreamCrawler implements Crawler {
                 }
             } else {
                 queue.add(p);
+                progress.reportFileFound();
                 totalFilesCrawled++;
             }
         });

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -118,7 +118,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
     }
 
     private void populateUploadQueue() {
-        Crawler homeCrawler = new DirectoryStreamCrawler(report);
+        Crawler homeCrawler = new DirectoryStreamCrawler(report, report);
         try {
             homeCrawler.crawlDirectory(getSharedHomeDir(), uploadQueue);
         } catch (IOException e) {

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -51,6 +51,7 @@ public class S3Uploader implements Uploader {
                             .key(key)
                             .build();
                     final CompletableFuture<PutObjectResponse> response = config.getS3AsyncClient().putObject(putRequest, path);
+                    progress.reportFileInFlight();
                     final S3UploadOperation uploadOperation = new S3UploadOperation(path, response);
 
                     responsesQueue.add(uploadOperation);

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -85,6 +85,16 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
+    public Long getNumberOfFilesInFlight() {
+        return progress.getNumberOfFilesInFlight();
+    }
+
+    @Override
+    public void reportFileInFlight() {
+        progress.reportFileInFlight();
+    }
+
+    @Override
     public List<Path> getMigratedFiles() {
         return progress.getMigratedFiles();
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -75,6 +75,16 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
+    public Long getNumberOfFilesFound() {
+        return progress.getNumberOfFilesFound();
+    }
+
+    @Override
+    public void reportFileFound() {
+        progress.reportFileFound();
+    }
+
+    @Override
     public List<Path> getMigratedFiles() {
         return progress.getMigratedFiles();
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -11,6 +11,16 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     private List<Path> migratedFiles = new LinkedList<>();
 
     @Override
+    public Long getNumberOfFilesFound() {
+        return null;
+    }
+
+    @Override
+    public void reportFileFound() {
+
+    }
+
+    @Override
     public List<Path> getMigratedFiles() {
         return migratedFiles;
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -13,6 +13,8 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
 
     private AtomicLong filesFound = new AtomicLong(0);
 
+    private AtomicLong filesInFlight = new AtomicLong(0);
+
     @Override
     public Long getNumberOfFilesFound() {
         return filesFound.get();
@@ -21,6 +23,16 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     @Override
     public void reportFileFound() {
         filesFound.incrementAndGet();
+    }
+
+    @Override
+    public Long getNumberOfFilesInFlight() {
+        return filesInFlight.get();
+    }
+
+    @Override
+    public void reportFileInFlight() {
+        filesInFlight.incrementAndGet();
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -43,5 +43,6 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     @Override
     public void reportFileMigrated(Path path) {
         migratedFiles.add(path);
+        filesInFlight.decrementAndGet();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -5,19 +5,22 @@ import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationPr
 import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
     private List<Path> migratedFiles = new LinkedList<>();
 
+    private AtomicLong filesFound = new AtomicLong(0);
+
     @Override
     public Long getNumberOfFilesFound() {
-        return null;
+        return filesFound.get();
     }
 
     @Override
     public void reportFileFound() {
-
+        filesFound.incrementAndGet();
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -1,5 +1,6 @@
 package com.atlassian.migration.datacenter.spi.fs.reporting;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.nio.file.Path;
@@ -10,6 +11,14 @@ import java.util.List;
  */
 @JsonSerialize(as = FileSystemMigrationProgress.class)
 public interface FileSystemMigrationProgress {
+
+    /**
+     * Gets the number of files which have been found to migrate.
+     */
+    @JsonProperty("filesFound")
+    Long getNumberOfFilesFound();
+
+    void reportFileFound();
 
     List<Path> getMigratedFiles();
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -20,6 +20,14 @@ public interface FileSystemMigrationProgress {
 
     void reportFileFound();
 
+    /**
+     * Gets the number of files which are currently being uploaded but not yet confirmed to be uploaded successfully
+     */
+    @JsonProperty("filesInFlight")
+    Long getNumberOfFilesInFlight();
+
+    void reportFileInFlight();
+
     List<Path> getMigratedFiles();
 
     void reportFileMigrated(Path path);

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -40,4 +40,11 @@ public class DefaultFileSystemMigrationProgressTest {
 
         assertEquals(1, sut.getNumberOfFilesFound());
     }
+
+    @Test
+    void shouldCountInFlightFile() {
+        sut.reportFileInFlight();
+
+        assertEquals(1, sut.getNumberOfFilesInFlight());
+    }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -33,4 +33,11 @@ public class DefaultFileSystemMigrationProgressTest {
         final Path migratedFile = sut.getMigratedFiles().get(0);
         assertEquals(testFile, migratedFile);
     }
+
+    @Test
+    void shouldCountMigratingFile() {
+        sut.reportFileFound();
+
+        assertEquals(1, sut.getNumberOfFilesFound());
+    }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -47,4 +47,16 @@ public class DefaultFileSystemMigrationProgressTest {
 
         assertEquals(1, sut.getNumberOfFilesInFlight());
     }
+
+    @Test
+    void ShouldRemoveFileFromInFlightWhenItIsMigrated() {
+        sut.reportFileInFlight();
+        sut.reportFileInFlight();
+
+        assertEquals(2, sut.getNumberOfFilesInFlight());
+
+        sut.reportFileMigrated(Paths.get("test"));
+
+        assertEquals(1, sut.getNumberOfFilesInFlight());
+    }
 }


### PR DESCRIPTION
I've implemented another metric in the FS migration progress which will make it much easier to see how the migration is going: In flight files

This should be the number of files which are being uploaded and have not been confirmed to be uploaded successfully. This is a good indicator on the progress the app is making through the migration.