### PR TITLE
CHET-154: Build thin wrapper over SSM API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,10 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+        </dependency>
 
         <!-- Test Dependencies follow -->
         <dependency>

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
@@ -4,7 +4,6 @@ import com.atlassian.migration.datacenter.core.aws.region.RegionService;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
-import software.amazon.awssdk.services.ssm.model.Command;
 import software.amazon.awssdk.services.ssm.model.GetCommandInvocationRequest;
 import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
@@ -12,7 +11,6 @@ import software.amazon.awssdk.services.ssm.model.SendCommandResponse;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 public class SSMApi {
 
@@ -45,8 +43,8 @@ public class SSMApi {
                 .timeoutSeconds(600)
                 .comment("command run by Jira DC Migration Assistant")
                 // FIXME: Pending migration stack
-                .outputS3BucketName("migration-bucket")
-                .outputS3KeyPrefix("fs-copy-down-log")
+                .outputS3BucketName(System.getProperty("ssmDocumentLoggingBucket", "migration-bucket"))
+                .outputS3KeyPrefix("trebuchet-ssm-document-logs")
                 // END FIXME
                 .build();
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
@@ -1,4 +1,32 @@
 package com.atlassian.migration.datacenter.core.aws;
 
+import com.atlassian.migration.datacenter.core.aws.region.RegionService;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
 public class SSMApi {
+
+    private final AwsCredentialsProvider credentialsService;
+    private final RegionService regionService;
+
+    // This may be null, use getClient to safely get a non-null SSM client
+    private SsmClient client;
+
+    public SSMApi(AwsCredentialsProvider credentialsService, RegionService regionService) {
+        this.credentialsService = credentialsService;
+        this.regionService = regionService;
+    }
+
+    // Lazily instantiates the ssm client
+    private SsmClient getClient() {
+        if (client == null) {
+            client = SsmClient.builder()
+                    .credentialsProvider(credentialsService)
+                    .region(Region.of(regionService.getRegion()))
+                    .build();
+        }
+
+        return client;
+    }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
@@ -4,18 +4,47 @@ import com.atlassian.migration.datacenter.core.aws.region.RegionService;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
+import software.amazon.awssdk.services.ssm.model.SendCommandResponse;
+
+import java.util.List;
+import java.util.Map;
 
 public class SSMApi {
 
     private final AwsCredentialsProvider credentialsService;
     private final RegionService regionService;
 
-    // This may be null, use getClient to safely get a non-null SSM client
+    // This may be null, use getClient() to safely get a non-null SSM client
     private SsmClient client;
 
     public SSMApi(AwsCredentialsProvider credentialsService, RegionService regionService) {
         this.credentialsService = credentialsService;
         this.regionService = regionService;
+    }
+
+    /**
+     * Runs an SSM automatiom document against a specific EC2 instance with the specified parameters.
+     * @param documentName The name of the document to run. The latest version will be used.
+     * @param targetEc2InstanceId The instance ID of the EC2 instance to run this command on
+     * @param commandParameters
+     * @return the command ID of the invoked command.
+     */
+    public String runSSMDocument(String documentName, String targetEc2InstanceId, Map<String, List<String>> commandParameters) {
+        SendCommandRequest request = SendCommandRequest.builder()
+                .documentName(documentName)
+                .documentVersion("$LATEST")
+                .instanceIds(targetEc2InstanceId)
+                .parameters(commandParameters)
+                .timeoutSeconds(600)
+                .comment("command run by Jira DC Migration Assistant")
+                .outputS3BucketName("migration-bucket")
+                .outputS3KeyPrefix("fs-copy-down-log")
+                .build();
+
+        SendCommandResponse response = getClient().sendCommand(request);
+
+        return response.command().commandId();
     }
 
     // Lazily instantiates the ssm client

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
@@ -31,7 +31,9 @@ public class SSMApi {
      * Runs an SSM automatiom document against a specific EC2 instance with the specified parameters.
      * @param documentName The name of the document to run. The latest version will be used.
      * @param targetEc2InstanceId The instance ID of the EC2 instance to run this command on
-     * @param commandParameters
+     * @param commandParameters The parameters for the command. The key should be the parameter name and the value should
+     *                          be a list filled with the lines to be used as the parameter value. If the parameter-type
+     *                          is a plain string then the list only have one element in it.
      * @return the command ID of the invoked command.
      */
     public String runSSMDocument(String documentName, String targetEc2InstanceId, Map<String, List<String>> commandParameters) {
@@ -42,8 +44,10 @@ public class SSMApi {
                 .parameters(commandParameters)
                 .timeoutSeconds(600)
                 .comment("command run by Jira DC Migration Assistant")
+                // FIXME: Pending migration stack
                 .outputS3BucketName("migration-bucket")
                 .outputS3KeyPrefix("fs-copy-down-log")
+                // END FIXME
                 .build();
 
         SendCommandResponse response = getClient().sendCommand(request);

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/SSMApi.java
@@ -1,0 +1,4 @@
+package com.atlassian.migration.datacenter.core.aws;
+
+public class SSMApi {
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
@@ -14,6 +14,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.CommandInvocationStatus;
+import software.amazon.awssdk.services.ssm.model.CommandStatus;
 import software.amazon.awssdk.services.ssm.model.GetCommandInvocationRequest;
 import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
@@ -23,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
@@ -50,18 +53,34 @@ public class SSMApiIT {
     }
 
     @Test
-    @Disabled("Requires true authentication to AWS and a specific EC2 instance to be running")
+//    @Disabled("Requires true authentication to AWS and a specific EC2 instance to be running")
     void shouldSendSsmCommandToAWS() {
         final String documentName = "AWS-RunShellScript";
         // Node ID of ConfluenceGiveMeAllTheData Confluence Node in us-east-1
         final String targetEc2InstanceId = "i-0d536acd983bade05";
         final HashMap<String, List<String>> commandParameters = new HashMap<String, List<String>>() {{
-           put("commands", Collections.singletonList("echo 'hello, world'"));
+            put("commands", Collections.singletonList("echo 'hello, world'"));
         }};
 
         String commandId = sut.runSSMDocument(documentName, targetEc2InstanceId, commandParameters);
 
         assertNotNull(commandId);
+    }
+
+    @Test
+    @Disabled("Requires true authentication to AWS")
+    void shouldGetCommand() {
+        // Command run by an earlier run of shouldSendSsmCommandToAWS
+        final String commandID = "5c45181c-ed0a-45db-9fb7-3a4cd1edef9d";
+        // Node ID of ConfluenceGiveMeAllTheData Confluence Node in us-east-1
+        final String targetEc2InstanceId = "i-0d536acd983bade05";
+
+        GetCommandInvocationResponse command = sut.getSSMCommand(commandID, targetEc2InstanceId);
+
+        assertNotNull(command);
+
+        assertEquals(CommandInvocationStatus.SUCCESS, command.status());
+        assertEquals("hello, world\n", command.standardOutputContent());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
@@ -3,11 +3,15 @@ package com.atlassian.migration.datacenter.core.aws;
 import cloud.localstack.TestUtils;
 import cloud.localstack.docker.LocalstackDockerExtension;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import com.atlassian.migration.datacenter.core.aws.region.InvalidAWSRegionException;
+import com.atlassian.migration.datacenter.core.aws.region.RegionService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetCommandInvocationRequest;
@@ -15,14 +19,50 @@ import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
-@ExtendWith({LocalstackDockerExtension.class})
-@LocalstackDockerProperties(services = {"cloudformation", "s3", "ssm"}, imageTag = "0.10.8")
+//@ExtendWith({LocalstackDockerExtension.class})
+//@LocalstackDockerProperties(services = {"cloudformation", "s3", "ssm"}, imageTag = "0.10.8")
 public class SSMApiIT {
 
     private static final String LOCALSTACK_SSM_ENDPOINT = "http://localhost:4583";
+
+    private SSMApi sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SSMApi(DefaultCredentialsProvider.create(), new RegionService() {
+            @Override
+            public String getRegion() {
+                return "us-east-1";
+            }
+
+            @Override
+            public void storeRegion(String string) throws InvalidAWSRegionException {
+
+            }
+        });
+    }
+
+    @Test
+    @Disabled("Requires true authentication to AWS and a specific EC2 instance to be running")
+    void shouldSendSsmCommandToAWS() {
+        final String documentName = "AWS-RunShellScript";
+        // Node ID of ConfluenceGiveMeAllTheData Confluence Node in us-east-1
+        final String targetEc2InstanceId = "i-0d536acd983bade05";
+        final HashMap<String, List<String>> commandParameters = new HashMap<String, List<String>>() {{
+           put("commands", Collections.singletonList("echo 'hello, world'"));
+        }};
+
+        String commandId = sut.runSSMDocument(documentName, targetEc2InstanceId, commandParameters);
+
+        assertNotNull(commandId);
+    }
 
     @Test
     @Disabled("Localstack is giving 500s for SSM send-command")

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
@@ -53,7 +53,7 @@ public class SSMApiIT {
     }
 
     @Test
-//    @Disabled("Requires true authentication to AWS and a specific EC2 instance to be running")
+    @Disabled("Requires true authentication to AWS and a specific EC2 instance to be running")
     void shouldSendSsmCommandToAWS() {
         final String documentName = "AWS-RunShellScript";
         // Node ID of ConfluenceGiveMeAllTheData Confluence Node in us-east-1

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/SSMApiIT.java
@@ -1,0 +1,88 @@
+package com.atlassian.migration.datacenter.core.aws;
+
+import cloud.localstack.TestUtils;
+import cloud.localstack.docker.LocalstackDockerExtension;
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetCommandInvocationRequest;
+import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
+import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
+
+import java.net.URI;
+import java.util.HashMap;
+
+@Tag("integration")
+@ExtendWith({LocalstackDockerExtension.class})
+@LocalstackDockerProperties(services = {"cloudformation", "s3", "ssm"}, imageTag = "0.10.8")
+public class SSMApiIT {
+
+    private static final String LOCALSTACK_SSM_ENDPOINT = "http://localhost:4583";
+
+    @Test
+    @Disabled("Localstack is giving 500s for SSM send-command")
+    void shouldStartSSMCommand() {
+        SsmClient client = SsmClient.builder()
+                .endpointOverride(URI.create(LOCALSTACK_SSM_ENDPOINT))
+                .credentialsProvider(() -> new AwsCredentials() {
+                    @Override
+                    public String accessKeyId() {
+                        return TestUtils.TEST_ACCESS_KEY;
+                    }
+
+                    @Override
+                    public String secretAccessKey() {
+                        return TestUtils.TEST_SECRET_KEY;
+                    }
+                })
+                .region(Region.of(TestUtils.DEFAULT_REGION))
+                .build();
+
+        SendCommandRequest request = SendCommandRequest.builder()
+                .documentName("document")
+                .documentVersion("$LATEST")
+                .timeoutSeconds(600)
+                .comment("running command to pull files down as part of migration")
+                .parameters(new HashMap<>())
+                .instanceIds("i-1234567")
+                .outputS3BucketName("migration-bucket")
+                .outputS3KeyPrefix("fs-copy-down-log")
+                .build();
+        client.sendCommand(request);
+    }
+
+    @Test
+    @Disabled("Localstack is giving 400s for SSM getCommandInvocation")
+    void shouldGetStatusOfRunningCommand() {
+        SsmClient client = SsmClient.builder()
+                .endpointOverride(URI.create(LOCALSTACK_SSM_ENDPOINT))
+                .credentialsProvider(() -> new AwsCredentials() {
+                    @Override
+                    public String accessKeyId() {
+                        return TestUtils.TEST_ACCESS_KEY;
+                    }
+
+                    @Override
+                    public String secretAccessKey() {
+                        return TestUtils.TEST_SECRET_KEY;
+                    }
+                })
+                .region(Region.of(TestUtils.DEFAULT_REGION))
+                .build();
+
+        GetCommandInvocationRequest request = GetCommandInvocationRequest.builder()
+                .commandId("commandID")
+                .instanceId("theInstance")
+                .build();
+
+        GetCommandInvocationResponse response = client.getCommandInvocation(request);
+
+        System.out.println(response.standardOutputContent());
+    }
+
+}


### PR DESCRIPTION
# Summary

* Manages SSM client
* Exposes key SSM operations
* Reduced complexity of return types where possible
* Builds in sensible defaults.