### PR TITLE
Drop next stage encoding

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -182,9 +182,14 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
     }
 
     @Override
-    public void nextStage() {
+    public void transition(MigrationStage from, MigrationStage to) throws InvalidMigrationStageError {
         Migration migration = loadMigration();
-        setCurrentStage(migration, migration.getStage().getNext());
+        final MigrationStage currentStage = migration.getStage();
+        if (!currentStage.equals(from)) {
+            throw new InvalidMigrationStageError(String.format("expected to be in %s but was in %s", from.toString(), currentStage.toString()));
+        }
+
+        setCurrentStage(migration, to);
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -1,5 +1,6 @@
 package com.atlassian.migration.datacenter.spi;
 
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.Migration;
 
 public interface MigrationServiceV2 {
@@ -8,7 +9,7 @@ public interface MigrationServiceV2 {
 
     MigrationStage getCurrentStage();
 
-    void nextStage();
+    void transition(MigrationStage from, MigrationStage to) throws InvalidMigrationStageError;
 
     void error();
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -4,32 +4,26 @@ package com.atlassian.migration.datacenter.spi;
  * Represents all possible states of an on-premise to cloud migration.
  */
 public enum MigrationStage {
-    ERROR("error", null),
-    FINISHED("finished", null),
-    CUTOVER("cutover", FINISHED),
-    VALIDATE("validate", CUTOVER),
-    DB_MIGRATION_IMPORT("db_migration_down", VALIDATE), DB_MIGRATION_EXPORT("db_migration_up", DB_MIGRATION_IMPORT),
-    OFFLINE_WARNING("cutover_warning", DB_MIGRATION_EXPORT),
-    FS_MIGRATION_IMPORT("fs_migration_down", OFFLINE_WARNING), FS_MIGRATION_EXPORT("fs_migration_up", FS_MIGRATION_IMPORT), READY_FS_MIGRATION("ready_fs_migration", FS_MIGRATION_EXPORT),
-    WAIT_PROVISION_MIGRATION_STACK("wait_provision_migration", READY_FS_MIGRATION), PROVISION_MIGRATION_STACK("provision_migration", WAIT_PROVISION_MIGRATION_STACK),
-    WAIT_PROVISION_APPLICATION("wait_provision_app", PROVISION_MIGRATION_STACK), PROVISION_APPLICATION("provision_app", WAIT_PROVISION_APPLICATION),
-    AUTHENTICATION("authentication", PROVISION_APPLICATION),
-    NOT_STARTED("", AUTHENTICATION);
+    ERROR("error"),
+    FINISHED("finished"),
+    CUTOVER("cutover"),
+    VALIDATE("validate"),
+    DB_MIGRATION_IMPORT("db_migration_down"), DB_MIGRATION_EXPORT("db_migration_up"),
+    OFFLINE_WARNING("cutover_warning"),
+    FS_MIGRATION_IMPORT("fs_migration_down"), FS_MIGRATION_EXPORT("fs_migration_up"), READY_FS_MIGRATION("ready_fs_migration"),
+    WAIT_PROVISION_MIGRATION_STACK("wait_provision_migration"), PROVISION_MIGRATION_STACK("provision_migration"),
+    WAIT_PROVISION_APPLICATION("wait_provision_app"), PROVISION_APPLICATION("provision_app"),
+    AUTHENTICATION("authentication"),
+    NOT_STARTED("");
 
     private String key;
-    private MigrationStage nextStage;
 
-    MigrationStage(String key, MigrationStage nextStage) {
+    MigrationStage(String key) {
         this.key = key;
-        this.nextStage = nextStage;
     }
 
     @Override
     public String toString() {
         return key;
-    }
-
-    public MigrationStage getNext() {
-        return nextStage;
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static com.atlassian.migration.datacenter.spi.MigrationStage.AUTHENTICATION;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.ERROR;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.FS_MIGRATION_EXPORT;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.NOT_STARTED;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.PROVISION_APPLICATION;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.READY_FS_MIGRATION;
@@ -177,13 +178,21 @@ public class AWSMigrationServiceTest {
     }
 
     @Test
-    public void shouldTransitionToCurrentStagesNextStageOnChange() {
+    public void shouldTransitionWhenSourceStageIsCurrentStage() throws InvalidMigrationStageError {
         initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
         assertEquals(AUTHENTICATION, sut.getCurrentStage());
 
-        sut.nextStage();
+        sut.transition(AUTHENTICATION, PROVISION_APPLICATION);
 
-        assertEquals(AUTHENTICATION.getNext(), sut.getCurrentStage());
+        assertEquals(PROVISION_APPLICATION, sut.getCurrentStage());
+    }
+
+    @Test
+    public void shouldNotTransitionWhenSourceStageIsNotCurrentStage() {
+        initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
+        assertEquals(AUTHENTICATION, sut.getCurrentStage());
+
+        assertThrows(InvalidMigrationStageError.class, () -> sut.transition(FS_MIGRATION_EXPORT, PROVISION_APPLICATION));
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -193,6 +193,7 @@ public class AWSMigrationServiceTest {
         assertEquals(AUTHENTICATION, sut.getCurrentStage());
 
         assertThrows(InvalidMigrationStageError.class, () -> sut.transition(FS_MIGRATION_EXPORT, PROVISION_APPLICATION));
+        assertEquals(sut.getCurrentStage(), AUTHENTICATION);
     }
 
     @Test


### PR DESCRIPTION
After working on the quickstart deployment stage I found an issue where you want to call "next stage" multiple times within the one service as you have the transition from:

Deploy application -> wait deploy application -> deploy migration stack

I don't think you want to call `nextStage()` to do that as `nextStage()` tries to encapsulate the path through stages however this stage expects a specific sequence when doing that.

I tried to move the waiting to `deploy application` to a separate service but this was also fruitless as you need to know when to start waiting for the deployment to finish which is impossible without some sort of `onTransition` hook. At this point, we'd basically be back with the heavyweight state pattern which we decided was undesirable.

After discussion with Varun, we found the best way to manage this without allowing arbitrary transitions was to have a transition method which supplies a source and a destination and the service simply verifies that the current stage is equal to the source before committing the transition.