### PR TITLE
CHET-128: quickstart state machine

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -5,6 +5,7 @@ import com.atlassian.migration.datacenter.core.exceptions.InfrastructureProvisio
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.core.fs.S3UploadJobRunner;
 import com.atlassian.migration.datacenter.dto.Migration;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
@@ -85,10 +86,15 @@ public class AWSMigrationService implements MigrationService, MigrationServiceV2
             // left off.
             return migrations[0];
         } else if (migrations.length == 0){
-            // We didn't start the migration, so we need to create record in the db
+            // We didn't start the migration, so we need to create record in the db and a migration context
             Migration migration = ao.create(Migration.class);
             migration.setStage(NOT_STARTED);
             migration.save();
+
+            MigrationContext context = ao.create(MigrationContext.class);
+            context.setMigration(migration);
+            context.save();
+
             return migration;
         } else {
             throw new RuntimeException("Invalid State - should only be 1 migration");

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -1,12 +1,15 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
+import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import org.tuckey.web.filters.urlrewrite.Run;
 import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
@@ -16,11 +19,12 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
 
     private static final String QUICKSTART_TEMPLATE_URL = "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml";
 
-    private CfnApi cfnApi;
+    private final CfnApi cfnApi;
+    private final MigrationServiceV2 migrationService;
+    private final ActiveObjects ao;
 
-    private MigrationServiceV2 migrationService;
-
-    public QuickstartDeploymentService(CfnApi cfnApi, MigrationServiceV2 migrationService) {
+    public QuickstartDeploymentService(@ComponentImport ActiveObjects ao, CfnApi cfnApi, MigrationServiceV2 migrationService) {
+        this.ao = ao;
         this.cfnApi = cfnApi;
         this.migrationService = migrationService;
     }
@@ -29,11 +33,45 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     public void deployApplication(String deploymentId, Map<String, String> params) {
         cfnApi.provisionStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
 
+        addDeploymentIdToMigrationContext(deploymentId);
+
         scheduleMigrationServiceTransition(deploymentId);
+    }
+
+    @Override
+    public ApplicationDeploymentStatus getDeploymentStatus() {
+        MigrationContext context = getMigrationContext();
+        StackStatus status = cfnApi.getStatus(context.getApplicationDeploymentId());
+
+        switch (status) {
+            case CREATE_COMPLETE:
+                return ApplicationDeploymentStatus.CREATE_COMPLETE;
+            case CREATE_FAILED:
+                return ApplicationDeploymentStatus.CREATE_FAILED;
+            case CREATE_IN_PROGRESS:
+                return ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
+            default:
+                throw new RuntimeException("Unexpected stack status");
+        }
+    }
+
+    private void addDeploymentIdToMigrationContext(String deploymentId) {
+        MigrationContext context = getMigrationContext();
+        context.setApplicationDeploymentId(deploymentId);
+        context.save();
+    }
+
+    private MigrationContext getMigrationContext() {
+        MigrationContext[] migrationContexts = ao.find(MigrationContext.class);
+        if (migrationContexts.length == 0) {
+            throw new RuntimeException("No migration context exists, are you really in a migration?");
+        }
+        return migrationContexts[0];
     }
 
     private void scheduleMigrationServiceTransition(String deploymentId) {
         CompletableFuture<String> stackCompleteFuture = new CompletableFuture<>();
+
         ScheduledFuture<?> ticker = Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
             final StackStatus status = cfnApi.getStatus(deploymentId);
             if (status.equals(StackStatus.CREATE_COMPLETE)) {
@@ -49,10 +87,5 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
         stackCompleteFuture.whenComplete((result, thrown) -> {
             ticker.cancel(true);
         });
-    }
-
-    @Override
-    public ApplicationDeploymentStatus getDeploymentStatus() {
-        return null;
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -1,14 +1,23 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
 
 import java.util.Map;
 
 public class QuickstartDeploymentService implements ApplicationDeploymentService {
 
+    private static final String QUICKSTART_TEMPLATE_URL = "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml";
+
+    private CfnApi cfnApi;
+
+    public QuickstartDeploymentService(CfnApi cfnApi) {
+        this.cfnApi = cfnApi;
+    }
+
     @Override
     public void deployApplication(String deploymentId, Map<String, String> params) {
-
+        cfnApi.provisionStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -14,8 +14,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class QuickstartDeploymentService implements ApplicationDeploymentService {
 
@@ -31,6 +29,14 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
         this.migrationService = migrationService;
     }
 
+    /**
+     * Commences the deployment of the AWS Quick Start. It will transition the state machine upon completion of the
+     * deployment. If the deployment finishes successfully we transition to the next stage, otherwise we transition
+     * to an error. The migration will also transition to an error if the deployment takes longer than an hour.
+     * @param deploymentId the stack name
+     * @param params the parameters for the cloudformation template. The key should be the parameter name and the value
+     *               should be the parameter value.
+     */
     @Override
     public void deployApplication(String deploymentId, Map<String, String> params) {
         cfnApi.provisionStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -1,0 +1,18 @@
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
+
+import java.util.Map;
+
+public class QuickstartDeploymentService implements ApplicationDeploymentService {
+
+    @Override
+    public void deployApplication(String deploymentId, Map<String, String> params) {
+
+    }
+
+    @Override
+    public ApplicationDeploymentStatus getDeploymentStatus() {
+        return null;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -47,6 +47,8 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
 
         cfnApi.provisionStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
 
+        migrationService.nextStage();
+
         addDeploymentIdToMigrationContext(deploymentId);
 
         scheduleMigrationServiceTransition(deploymentId);

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -27,8 +27,13 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
 
         Executors.newFixedThreadPool(1).submit(() -> {
             while (true) {
-                if (cfnApi.getStatus(deploymentId).equals(StackStatus.CREATE_COMPLETE)) {
+                final StackStatus status = cfnApi.getStatus(deploymentId);
+                if (status.equals(StackStatus.CREATE_COMPLETE)) {
                     migrationService.nextStage();
+                    return;
+                }
+                if (status.equals(StackStatus.CREATE_FAILED)) {
+                    migrationService.error();
                     return;
                 }
             }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -96,7 +96,8 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
         ScheduledFuture<?> canceller = scheduledExecutorService.scheduleAtFixedRate(() -> {
             migrationService.error();
             ticker.cancel(true);
-        }, 1, 0, TimeUnit.HOURS);
+            // Need to have non-zero period otherwise we get illegal argument exception
+        }, 1, 100, TimeUnit.HOURS);
 
         stackCompleteFuture.whenComplete((result, thrown) -> {
             ticker.cancel(true);

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -65,6 +65,7 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
             case CREATE_IN_PROGRESS:
                 return ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
             default:
+                migrationService.error();
                 throw new RuntimeException("Unexpected stack status");
         }
     }
@@ -78,6 +79,7 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     private MigrationContext getMigrationContext() {
         MigrationContext[] migrationContexts = ao.find(MigrationContext.class);
         if (migrationContexts.length == 0) {
+            migrationService.error();
             throw new RuntimeException("No migration context exists, are you really in a migration?");
         }
         return migrationContexts[0];

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -2,8 +2,10 @@ package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import software.amazon.awssdk.services.cloudformation.model.StackStatus;
@@ -38,7 +40,11 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
      *               should be the parameter value.
      */
     @Override
-    public void deployApplication(String deploymentId, Map<String, String> params) {
+    public void deployApplication(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
+        if(!migrationService.getCurrentStage().equals(MigrationStage.PROVISION_APPLICATION)) {
+            throw new InvalidMigrationStageError("must be in " + MigrationStage.PROVISION_APPLICATION.toString() + " to deploy application");
+        }
+
         cfnApi.provisionStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
 
         addDeploymentIdToMigrationContext(deploymentId);

--- a/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
@@ -1,0 +1,14 @@
+package com.atlassian.migration.datacenter.dto;
+
+import net.java.ao.Entity;
+
+public interface MigrationContext extends Entity {
+
+    Migration getMigration();
+
+    void setMigration(Migration migration);
+
+    String getApplicationDeploymentId();
+
+    void setApplicationDeploymentId(String id);
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -18,6 +18,12 @@ public interface MigrationServiceV2 {
      */
     MigrationStage getCurrentStage();
 
+    /**
+     * Tries to transition the migration state from one to another
+     * @param from the state you are expected to be in currently when beginning the transition
+     * @param to the state you want to transition to
+     * @throws InvalidMigrationStageError when the transition is invalid
+     */
     void transition(MigrationStage from, MigrationStage to) throws InvalidMigrationStageError;
 
     /**

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationServiceV2.java
@@ -3,14 +3,27 @@ package com.atlassian.migration.datacenter.spi;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.Migration;
 
+/**
+ * Manages the lifecycle of the migration
+ */
 public interface MigrationServiceV2 {
 
+    /**
+     * Creates a new migration in the initial stage
+     */
     Migration createMigration();
 
+    /**
+     * Gets the current stage of the migration
+     */
     MigrationStage getCurrentStage();
 
     void transition(MigrationStage from, MigrationStage to) throws InvalidMigrationStageError;
 
+    /**
+     * Moves the migration into an error stage
+     * @see MigrationStage#ERROR
+     */
     void error();
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.java
@@ -9,6 +9,6 @@ public interface ApplicationDeploymentService {
     ApplicationDeploymentStatus getDeploymentStatus();
 
     enum ApplicationDeploymentStatus {
-        CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILEd
+        CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILED
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.java
@@ -1,10 +1,12 @@
 package com.atlassian.migration.datacenter.spi.infrastructure;
 
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+
 import java.util.Map;
 
 public interface ApplicationDeploymentService {
 
-    void deployApplication(String deploymentId, Map<String, String> params);
+    void deployApplication(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError;
 
     ApplicationDeploymentStatus getDeploymentStatus();
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.java
@@ -1,0 +1,14 @@
+package com.atlassian.migration.datacenter.spi.infrastructure;
+
+import java.util.Map;
+
+public interface ApplicationDeploymentService {
+
+    void deployApplication(String deploymentId, Map<String, String> params);
+
+    ApplicationDeploymentStatus getDeploymentStatus();
+
+    enum ApplicationDeploymentStatus {
+        CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILEd
+    }
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -5,6 +5,7 @@ import com.atlassian.activeobjects.test.TestActiveObjects;
 import com.atlassian.migration.datacenter.core.exceptions.InfrastructureProvisioningError;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.Migration;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
@@ -62,7 +63,7 @@ public class AWSMigrationServiceTest {
 
     @Test
     public void shouldBeInUnStartedStageWhenNoMigrationExists() {
-        ao.migrate(Migration.class);
+        setupEntities();
 
         MigrationStage initialStage = sut.getMigrationStage();
 
@@ -85,7 +86,8 @@ public class AWSMigrationServiceTest {
 
     @Test
     public void shouldTransitionStageToAuthenticationWhenCreated() {
-        ao.migrate();
+        setupEntities();
+
         assertNumberOfMigrations(0);
 
         assertTrue(sut.startMigration());
@@ -170,13 +172,13 @@ public class AWSMigrationServiceTest {
 
 
     // MigrationServiceV2 Tests
+
     @Test
     public void shouldBeAbleToGetCurrentStage() {
         initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
 
         assertEquals(AUTHENTICATION, sut.getCurrentStage());
     }
-
     @Test
     public void shouldTransitionWhenSourceStageIsCurrentStage() throws InvalidMigrationStageError {
         initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
@@ -224,10 +226,17 @@ public class AWSMigrationServiceTest {
     }
 
     private Migration initializeAndCreateSingleMigrationWithStage(MigrationStage stage) {
-        ao.migrate(Migration.class);
+        setupEntities();
+
         Migration migration = ao.create(Migration.class);
         migration.setStage(stage);
         migration.save();
+
         return migration;
+    }
+
+    private void setupEntities() {
+        ao.migrate(Migration.class);
+        ao.migrate(MigrationContext.class);
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -1,34 +1,57 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 
 import java.util.HashMap;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class QuickstartDeploymentServiceTest {
 
+    static final String STACK_NAME = "my-stack";
+    static final HashMap<String, String> STACK_PARAMS = new HashMap<String, String>(){{
+        put("parameter", "value");
+    }};
+
     @Mock
     CfnApi mockCfnApi;
+
+    @Mock
+    MigrationServiceV2 mockMigrationService;
 
     @InjectMocks
     QuickstartDeploymentService deploymentService;
 
     @Test
     void shouldDeployQuickStart() {
-        final String stackName = "my-stack";
-        final HashMap<String, String> stackParams = new HashMap<>();
-        stackParams.put("parameter", "value");
+        deploySimpleStack();
 
-        deploymentService.deployApplication(stackName, stackParams);
+        verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml", STACK_NAME, STACK_PARAMS);
+    }
 
-        verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml", stackName, stackParams);
+    @Test
+    void shouldTransitionMigrationServiceStateWhenDeploymentFinishes() throws InterruptedException {
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_COMPLETE);
+
+        deploySimpleStack();
+
+        Thread.sleep(100);
+
+        verify(mockMigrationService).nextStage();
+    }
+
+    private void deploySimpleStack() {
+        deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
     }
 
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -50,6 +50,17 @@ class QuickstartDeploymentServiceTest {
         verify(mockMigrationService).nextStage();
     }
 
+    @Test
+    void shouldTransitionMigrationServiceToErrorWhenDeploymentFails() throws InterruptedException {
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_FAILED);
+
+        deploySimpleStack();
+
+        Thread.sleep(100);
+
+        verify(mockMigrationService).error();
+    }
+
     private void deploySimpleStack() {
         deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
     }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -1,31 +1,34 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class QuickstartDeploymentServiceTest {
-
-    QuickstartDeploymentService deploymentService;
 
     @Mock
     CfnApi mockCfnApi;
 
-    @BeforeEach
-    void setUp() {
-        deploymentService = new QuickstartDeploymentService();
-    }
+    @InjectMocks
+    QuickstartDeploymentService deploymentService;
 
     @Test
     void shouldDeployQuickStart() {
-        deploymentService.deployApplication("my-stack", new HashMap<>());
+        final String stackName = "my-stack";
+        final HashMap<String, String> stackParams = new HashMap<>();
+        stackParams.put("parameter", "value");
 
-        verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yml", "my-stack", new HashMap<>());
+        deploymentService.deployApplication(stackName, stackParams);
+
+        verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml", stackName, stackParams);
     }
 
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -1,16 +1,22 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
+import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 
 import java.util.HashMap;
 
+import static com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService.ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,7 +24,7 @@ import static org.mockito.Mockito.when;
 class QuickstartDeploymentServiceTest {
 
     static final String STACK_NAME = "my-stack";
-    static final HashMap<String, String> STACK_PARAMS = new HashMap<String, String>(){{
+    static final HashMap<String, String> STACK_PARAMS = new HashMap<String, String>() {{
         put("parameter", "value");
     }};
 
@@ -28,14 +34,35 @@ class QuickstartDeploymentServiceTest {
     @Mock
     MigrationServiceV2 mockMigrationService;
 
+    @Mock
+    ActiveObjects mockAo;
+
     @InjectMocks
     QuickstartDeploymentService deploymentService;
+
+    @Mock
+    MigrationContext mockContext;
+
+    @BeforeEach
+    void setUp() {
+        when(mockAo.find(MigrationContext.class)).thenReturn(new MigrationContext[]{mockContext});
+    }
 
     @Test
     void shouldDeployQuickStart() {
         deploySimpleStack();
 
         verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml", STACK_NAME, STACK_PARAMS);
+    }
+
+    @Test
+    void shouldReturnInProgressWhileDeploying() {
+        when(mockContext.getApplicationDeploymentId()).thenReturn(STACK_NAME);
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
+
+        deploySimpleStack();
+
+        assertEquals(CREATE_IN_PROGRESS, deploymentService.getDeploymentStatus());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -11,7 +11,6 @@ import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 
 import java.util.HashMap;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -1,0 +1,31 @@
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+
+import static org.mockito.Mockito.verify;
+
+class QuickstartDeploymentServiceTest {
+
+    QuickstartDeploymentService deploymentService;
+
+    @Mock
+    CfnApi mockCfnApi;
+
+    @BeforeEach
+    void setUp() {
+        deploymentService = new QuickstartDeploymentService();
+    }
+
+    @Test
+    void shouldDeployQuickStart() {
+        deploymentService.deployApplication("my-stack", new HashMap<>());
+
+        verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yml", "my-stack", new HashMap<>());
+    }
+
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import static com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService.ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +74,7 @@ class QuickstartDeploymentServiceTest {
 
         Thread.sleep(100);
 
-        verify(mockMigrationService).nextStage();
+        verify(mockMigrationService, times(2)).nextStage();
     }
 
     @Test
@@ -86,6 +87,18 @@ class QuickstartDeploymentServiceTest {
         Thread.sleep(100);
 
         verify(mockMigrationService).error();
+    }
+
+    @Test
+    void shouldTransitionToWaitingForDeploymentWhileDeploymentIsCompleting() throws InvalidMigrationStageError, InterruptedException {
+        initialiseValidMigration();
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
+
+        deploySimpleStack();
+
+        Thread.sleep(100);
+
+        verify(mockMigrationService).nextStage();
     }
 
     @Test


### PR DESCRIPTION
Bring quickstart deployment into state machine. Manages states:

DEPLOY_APPLICATION -> WAIT_DEPLOY_APPLICATION -> DEPLOY_MIGRATION_STACK

Also introduces `MigrationContext` where we can persist all data related to the migration that other stages may need access to. The `MigrationContext` is linked to the `Migration`.

The new service needs to be connected to a REST API but I figured we do that once we actually start tackling the UI.