### PR TITLE
CHET-142: implement different modes for state machine enforcement

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/api/MigrationEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/MigrationEndpoint.java
@@ -75,11 +75,12 @@ public class MigrationEndpoint {
 
     /**
      * Sets the current mode of the migration assistant
-     * @see DCMigrationAssistantMode
+     *
      * @param request a JSON object with a single key - "mode", the value of which must be a valid mode
      *                - no-verify
      *                - passthrough
      *                - default
+     * @see DCMigrationAssistantMode
      */
     @Path("/mode")
     @POST
@@ -108,14 +109,19 @@ public class MigrationEndpoint {
 
     /**
      * Gets the current mode of the migration assistant
+     *
      * @see DCMigrationAssistantMode
      */
     @Path("/mode")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAppMode() {
+        String mode = modalMigrationStageWorker.getMode().toString();
+        Map<String, String> entity = new HashMap<String, String>() {{
+            put("mode", mode);
+        }};
         return Response
-                .ok(modalMigrationStageWorker.getMode())
+                .ok(entity)
                 .build();
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/api/MigrationEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/MigrationEndpoint.java
@@ -76,6 +76,7 @@ public class MigrationEndpoint {
     /**
      * Sets the current mode of the migration assistant
      * @see DCMigrationAssistantMode
+     * @param
      */
     @Path("/mode")
     @POST
@@ -107,6 +108,7 @@ public class MigrationEndpoint {
      * @see DCMigrationAssistantMode
      */
     @Path("/mode")
+    @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAppMode() {
         return Response

--- a/src/main/java/com/atlassian/migration/datacenter/api/MigrationEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/MigrationEndpoint.java
@@ -76,7 +76,10 @@ public class MigrationEndpoint {
     /**
      * Sets the current mode of the migration assistant
      * @see DCMigrationAssistantMode
-     * @param
+     * @param request a JSON object with a single key - "mode", the value of which must be a valid mode
+     *                - no-verify
+     *                - passthrough
+     *                - default
      */
     @Path("/mode")
     @POST

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -1,0 +1,60 @@
+package com.atlassian.migration.datacenter.core;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ModalMigrationStageWorker {
+
+    private static final Logger logger = LoggerFactory.getLogger(ModalMigrationStageWorker.class);
+    private static final String MIGRATION_MODE_PLUGIN_SETTINGS_KEY = "com.atlassian.migration.datacenter.core.mode";
+
+    private final MigrationServiceV2 migrationService;
+    private final PluginSettingsFactory pluginSettingsFactory;
+
+    public ModalMigrationStageWorker(@ComponentImport PluginSettingsFactory pluginSettingsFactory, MigrationServiceV2 migrationService) {
+        this.pluginSettingsFactory = pluginSettingsFactory;
+        this.migrationService = migrationService;
+    }
+
+    /**
+     * Determines whether a migration operation should be run given the current mode the app is in.
+     * If the app is in the default mode, it will verify the current stage the expected current stage and run the migration operation
+     * If the app is in no-verify mode, it will run the migration operation without verifying the current stage
+     * If the app is in passthrough mode, it will skip the stage verification, ignore the operation and simply set the migration stage to the passThroughStage
+     * @param operation The migration operation e.g. upload files, restore database
+     * @param expectedCurrentStage The stage that the migration is expected to be in to run the given operation
+     * @param passThroughStage The stage that should be transitioned to if passing through this migration operation
+     */
+    public void runAccordingToCurrentMode(MigrationOperation operation, MigrationStage expectedCurrentStage, MigrationStage passThroughStage) {
+        PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
+        String mode = (String) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
+
+        if (mode != null && mode.equals("passthrough")) {
+            try {
+                migrationService.transition(migrationService.getCurrentStage(), passThroughStage);
+            } catch (InvalidMigrationStageError e) {
+                logger.error("Unable to transition from current stage to {}", passThroughStage, e);
+            }
+        }
+
+    }
+
+    /**
+     * Represents one operation in a migration. It should do whatever tasks it deems necessary to facilitate the
+     * migration and manage the transitions of the migration service.
+     */
+    @FunctionalInterface
+    public interface MigrationOperation {
+
+        void migrate();
+    }
+
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -33,7 +33,7 @@ public class ModalMigrationStageWorker {
      * @param expectedCurrentStage The stage that the migration is expected to be in to run the given operation
      * @param passThroughStage The stage that should be transitioned to if passing through this migration operation
      */
-    public void runAccordingToCurrentMode(MigrationOperation operation, MigrationStage expectedCurrentStage, MigrationStage passThroughStage) {
+    public void runAccordingToCurrentMode(MigrationOperation operation, MigrationStage expectedCurrentStage, MigrationStage passThroughStage) throws InvalidMigrationStageError {
         PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
         DCMigrationAssistantMode mode = (DCMigrationAssistantMode) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
 
@@ -55,6 +55,20 @@ public class ModalMigrationStageWorker {
         }
     }
 
+    public void setMode(DCMigrationAssistantMode mode) {
+        PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
+        settings.put(MIGRATION_MODE_PLUGIN_SETTINGS_KEY, mode);
+    }
+
+    public DCMigrationAssistantMode getMode() {
+        PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
+        DCMigrationAssistantMode mode = (DCMigrationAssistantMode) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
+        if (mode == null) {
+            return DCMigrationAssistantMode.DEFAULT;
+        }
+        return mode;
+    }
+
     /**
      * Represents one operation in a migration. It should do whatever tasks it deems necessary to facilitate the
      * migration and manage the transitions of the migration service.
@@ -62,7 +76,7 @@ public class ModalMigrationStageWorker {
     @FunctionalInterface
     public interface MigrationOperation {
 
-        void migrate();
+        void migrate() throws InvalidMigrationStageError;
     }
 
     public enum DCMigrationAssistantMode {
@@ -72,6 +86,11 @@ public class ModalMigrationStageWorker {
 
         DCMigrationAssistantMode(String mode) {
             this.mode = mode;
+        }
+
+        @Override
+        public String toString() {
+            return mode;
         }
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ModalMigrationStageWorker {
+    public static final String MIGRATION_MODE_PLUGIN_SETTINGS_KEY = "com.atlassian.migration.datacenter.core.mode";
 
     private static final Logger logger = LoggerFactory.getLogger(ModalMigrationStageWorker.class);
-    private static final String MIGRATION_MODE_PLUGIN_SETTINGS_KEY = "com.atlassian.migration.datacenter.core.mode";
 
     private final MigrationServiceV2 migrationService;
     private final PluginSettingsFactory pluginSettingsFactory;

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -66,7 +66,7 @@ public class ModalMigrationStageWorker {
 
     public DCMigrationAssistantMode getMode() {
         PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
-        DCMigrationAssistantMode mode = (DCMigrationAssistantMode) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
+        DCMigrationAssistantMode mode = DCMigrationAssistantMode.fromModeName((String) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY));
         if (mode == null) {
             return DCMigrationAssistantMode.DEFAULT;
         }

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -61,7 +61,7 @@ public class ModalMigrationStageWorker {
 
     public void setMode(DCMigrationAssistantMode mode) {
         PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
-        settings.put(MIGRATION_MODE_PLUGIN_SETTINGS_KEY, mode);
+        settings.put(MIGRATION_MODE_PLUGIN_SETTINGS_KEY, mode.toString());
     }
 
     public DCMigrationAssistantMode getMode() {
@@ -95,6 +95,22 @@ public class ModalMigrationStageWorker {
         @Override
         public String toString() {
             return mode;
+        }
+
+        public static DCMigrationAssistantMode fromModeName(String mode) {
+            if (mode == null) {
+                throw new IllegalArgumentException("mode cannot be null");
+            }
+            if (mode.equals(DEFAULT.mode)) {
+                return DEFAULT;
+            } else if (mode.equals(PASSTHROUGH.mode)) {
+                return PASSTHROUGH;
+            } else if (mode.equals(NO_VERIFY.mode)) {
+                return NO_VERIFY;
+            } else {
+                logger.error("tried to get DCMigrationAssistantMode from invalid string: {}", mode);
+                throw new IllegalArgumentException(mode + " is not a valid DC Migration Assistant mode");
+            }
         }
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -37,7 +37,10 @@ public class ModalMigrationStageWorker {
         PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
         String mode = (String) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
 
-        if (mode == null) {
+        if (mode == null || mode.equals("default")) {
+            if (migrationService.getCurrentStage().equals(expectedCurrentStage)) {
+                operation.migrate();
+            }
             return;
         }
 
@@ -49,12 +52,7 @@ public class ModalMigrationStageWorker {
             }
         } else if (mode.equals("no-verify")) {
             operation.migrate();
-        } else if (mode.equals("default")) {
-            if (migrationService.getCurrentStage().equals(expectedCurrentStage)) {
-                operation.migrate();
-            }
         }
-
     }
 
     /**

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -37,12 +37,18 @@ public class ModalMigrationStageWorker {
         PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
         String mode = (String) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
 
-        if (mode != null && mode.equals("passthrough")) {
+        if (mode == null) {
+            return;
+        }
+
+        if (mode.equals("passthrough")) {
             try {
                 migrationService.transition(migrationService.getCurrentStage(), passThroughStage);
             } catch (InvalidMigrationStageError e) {
                 logger.error("Unable to transition from current stage to {}", passThroughStage, e);
             }
+        } else if (mode.equals("no-verify")) {
+            operation.migrate();
         }
 
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -35,22 +35,22 @@ public class ModalMigrationStageWorker {
      */
     public void runAccordingToCurrentMode(MigrationOperation operation, MigrationStage expectedCurrentStage, MigrationStage passThroughStage) {
         PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
-        String mode = (String) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
+        DCMigrationAssistantMode mode = (DCMigrationAssistantMode) settings.get(MIGRATION_MODE_PLUGIN_SETTINGS_KEY);
 
-        if (mode == null || mode.equals("default")) {
+        if (mode == null || mode.equals(DCMigrationAssistantMode.DEFAULT)) {
             if (migrationService.getCurrentStage().equals(expectedCurrentStage)) {
                 operation.migrate();
             }
             return;
         }
 
-        if (mode.equals("passthrough")) {
+        if (mode.equals(DCMigrationAssistantMode.PASSTHROUGH)) {
             try {
                 migrationService.transition(migrationService.getCurrentStage(), passThroughStage);
             } catch (InvalidMigrationStageError e) {
                 logger.error("Unable to transition from current stage to {}", passThroughStage, e);
             }
-        } else if (mode.equals("no-verify")) {
+        } else if (mode.equals(DCMigrationAssistantMode.NO_VERIFY)) {
             operation.migrate();
         }
     }
@@ -63,6 +63,16 @@ public class ModalMigrationStageWorker {
     public interface MigrationOperation {
 
         void migrate();
+    }
+
+    public enum DCMigrationAssistantMode {
+        DEFAULT("default"), PASSTHROUGH("passthrough"), NO_VERIFY("no-verify");
+
+        private final String mode;
+
+        DCMigrationAssistantMode(String mode) {
+            this.mode = mode;
+        }
     }
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorker.java
@@ -49,6 +49,10 @@ public class ModalMigrationStageWorker {
             }
         } else if (mode.equals("no-verify")) {
             operation.migrate();
+        } else if (mode.equals("default")) {
+            if (migrationService.getCurrentStage().equals(expectedCurrentStage)) {
+                operation.migrate();
+            }
         }
 
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -1,6 +1,7 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.migration.datacenter.core.ModalMigrationStageWorker;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.MigrationContext;
@@ -29,11 +30,13 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     private final CfnApi cfnApi;
     private final MigrationServiceV2 migrationService;
     private final ActiveObjects ao;
+    private final ModalMigrationStageWorker modalMigrationStageWorker;
 
-    public QuickstartDeploymentService(@ComponentImport ActiveObjects ao, CfnApi cfnApi, MigrationServiceV2 migrationService) {
+    public QuickstartDeploymentService(@ComponentImport ActiveObjects ao, CfnApi cfnApi, MigrationServiceV2 migrationService, ModalMigrationStageWorker modalMigrationStageWorker) {
         this.ao = ao;
         this.cfnApi = cfnApi;
         this.migrationService = migrationService;
+        this.modalMigrationStageWorker = modalMigrationStageWorker;
     }
 
     /**
@@ -46,6 +49,10 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
      */
     @Override
     public void deployApplication(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
+        modalMigrationStageWorker.runAccordingToCurrentMode(() -> doDeployApplication(deploymentId, params), MigrationStage.PROVISION_APPLICATION, MigrationStage.PROVISION_MIGRATION_STACK);
+    }
+
+    private void doDeployApplication(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
         logger.info("received request to deploy application");
         migrationService.transition(MigrationStage.PROVISION_APPLICATION, MigrationStage.WAIT_PROVISION_APPLICATION);
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -84,10 +85,10 @@ class ModalMigrationStageWorkerTest {
     }
 
     @Test
-    void shouldNotRunOperationWhenModeIsDefaultAndCurrentStageDoesNotMatchExpectedStage() throws InvalidMigrationStageError {
+    void shouldNotRunOperationWhenModeIsDefaultAndCurrentStageDoesNotMatchExpectedStage() {
         when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.DEFAULT);
         when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 
-        sut.runAccordingToCurrentMode(Assertions::fail, MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT);
+        assertThrows(InvalidMigrationStageError.class, () -> sut.runAccordingToCurrentMode(Assertions::fail, MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT));
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -1,6 +1,7 @@
 package com.atlassian.migration.datacenter.core;
 
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
@@ -82,5 +83,13 @@ class ModalMigrationStageWorkerTest {
         sut.runAccordingToCurrentMode(() -> hasFuncBeenRun.set(true), currentStage, MigrationStage.DB_MIGRATION_EXPORT);
 
         assertTrue(hasFuncBeenRun.get(), "expected operation to be executed when mode is default and current stage matches expected stage");
+    }
+
+    @Test
+    void shouldNotRunOperationWhenModeIsDefaultAndCurrentStageDoesNotMatchExpectedStage() {
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("default");
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
+
+        sut.runAccordingToCurrentMode(Assertions::fail, MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT);
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -1,8 +1,6 @@
 package com.atlassian.migration.datacenter.core;
 
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
-import com.atlassian.migration.datacenter.dto.Migration;
-import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
@@ -66,5 +64,17 @@ class ModalMigrationStageWorkerTest {
         sut.runAccordingToCurrentMode(() -> hasFuncBeenRun.set(true), MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT);
 
         assertTrue(hasFuncBeenRun.get(), "expected operation to be executed when mode is no-verify");
+    }
+
+    @Test
+    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage() {
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("default");
+        final MigrationStage currentStage = MigrationStage.PROVISION_APPLICATION;
+        when(mockMigrationService.getCurrentStage()).thenReturn(currentStage);
+
+        AtomicBoolean hasFuncBeenRun = new AtomicBoolean(false);
+        sut.runAccordingToCurrentMode(() -> hasFuncBeenRun.set(true), currentStage, MigrationStage.DB_MIGRATION_EXPORT);
+
+        assertTrue(hasFuncBeenRun.get(), "expected operation to be executed when mode is default and current stage matches expected stage");
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -54,7 +54,7 @@ class ModalMigrationStageWorkerTest {
     }
 
     @Test
-    void shouldRunOperationEvenWhenCurrentStageIsNotExpectedStageWhenModeIsNoVerify() {
+    void shouldRunOperationEvenWhenCurrentStageIsNotExpectedStageWhenModeIsNoVerify() throws InvalidMigrationStageError {
         when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.NO_VERIFY);
 
         /*
@@ -72,7 +72,7 @@ class ModalMigrationStageWorkerTest {
     @ParameterizedTest
     @EnumSource(value = ModalMigrationStageWorker.DCMigrationAssistantMode.class, names = { "DEFAULT" })
     @NullSource
-    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage(ModalMigrationStageWorker.DCMigrationAssistantMode mode) {
+    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage(ModalMigrationStageWorker.DCMigrationAssistantMode mode) throws InvalidMigrationStageError {
         when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(mode);
         final MigrationStage currentStage = MigrationStage.PROVISION_APPLICATION;
         when(mockMigrationService.getCurrentStage()).thenReturn(currentStage);
@@ -84,7 +84,7 @@ class ModalMigrationStageWorkerTest {
     }
 
     @Test
-    void shouldNotRunOperationWhenModeIsDefaultAndCurrentStageDoesNotMatchExpectedStage() {
+    void shouldNotRunOperationWhenModeIsDefaultAndCurrentStageDoesNotMatchExpectedStage() throws InvalidMigrationStageError {
         when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.DEFAULT);
         when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -1,0 +1,48 @@
+package com.atlassian.migration.datacenter.core;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ModalMigrationStageWorkerTest {
+
+    @Mock
+    MigrationServiceV2 mockMigrationService;
+
+    @Mock
+    PluginSettingsFactory mockPluginSettingsFactory;
+
+    @Mock
+    PluginSettings mockPluginSettings;
+
+    @InjectMocks
+    ModalMigrationStageWorker sut;
+
+    @BeforeEach
+    void setUp() {
+        when(mockPluginSettingsFactory.createGlobalSettings()).thenReturn(mockPluginSettings);
+    }
+
+    @Test
+    void shouldTransitionToShortCircuitWhenModeIsPassthrough() throws InvalidMigrationStageError {
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("passthrough");
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
+
+        sut.runAccordingToCurrentMode(Assertions::fail, MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT);
+
+        verify(mockMigrationService).transition(MigrationStage.PROVISION_APPLICATION, MigrationStage.DB_MIGRATION_EXPORT);
+    }
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -1,7 +1,6 @@
 package com.atlassian.migration.datacenter.core;
 
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
-import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
@@ -11,9 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -47,7 +45,7 @@ class ModalMigrationStageWorkerTest {
 
     @Test
     void shouldTransitionToShortCircuitWhenModeIsPassthrough() throws InvalidMigrationStageError {
-        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("passthrough");
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.PASSTHROUGH);
         when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 
         sut.runAccordingToCurrentMode(Assertions::fail, MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT);
@@ -57,7 +55,7 @@ class ModalMigrationStageWorkerTest {
 
     @Test
     void shouldRunOperationEvenWhenCurrentStageIsNotExpectedStageWhenModeIsNoVerify() {
-        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("no-verify");
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.NO_VERIFY);
 
         /*
          * This mock is lenient because we want to be explicit that the current stage is not equal to the expected
@@ -72,9 +70,9 @@ class ModalMigrationStageWorkerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = "default")
+    @EnumSource(value = ModalMigrationStageWorker.DCMigrationAssistantMode.class, names = { "DEFAULT" })
     @NullSource
-    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage(String mode) {
+    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage(ModalMigrationStageWorker.DCMigrationAssistantMode mode) {
         when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(mode);
         final MigrationStage currentStage = MigrationStage.PROVISION_APPLICATION;
         when(mockMigrationService.getCurrentStage()).thenReturn(currentStage);
@@ -87,7 +85,7 @@ class ModalMigrationStageWorkerTest {
 
     @Test
     void shouldNotRunOperationWhenModeIsDefaultAndCurrentStageDoesNotMatchExpectedStage() {
-        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("default");
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.DEFAULT);
         when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 
         sut.runAccordingToCurrentMode(Assertions::fail, MigrationStage.AUTHENTICATION, MigrationStage.DB_MIGRATION_EXPORT);

--- a/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/ModalMigrationStageWorkerTest.java
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -66,9 +70,11 @@ class ModalMigrationStageWorkerTest {
         assertTrue(hasFuncBeenRun.get(), "expected operation to be executed when mode is no-verify");
     }
 
-    @Test
-    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage() {
-        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn("default");
+    @ParameterizedTest
+    @ValueSource(strings = "default")
+    @NullSource
+    void shouldRunOperationWhenModeIsDefaultAndCurrentStageMatchesExpectedStage(String mode) {
+        when(mockPluginSettings.get("com.atlassian.migration.datacenter.core.mode")).thenReturn(mode);
         final MigrationStage currentStage = MigrationStage.PROVISION_APPLICATION;
         when(mockMigrationService.getCurrentStage()).thenReturn(currentStage);
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/cloud/AWSConfigurationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/cloud/AWSConfigurationServiceTest.java
@@ -1,11 +1,15 @@
 package com.atlassian.migration.datacenter.core.aws.cloud;
 
+import com.atlassian.migration.datacenter.core.ModalMigrationStageWorker;
 import com.atlassian.migration.datacenter.core.aws.auth.WriteCredentialsService;
 import com.atlassian.migration.datacenter.core.aws.region.InvalidAWSRegionException;
 import com.atlassian.migration.datacenter.core.aws.region.RegionService;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.MigrationServiceV2;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,8 +37,23 @@ class AWSConfigurationServiceTest {
     @Mock
     MigrationServiceV2 mockMigrationService;
 
-    @InjectMocks
-    AWSConfigurationService sut;
+    @Mock
+    PluginSettingsFactory pluginSettingsFactory;
+
+    @Mock
+    PluginSettings pluginSettings;
+
+    private AWSConfigurationService sut;
+
+    @BeforeEach
+    void setUp() {
+        when(pluginSettingsFactory.createGlobalSettings()).thenReturn(pluginSettings);
+        when(pluginSettings.get(ModalMigrationStageWorker.MIGRATION_MODE_PLUGIN_SETTINGS_KEY)).thenReturn(ModalMigrationStageWorker.DCMigrationAssistantMode.DEFAULT);
+
+        ModalMigrationStageWorker worker = new ModalMigrationStageWorker(pluginSettingsFactory, mockMigrationService);
+
+        sut = new AWSConfigurationService(mockCredentialsWriter, mockRegionService, mockMigrationService, worker);
+    }
 
     @Test
     void shouldStoreCredentials() throws InvalidMigrationStageError {


### PR DESCRIPTION
This is a proof of concept for how we could have multiple modes for the migration assistant.

Default - enforce the current stage is as expected before running the operation
no-verify - always run the migration operation regardless of the current stage. This lets you test the database migration stage without having to wait to have moved through a file system migration.
passthrough - doesn't run the operation and sets the stage to the specified short circuit stage. This is good for if you just want to click through the UI.

I'm not completely happy with this approach as it warps how you write tests for migration operations in a couple of ways:

* Your tests need to have a ModalMigrationStageWorker
* When you create a new operation as a part of the migration you need to remember to call the worker so that it does the mode check.

I wanted to use a template method approach at first however there would need to be an abstract class doing this logic for each migration operation so there is still a bit of pain every time you implement a new migration operation.