### PR TITLE
CHET-148: Re-work in-flight file reporting

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -66,7 +66,7 @@ public class S3Uploader implements Uploader {
                             .key(key)
                             .build();
                     final CompletableFuture<PutObjectResponse> response = config.getS3AsyncClient().putObject(putRequest, path);
-                    progress.reportFileInFlight();
+                    progress.reportFileUploadCommenced();
                     final S3UploadOperation uploadOperation = new S3UploadOperation(path, response);
 
                     responsesQueue.add(uploadOperation);

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -113,13 +113,13 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public Long getNumberOfFilesInFlight() {
-        return progress.getNumberOfFilesInFlight();
+    public Long getNumberOfCommencedFileUploads() {
+        return progress.getNumberOfCommencedFileUploads();
     }
 
     @Override
-    public void reportFileInFlight() {
-        progress.reportFileInFlight();
+    public void reportFileUploadCommenced() {
+        progress.reportFileUploadCommenced();
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -10,7 +10,7 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
 
     private AtomicLong filesFound = new AtomicLong(0);
 
-    private AtomicLong filesInFlight = new AtomicLong(0);
+    private AtomicLong fileUploadsCommenced = new AtomicLong(0);
 
     @Override
     public Long getNumberOfFilesFound() {
@@ -23,13 +23,13 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     }
 
     @Override
-    public Long getNumberOfFilesInFlight() {
-        return filesInFlight.get();
+    public Long getNumberOfCommencedFileUploads() {
+        return fileUploadsCommenced.get();
     }
 
     @Override
-    public void reportFileInFlight() {
-        filesInFlight.incrementAndGet();
+    public void reportFileUploadCommenced() {
+        fileUploadsCommenced.incrementAndGet();
     }
 
     @Override
@@ -39,7 +39,6 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
 
     @Override
     public void reportFileMigrated() {
-        filesInFlight.decrementAndGet();
         numFilesMigrated.incrementAndGet();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -18,12 +18,12 @@ public interface FileSystemMigrationProgress {
     void reportFileFound();
 
     /**
-     * Gets the number of files which are currently being uploaded but not yet confirmed to be uploaded successfully
+     * Gets the number of files which have had their upload commenced
      */
     @JsonProperty("filesInFlight")
-    Long getNumberOfFilesInFlight();
+    Long getNumberOfCommencedFileUploads();
 
-    void reportFileInFlight();
+    void reportFileUploadCommenced();
 
     /**
      * Gets the number of files which have been successfully migrated

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -138,12 +138,11 @@ class S3UploaderTest {
 
         Thread.sleep(100);
 
-        assertEquals(1, progress.getNumberOfFilesInFlight());
+        assertEquals(1, progress.getNumberOfCommencedFileUploads());
 
         isCrawlDone.set(true);
 
         submit.get();
-        assertEquals(0, progress.getNumberOfFilesInFlight());
     }
 
     Path addFileToQueue(String fileName) throws IOException {

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -36,22 +36,10 @@ public class DefaultFileSystemMigrationProgressTest {
     }
 
     @Test
-    void shouldCountInFlightFile() {
-        sut.reportFileInFlight();
+    void shouldCountCommencedFileUploads() {
+        sut.reportFileUploadCommenced();
 
-        assertEquals(1, sut.getNumberOfFilesInFlight());
-    }
-
-    @Test
-    void ShouldRemoveFileFromInFlightWhenItIsMigrated() {
-        sut.reportFileInFlight();
-        sut.reportFileInFlight();
-
-        assertEquals(2, sut.getNumberOfFilesInFlight());
-
-        sut.reportFileMigrated();
-
-        assertEquals(1, sut.getNumberOfFilesInFlight());
+        assertEquals(1, sut.getNumberOfCommencedFileUploads());
     }
 
     @Test


### PR DESCRIPTION
Adam was observing that the in-flight files were being reported as a negative number. I wasn't able to reproduce this locally. I had a look through the code and the in-flight file reporting is not very consistent anyway: Files which have an error do not decrement the files in-flight counter and it would take a non-trivial amount of effort to correct this.

The aim of the files-in-flight counter was to get an indication of how far behind the crawler the uploader is. With that in mind, I've refactored the files-in-flight to be a "files with commenced upload" counter. This still lets us track the uploader without reporting incorrect information. I'm open to the possibility that we could just drop this notion altogether.