### PR TITLE
CHET-124: implement state management service

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -177,7 +177,11 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
     }
 
     @Override
-    public void setCurrentStage(MigrationStage stage) {
+    public void nextStage() {
+        setCurrentStage(getCurrentStage().getNext());
+    }
+
+    private void setCurrentStage(MigrationStage stage) {
         migration.setStage(stage);
         migration.save();
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -183,17 +183,17 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
 
     @Override
     public void nextStage() {
-        setCurrentStage(getCurrentStage().getNext());
+        Migration migration = loadMigration();
+        setCurrentStage(migration, migration.getStage().getNext());
     }
 
     @Override
     public void error() {
-        loadMigration();
-        setCurrentStage(ERROR);
+        Migration migration = loadMigration();
+        setCurrentStage(migration, ERROR);
     }
 
-    private void setCurrentStage(MigrationStage stage) {
-        Migration migration = loadMigration();
+    private void setCurrentStage(Migration migration, MigrationStage stage) {
         migration.setStage(stage);
         migration.save();
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -186,6 +186,12 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
         setCurrentStage(getCurrentStage().getNext());
     }
 
+    @Override
+    public void error() {
+        findOrCreateMigration();
+        setCurrentStage(ERROR);
+    }
+
     private void setCurrentStage(MigrationStage stage) {
         migration.setStage(stage);
         migration.save();

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -169,6 +169,7 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
 
     @Override
     public void setCurrentStage(MigrationStage stage) {
-
+        migration.setStage(stage);
+        migration.save();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -6,6 +6,7 @@ import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageE
 import com.atlassian.migration.datacenter.core.fs.S3UploadJobRunner;
 import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
@@ -30,7 +31,7 @@ import static java.util.Objects.requireNonNull;
  * Manages a migration from on-premise to self-hosted AWS.
  */
 @Component
-public class AWSMigrationService implements MigrationService {
+public class AWSMigrationService implements MigrationService, MigrationServiceV2 {
     private static final Logger log = LoggerFactory.getLogger(AWSMigrationService.class);
     private final FilesystemMigrationService fsService;
     private final SchedulerService schedulerService;
@@ -159,5 +160,15 @@ public class AWSMigrationService implements MigrationService {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public MigrationStage getCurrentStage() {
+        return getMigration().getStage();
+    }
+
+    @Override
+    public void setCurrentStage(MigrationStage stage) {
+
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -71,10 +71,10 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
      */
     @Override
     public MigrationStage getMigrationStage() {
-        return getMigration().getStage();
+        return findOrCreateMigration().getStage();
     }
 
-    private Migration getMigration() {
+    private Migration findOrCreateMigration() {
         if (migration == null) {
             Migration[] migrations = ao.find(Migration.class);
             if (migrations.length == 1) {
@@ -129,7 +129,7 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
     }
 
     public boolean startFilesystemMigration() {
-        final Migration migration = getMigration();
+        final Migration migration = findOrCreateMigration();
         if (migration.getStage() == MigrationStage.NOT_STARTED) {
             return false;
         }
@@ -163,8 +163,17 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
     }
 
     @Override
+    public Migration createMigration() {
+        Migration migration = findOrCreateMigration();
+        if (migration.getStage().equals(MigrationStage.NOT_STARTED)) {
+            return migration;
+        }
+        throw new RuntimeException("Migration already exists");
+    }
+
+    @Override
     public MigrationStage getCurrentStage() {
-        return getMigration().getStage();
+        return findOrCreateMigration().getStage();
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -10,4 +10,6 @@ public interface MigrationServiceV2 {
 
     void nextStage();
 
+    void error();
+
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -1,0 +1,9 @@
+package com.atlassian.migration.datacenter.spi;
+
+public interface MigrationServiceV2 {
+
+    MigrationStage getCurrentStage();
+
+    void setCurrentStage(MigrationStage stage);
+
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -1,6 +1,10 @@
 package com.atlassian.migration.datacenter.spi;
 
+import com.atlassian.migration.datacenter.dto.Migration;
+
 public interface MigrationServiceV2 {
+
+    Migration createMigration();
 
     MigrationStage getCurrentStage();
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -8,6 +8,6 @@ public interface MigrationServiceV2 {
 
     MigrationStage getCurrentStage();
 
-    void setCurrentStage(MigrationStage stage);
+    void nextStage();
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -28,4 +28,8 @@ public enum MigrationStage {
     public String toString() {
         return key;
     }
+
+    public MigrationStage getNext() {
+        return nextStage;
+    }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -4,22 +4,24 @@ package com.atlassian.migration.datacenter.spi;
  * Represents all possible states of an on-premise to cloud migration.
  */
 public enum MigrationStage {
-    NOT_STARTED(""),
-    ERROR("error"),
-    AUTHENTICATION("authentication"),
-    PROVISION_APPLICATION("provision_app"), WAIT_PROVISION_APPLICATION("wait_provision_app"),
-    PROVISION_MIGRATION_STACK("provision_migration"), WAIT_PROVISION_MIGRATION_STACK("wait_provision_migration"),
-    READY_FS_MIGRATION("ready_fs_migration"), FS_MIGRATION_EXPORT("fs_migration_up"), FS_MIGRATION_IMPORT("fs_migration_down"),
-    OFFLINE_WARNING("cutover_warning"),
-    DB_MIGRATION_EXPORT("db_migration_up"), DB_MIGRATION_IMPORT("db_migration_down"),
-    VALIDATE("validate"),
-    CUTOVER("cutover"),
-    FINISHED("finished");
+    ERROR("error", null),
+    FINISHED("finished", null),
+    CUTOVER("cutover", FINISHED),
+    VALIDATE("validate", CUTOVER),
+    DB_MIGRATION_IMPORT("db_migration_down", VALIDATE), DB_MIGRATION_EXPORT("db_migration_up", DB_MIGRATION_IMPORT),
+    OFFLINE_WARNING("cutover_warning", DB_MIGRATION_EXPORT),
+    FS_MIGRATION_IMPORT("fs_migration_down", OFFLINE_WARNING), FS_MIGRATION_EXPORT("fs_migration_up", FS_MIGRATION_IMPORT), READY_FS_MIGRATION("ready_fs_migration", FS_MIGRATION_EXPORT),
+    WAIT_PROVISION_MIGRATION_STACK("wait_provision_migration", READY_FS_MIGRATION), PROVISION_MIGRATION_STACK("provision_migration", WAIT_PROVISION_MIGRATION_STACK),
+    WAIT_PROVISION_APPLICATION("wait_provision_app", PROVISION_MIGRATION_STACK), PROVISION_APPLICATION("provision_app", WAIT_PROVISION_APPLICATION),
+    AUTHENTICATION("authentication", PROVISION_APPLICATION),
+    NOT_STARTED("", AUTHENTICATION);
 
     private String key;
+    private MigrationStage nextStage;
 
-    MigrationStage(String key) {
+    MigrationStage(String key, MigrationStage nextStage) {
         this.key = key;
+        this.nextStage = nextStage;
     }
 
     @Override

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -201,6 +201,14 @@ public class AWSMigrationServiceTest {
         assertThrows(RuntimeException.class, () -> sut.createMigration());
     }
 
+    @Test
+    public void errorShouldSetCurrentStageToError() {
+        initializeAndCreateSingleMigrationWithStage(PROVISION_APPLICATION);
+
+        sut.error();
+
+        assertEquals(ERROR, sut.getCurrentStage());
+    }
 
     private void assertNumberOfMigrations(int i) {
         assertEquals(i, ao.find(Migration.class).length);

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -186,6 +186,14 @@ public class AWSMigrationServiceTest {
         assertEquals(PROVISION_APPLICATION, sut.getCurrentStage());
     }
 
+    @Test
+    public void shouldCreateMigrationInNotStarted() {
+        ao.migrate(Migration.class);
+        Migration migration = sut.createMigration();
+
+        assertEquals(NOT_STARTED, migration.getStage());
+    }
+
 
     private void assertNumberOfMigrations(int i) {
         assertEquals(i, ao.find(Migration.class).length);

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -11,6 +11,7 @@ import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
 import com.atlassian.scheduler.SchedulerService;
 import net.java.ao.EntityManager;
 import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
+import org.apache.http.auth.AUTH;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -177,13 +178,13 @@ public class AWSMigrationServiceTest {
     }
 
     @Test
-    public void shouldBeABleToSetCurrentStage() {
+    public void shouldTransitionToCurrentStagesNextStageOnChange() {
         initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
         assertEquals(AUTHENTICATION, sut.getCurrentStage());
 
-        sut.setCurrentStage(PROVISION_APPLICATION);
+        sut.nextStage();
 
-        assertEquals(PROVISION_APPLICATION, sut.getCurrentStage());
+        assertEquals(AUTHENTICATION.getNext(), sut.getCurrentStage());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -194,6 +194,12 @@ public class AWSMigrationServiceTest {
         assertEquals(NOT_STARTED, migration.getStage());
     }
 
+    @Test
+    public void shouldThrowExceptionWhenMigrationExistsAlready() {
+        initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
+        assertThrows(RuntimeException.class, () -> sut.createMigration());
+    }
+
 
     private void assertNumberOfMigrations(int i) {
         assertEquals(i, ao.find(Migration.class).length);

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -158,6 +158,16 @@ public class AWSMigrationServiceTest {
         verify(this.cfnApi, never()).provisionStack(any(), any(), any());
     }
 
+
+    // MigrationServiceV2 Tests
+    @Test
+    public void shouldBeAbleToGetCurrentStage() {
+        initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
+
+        assertEquals(AUTHENTICATION, sut.getCurrentStage());
+    }
+
+
     private void assertNumberOfMigrations(int i) {
         assertEquals(i, ao.find(Migration.class).length);
     }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -11,7 +11,6 @@ import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
 import com.atlassian.scheduler.SchedulerService;
 import net.java.ao.EntityManager;
 import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
-import org.apache.http.auth.AUTH;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -11,7 +11,6 @@ import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
 import com.atlassian.scheduler.SchedulerService;
 import net.java.ao.EntityManager;
 import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
-import org.apache.http.auth.AUTH;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,10 +22,20 @@ import org.mockito.junit.MockitoRule;
 import java.util.HashMap;
 import java.util.Optional;
 
-import static com.atlassian.migration.datacenter.spi.MigrationStage.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.AUTHENTICATION;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.ERROR;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.NOT_STARTED;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.PROVISION_APPLICATION;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.READY_FS_MIGRATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 // We have to use the JUnit 4 API because there is no JUnit 5 active objects extension :(
 @RunWith(ActiveObjectsJUnitRunner.class)
@@ -165,6 +174,16 @@ public class AWSMigrationServiceTest {
         initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
 
         assertEquals(AUTHENTICATION, sut.getCurrentStage());
+    }
+
+    @Test
+    public void shouldBeABleToSetCurrentStage() {
+        initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
+        assertEquals(AUTHENTICATION, sut.getCurrentStage());
+
+        sut.setCurrentStage(PROVISION_APPLICATION);
+
+        assertEquals(PROVISION_APPLICATION, sut.getCurrentStage());
     }
 
 


### PR DESCRIPTION
Paired with @theghostwhoforks 

This is the new state management service based on the specification from #30 

There is just one distinction and that is that there is no ability to set the stage directly.
Services either tell the state machine to move to the next stage (once they are done). The next stage is determined by the current stage. Services can also tell the state machine to move to an Error state.

The only pitfall with this approach is recovering from the Error state as it can potentially have multiple next states that aren't known until runtime, depending on the recovery approach. I suspect we may need to revert to setting the stage directly.
Should we defer that decision to when we start handling the unhappy path?