### PR TITLE
CHET-145: Add database migration service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgres.driver.version}</version>

--- a/src/main/java/com/atlassian/migration/datacenter/core/application/DatabaseConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/application/DatabaseConfiguration.java
@@ -5,19 +5,28 @@ package com.atlassian.migration.datacenter.core.application;
  */
 public class DatabaseConfiguration
 {
+    public enum DBType {
+        POSTGRESQL,
+        MYSQL,
+        SQLSERVER,
+        ORACLE
+    }
+
     private String host;
     private String name;
     private String username;
     private String password;
     private Integer port;
+    private DBType type;
 
-    public DatabaseConfiguration(String host, Integer port, String name, String username, String password)
+    public DatabaseConfiguration(DBType type, String host, Integer port, String name, String username, String password)
     {
         this.host = host;
         this.name = name;
         this.username = username;
         this.password = password;
         this.port = port;
+        this.type = type;
     }
 
     public String getHost()
@@ -43,5 +52,10 @@ public class DatabaseConfiguration
     public Integer getPort()
     {
         return port;
+    }
+
+    public DBType getType()
+    {
+        return type;
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/application/JiraConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/application/JiraConfiguration.java
@@ -1,6 +1,7 @@
 package com.atlassian.migration.datacenter.core.application;
 
 import com.atlassian.jira.config.util.JiraHome;
+import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration.DBType;
 import org.springframework.stereotype.Component;
 import org.xml.sax.InputSource;
 
@@ -93,13 +94,14 @@ public class JiraConfiguration implements ApplicationConfiguration
             // JDBC URIs are absolute, so we need to parse them in 2 steps.
             URI absURI = URI.create(urlStr);
             URI dbURI = URI.create(absURI.getSchemeSpecificPart());
+            DBType type = DBType.valueOf(dbURI.getScheme().toUpperCase());
             String host = dbURI.getHost();
             Integer port = dbURI.getPort();
             if (port == -1)
                 port = 5432;
             String name = dbURI.getPath().substring(1); // Remove leading '/'
 
-            return new DatabaseConfiguration(host, port, name, username, password);
+            return new DatabaseConfiguration(type, host, port, name, username, password);
         } catch (Exception e) {
             throw new ConfigurationReadException("Failed to parse dbconfig.xml", e);
         }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -5,6 +5,7 @@ import com.atlassian.migration.datacenter.core.aws.region.RegionService;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractor;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
+import com.atlassian.migration.datacenter.core.fs.S3Uploader;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -40,33 +41,41 @@ public class DatabaseMigrationService
         this.awsCredentialsProvider = awsCredentialsProvider;
         this.regionService = regionService;
         this.tempDirectory = tempDirectory;
+        this.setStatus(MigrationStatus.NOT_STARTED);
     }
 
-    public File startMigration() throws DatabaseMigrationFailure
+    /**
+     * Start database dump and upload to S3 bucket. This is a blocking operation and should be started from ExecutorService
+     * or preferably from ScheduledJob. The status of the migration can be queried via
+     */
+    public void performMigration() throws DatabaseMigrationFailure
     {
         dbMigrationThread = Executors.newSingleThreadExecutor();
         DatabaseExtractor extractor = DatabaseExtractorFactory.getExtractor(applicationConfiguration);
         File target;
         try {
-            target = Files.createTempFile(tempDirectory, "dbdump", ".sql.gz").toFile();
+            target = Files.createTempFile(tempDirectory, "dbdump", ".dump").toFile();
         } catch (IOException e) {
             throw new DatabaseMigrationFailure("Failed to create temporary database file under: "+tempDirectory);
         }
 
         extractorProcess = extractor.startDatabaseDump(target);
+        setStatus(MigrationStatus.DUMP_IN_PROGRESS);
+        try {
+            extractorProcess.waitFor();
+        } catch (Exception e) {
+            String msg = "Error while waiting for DB extractor to finish";
+            setStatus(MigrationStatus.error(msg, e));
+            throw new DatabaseMigrationFailure(msg, e);
+        }
+        setStatus(MigrationStatus.DUMP_COMPLETE);
 
-        status.set(MigrationStatus.STARTED);
 
-        dbMigrationThread.submit(() -> {
-            try {
-                extractorProcess.waitFor();
-            } catch (Exception e) {
-                status.set(MigrationStatus.error("Error while waiting for DB extractor to finish", e));
-            }
-            status.set(MigrationStatus.FINISHED);
-        });
+        setStatus(MigrationStatus.FINISHED);
+    }
 
-        return target;
+    private void setStatus(MigrationStatus status) {
+        this.status.set(status);
     }
 
     public MigrationStatus getStatus() {

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -5,16 +5,31 @@ import com.atlassian.migration.datacenter.core.aws.region.RegionService;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractor;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
+import com.atlassian.migration.datacenter.core.fs.Crawler;
+import com.atlassian.migration.datacenter.core.fs.DirectoryStreamCrawler;
+import com.atlassian.migration.datacenter.core.fs.S3UploadConfig;
 import com.atlassian.migration.datacenter.core.fs.S3Uploader;
+import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFileSystemMigrationErrorReport;
+import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFilesystemMigrationProgress;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -26,6 +41,7 @@ public class DatabaseMigrationService
     private final ApplicationConfiguration applicationConfiguration;
     private final AwsCredentialsProvider awsCredentialsProvider;
     private final RegionService regionService;
+    private final Optional<URI> endpointOverride;
     private final Path tempDirectory;
 
     private ExecutorService dbMigrationThread;
@@ -41,6 +57,21 @@ public class DatabaseMigrationService
         this.awsCredentialsProvider = awsCredentialsProvider;
         this.regionService = regionService;
         this.tempDirectory = tempDirectory;
+        this.endpointOverride = Optional.empty();
+        this.setStatus(MigrationStatus.NOT_STARTED);
+    }
+
+    public DatabaseMigrationService(ApplicationConfiguration applicationConfiguration,
+                                    AwsCredentialsProvider awsCredentialsProvider,
+                                    RegionService regionService,
+                                    Path tempDirectory,
+                                    URI endointOverride)
+    {
+        this.applicationConfiguration = applicationConfiguration;
+        this.awsCredentialsProvider = awsCredentialsProvider;
+        this.regionService = regionService;
+        this.tempDirectory = tempDirectory;
+        this.endpointOverride = Optional.of(endointOverride);
         this.setStatus(MigrationStatus.NOT_STARTED);
     }
 
@@ -48,16 +79,11 @@ public class DatabaseMigrationService
      * Start database dump and upload to S3 bucket. This is a blocking operation and should be started from ExecutorService
      * or preferably from ScheduledJob. The status of the migration can be queried via
      */
-    public void performMigration() throws DatabaseMigrationFailure
+    public FileSystemMigrationErrorReport performMigration() throws DatabaseMigrationFailure
     {
         dbMigrationThread = Executors.newSingleThreadExecutor();
         DatabaseExtractor extractor = DatabaseExtractorFactory.getExtractor(applicationConfiguration);
-        File target;
-        try {
-            target = Files.createTempFile(tempDirectory, "dbdump", ".dump").toFile();
-        } catch (IOException e) {
-            throw new DatabaseMigrationFailure("Failed to create temporary database file under: "+tempDirectory);
-        }
+        Path target = tempDirectory.resolve("db.dump");
 
         extractorProcess = extractor.startDatabaseDump(target);
         setStatus(MigrationStatus.DUMP_IN_PROGRESS);
@@ -71,7 +97,36 @@ public class DatabaseMigrationService
         setStatus(MigrationStatus.DUMP_COMPLETE);
 
 
+        ConcurrentLinkedQueue<Path> uploadQueue = new ConcurrentLinkedQueue<>();
+        FileSystemMigrationProgress progress = new DefaultFilesystemMigrationProgress();
+        FileSystemMigrationErrorReport report = new DefaultFileSystemMigrationErrorReport();
+
+        S3AsyncClientBuilder builder = S3AsyncClient.builder()
+            .credentialsProvider(awsCredentialsProvider)
+            .region(Region.of(regionService.getRegion()));
+        if (endpointOverride.isPresent()) {
+            builder = builder.endpointOverride(endpointOverride.get());
+        }
+        S3AsyncClient client = builder.build();
+
+        String bucket = System.getProperty("S3_TARGET_BUCKET_NAME", "trebuchet-testing");
+        S3UploadConfig config = new S3UploadConfig(bucket, client, target.getParent());
+
+        S3Uploader uploader = new S3Uploader(config, report, progress);
+        Crawler crawler = new DirectoryStreamCrawler(report, progress);
+
+        setStatus(MigrationStatus.UPLOAD_IN_PROGRESS);
+        try {
+            crawler.crawlDirectory(target, uploadQueue);
+        } catch (IOException e) {
+
+        }
+        uploader.upload(uploadQueue, new AtomicBoolean(true));
+        setStatus(MigrationStatus.UPLOAD_COMPLETE);
+
         setStatus(MigrationStatus.FINISHED);
+
+        return report;
     }
 
     private void setStatus(MigrationStatus status) {

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -1,0 +1,75 @@
+package com.atlassian.migration.datacenter.core.aws.db;
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
+import com.atlassian.migration.datacenter.core.aws.region.RegionService;
+import com.atlassian.migration.datacenter.core.db.DatabaseExtractor;
+import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
+import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Copyright Atlassian: 10/03/2020
+ */
+@Component
+public class DatabaseMigrationService
+{
+    private final ApplicationConfiguration applicationConfiguration;
+    private final AwsCredentialsProvider awsCredentialsProvider;
+    private final RegionService regionService;
+    private final Path tempDirectory;
+
+    private ExecutorService dbMigrationThread;
+    private Process extractorProcess;
+    private AtomicReference<MigrationStatus> status = new AtomicReference();
+
+    public DatabaseMigrationService(ApplicationConfiguration applicationConfiguration,
+                                    AwsCredentialsProvider awsCredentialsProvider,
+                                    RegionService regionService,
+                                    Path tempDirectory)
+    {
+        this.applicationConfiguration = applicationConfiguration;
+        this.awsCredentialsProvider = awsCredentialsProvider;
+        this.regionService = regionService;
+        this.tempDirectory = tempDirectory;
+    }
+
+    public File startMigration() throws DatabaseMigrationFailure
+    {
+        dbMigrationThread = Executors.newSingleThreadExecutor();
+        DatabaseExtractor extractor = DatabaseExtractorFactory.getExtractor(applicationConfiguration);
+        File target;
+        try {
+            target = Files.createTempFile(tempDirectory, "dbdump", ".sql.gz").toFile();
+        } catch (IOException e) {
+            throw new DatabaseMigrationFailure("Failed to create temporary database file under: "+tempDirectory);
+        }
+
+        extractorProcess = extractor.startDatabaseDump(target);
+
+        status.set(MigrationStatus.STARTED);
+
+        dbMigrationThread.submit(() -> {
+            try {
+                extractorProcess.waitFor();
+            } catch (Exception e) {
+                status.set(MigrationStatus.error("Error while waiting for DB extractor to finish", e));
+            }
+            status.set(MigrationStatus.FINISHED);
+        });
+
+        return target;
+    }
+
+    public MigrationStatus getStatus() {
+        return status.get();
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/MigrationStatus.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/MigrationStatus.java
@@ -1,0 +1,44 @@
+package com.atlassian.migration.datacenter.core.aws.db;
+
+import java.util.Optional;
+
+/**
+ * Copyright Atlassian: 11/03/2020
+ */
+public class MigrationStatus
+{
+    public enum State {
+        NOT_STARTED,
+        STARTED,
+        IN_PROGRESS,
+        ERROR,
+        FINISHED;
+    }
+
+    private final State state;
+    private final Optional<Throwable> exception;
+    private final String message;
+
+    MigrationStatus(State state, String message)
+    {
+        this.state = state;
+        this.message = message;
+        this.exception = Optional.empty();
+    }
+
+    MigrationStatus(State state, String message, Throwable exception)
+    {
+        this.state = state;
+        this.exception = Optional.of(exception);
+        this.message = message;
+    }
+
+    public static final MigrationStatus NOT_STARTED = new MigrationStatus(State.NOT_STARTED, "Not started");
+    public static final MigrationStatus STARTED = new MigrationStatus(State.STARTED, "Started");
+    public static final MigrationStatus IN_PROGRESS = new MigrationStatus(State.IN_PROGRESS, "In Progress");
+    public static final MigrationStatus FINISHED = new MigrationStatus(State.FINISHED, "Started");
+
+    public static MigrationStatus error(String message, Throwable exception) {
+        return new MigrationStatus(State.ERROR, message, exception);
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/MigrationStatus.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/MigrationStatus.java
@@ -9,8 +9,10 @@ public class MigrationStatus
 {
     public enum State {
         NOT_STARTED,
-        STARTED,
-        IN_PROGRESS,
+        DUMP_IN_PROGRESS,
+        DUMP_COMPLETE,
+        UPLOAD_IN_PROGRESS,
+        UPLOAD_COMPLETE,
         ERROR,
         FINISHED;
     }
@@ -34,9 +36,11 @@ public class MigrationStatus
     }
 
     public static final MigrationStatus NOT_STARTED = new MigrationStatus(State.NOT_STARTED, "Not started");
-    public static final MigrationStatus STARTED = new MigrationStatus(State.STARTED, "Started");
-    public static final MigrationStatus IN_PROGRESS = new MigrationStatus(State.IN_PROGRESS, "In Progress");
-    public static final MigrationStatus FINISHED = new MigrationStatus(State.FINISHED, "Started");
+    public static final MigrationStatus DUMP_IN_PROGRESS = new MigrationStatus(State.DUMP_IN_PROGRESS, "Database dump in progress.");
+    public static final MigrationStatus DUMP_COMPLETE = new MigrationStatus(State.DUMP_COMPLETE, "Database dump complete.");
+    public static final MigrationStatus UPLOAD_IN_PROGRESS = new MigrationStatus(State.UPLOAD_IN_PROGRESS, "Database upload in progress.");
+    public static final MigrationStatus UPLOAD_COMPLETE = new MigrationStatus(State.UPLOAD_COMPLETE, "Database upload complete.");
+    public static final MigrationStatus FINISHED = new MigrationStatus(State.FINISHED, "Finished");
 
     public static MigrationStatus error(String message, Throwable exception) {
         return new MigrationStatus(State.ERROR, message, exception);

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractor.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractor.java
@@ -9,7 +9,8 @@ import java.io.File;
  */
 public interface DatabaseExtractor
 {
-    Process startDatabaseDump(File to) throws DatabaseMigrationFailure;
+    Process startDatabaseDump(File target) throws DatabaseMigrationFailure;
+    Process startDatabaseDump(File target, Boolean parallel) throws DatabaseMigrationFailure;
 
     void dumpDatabase(File to) throws DatabaseMigrationFailure;
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractor.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractor.java
@@ -1,4 +1,4 @@
-package com.atlassian.migration.datacenter.core.aws.db;
+package com.atlassian.migration.datacenter.core.db;
 
 import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
 
@@ -7,7 +7,7 @@ import java.io.File;
 /**
  * Copyright Atlassian: 10/03/2020
  */
-public interface DatabaseMigration
+public interface DatabaseExtractor
 {
     Process startDatabaseDump(File to) throws DatabaseMigrationFailure;
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractor.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractor.java
@@ -3,14 +3,15 @@ package com.atlassian.migration.datacenter.core.db;
 import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
 
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Copyright Atlassian: 10/03/2020
  */
 public interface DatabaseExtractor
 {
-    Process startDatabaseDump(File target) throws DatabaseMigrationFailure;
-    Process startDatabaseDump(File target, Boolean parallel) throws DatabaseMigrationFailure;
+    Process startDatabaseDump(Path target) throws DatabaseMigrationFailure;
+    Process startDatabaseDump(Path target, Boolean parallel) throws DatabaseMigrationFailure;
 
-    void dumpDatabase(File to) throws DatabaseMigrationFailure;
+    void dumpDatabase(Path to) throws DatabaseMigrationFailure;
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractorFactory.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/DatabaseExtractorFactory.java
@@ -1,0 +1,22 @@
+package com.atlassian.migration.datacenter.core.db;
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
+import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration.DBType;
+import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
+import org.springframework.stereotype.Component;
+
+/**
+ * Copyright Atlassian: 10/03/2020
+ */
+@Component
+public class DatabaseExtractorFactory
+{
+    public static DatabaseExtractor getExtractor(ApplicationConfiguration config) throws DatabaseMigrationFailure
+    {
+        if (config.getDatabaseConfiguration().getType().equals(DBType.POSTGRESQL)) {
+            return new PostgresExtractor(config);
+        } else {
+            throw new DatabaseMigrationFailure("Unsupported database type: " + config.getDatabaseConfiguration().getType());
+        }
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/PostgresExtractor.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/PostgresExtractor.java
@@ -42,15 +42,15 @@ public class PostgresExtractor implements DatabaseExtractor
      *
      * <ul>
      * <li>It is the responsibility of the caller to ensure that the filesystems the target resides on has sufficient space.</li>
-     * <li>stderr is redirected to the stderr of the calling process.</li>
+     * <li>stdio & stderr are redirected to the stderr of the calling process.</li>
      * </ul>
      *
-     * @param to - The file to dump the compressed database export to.
+     * @param target - The directory to dump the compressed database export to.
      * @return The underlying process object.
      * @throws DatabaseMigrationFailure on failure.
      */
     @Override
-    public Process startDatabaseDump(File to) throws DatabaseMigrationFailure
+    public Process startDatabaseDump(File target) throws DatabaseMigrationFailure
     {
         String pgdump = getPgdumpPath()
             .orElseThrow(() -> new DatabaseMigrationFailure("Failed to find appropriate pg_dump executable."));
@@ -61,12 +61,13 @@ public class PostgresExtractor implements DatabaseExtractor
                                                     "--no-owner",
                                                     "--no-acl",
                                                     "--compress=9",
+                                                    "--format=directory",
+                                                    "--file", target.toString(),
                                                     "--dbname", config.getName(),
                                                     "--host", config.getHost(),
                                                     "--port", config.getPort().toString(),
                                                     "--username", config.getUsername())
-            .inheritIO()
-            .redirectOutput(Redirect.to(to));
+            .inheritIO();
         builder.environment().put("PGPASSWORD", config.getPassword());
 
         try {

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/PostgresExtractor.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/PostgresExtractor.java
@@ -1,4 +1,4 @@
-package com.atlassian.migration.datacenter.core.aws.db;
+package com.atlassian.migration.datacenter.core.db;
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
@@ -15,13 +15,13 @@ import java.util.Optional;
 /**
  * Copyright Atlassian: 03/03/2020
  */
-public class PostgresMigration implements DatabaseMigration
+public class PostgresExtractor implements DatabaseExtractor
 {
     private ApplicationConfiguration applicationConfiguration;
 
     private static String pddumpPaths[] = {"/usr/bin/pg_dump", "/usr/local/bin/pg_dump"};
 
-    public PostgresMigration(ApplicationConfiguration applicationConfiguration)
+    public PostgresExtractor(ApplicationConfiguration applicationConfiguration)
     {
         this.applicationConfiguration = applicationConfiguration;
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/db/PostgresExtractor.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/db/PostgresExtractor.java
@@ -4,9 +4,7 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
 import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
 
-import java.io.File;
 import java.io.IOException;
-import java.lang.ProcessBuilder.Redirect;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -38,7 +36,7 @@ public class PostgresExtractor implements DatabaseExtractor
     }
 
     @Override
-    public Process startDatabaseDump(File target) throws DatabaseMigrationFailure
+    public Process startDatabaseDump(Path target) throws DatabaseMigrationFailure
     {
         return startDatabaseDump(target, false);
     }
@@ -57,7 +55,7 @@ public class PostgresExtractor implements DatabaseExtractor
      * @throws DatabaseMigrationFailure on failure.
      */
     @Override
-    public Process startDatabaseDump(File target, Boolean parallel) throws DatabaseMigrationFailure
+    public Process startDatabaseDump(Path target, Boolean parallel) throws DatabaseMigrationFailure
     {
         String pgdump = getPgdumpPath()
             .orElseThrow(() -> new DatabaseMigrationFailure("Failed to find appropriate pg_dump executable."));
@@ -96,7 +94,7 @@ public class PostgresExtractor implements DatabaseExtractor
      * @throws DatabaseMigrationFailure on failure, including a non-zero exit code.
      */
     @Override
-    public void dumpDatabase(File to) throws DatabaseMigrationFailure
+    public void dumpDatabase(Path to) throws DatabaseMigrationFailure
     {
         Process proc = startDatabaseDump(to);
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/application/JiraConfigurationTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/application/JiraConfigurationTest.java
@@ -83,6 +83,7 @@ class JiraConfigurationTest
         assertEquals("dbhost", config.getHost());
         assertEquals("dbname", config.getName());
         assertEquals(9876, config.getPort());
+        assertEquals(DatabaseConfiguration.DBType.POSTGRESQL, config.getType());
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -25,14 +23,12 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
-import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -1,0 +1,110 @@
+package com.atlassian.migration.datacenter.core.aws.db;
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
+import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
+import com.atlassian.migration.datacenter.core.aws.region.InvalidAWSRegionException;
+import com.atlassian.migration.datacenter.core.aws.region.RegionService;
+import com.atlassian.migration.datacenter.util.AwsCredentialsProviderShim;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.when;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+/**
+ * Copyright Atlassian: 12/03/2020
+ */
+@Testcontainers
+@ExtendWith(MockitoExtension.class)
+class DatabaseMigrationServiceIT
+{
+    @Container
+    public static PostgreSQLContainer postgres = (PostgreSQLContainer) new PostgreSQLContainer("postgres:9.6")
+        .withDatabaseName("jira")
+        .withCopyFileToContainer(MountableFile.forClasspathResource("db/jira.sql"), "/docker-entrypoint-initdb.d/jira.sql");
+
+    @Container
+    public LocalStackContainer s3 = new LocalStackContainer()
+        .withServices(S3)
+        .withEnv("DEFAULT_REGION", regionService.getRegion());
+
+    private static RegionService regionService = new RegionService() {
+        public String getRegion() { return "us-east-1"; }
+        public void storeRegion(String string) throws InvalidAWSRegionException { throw new UnsupportedOperationException(); }
+    };
+
+    private AwsCredentialsProvider credentialsProvider = new AwsCredentialsProviderShim(s3.getDefaultCredentialsProvider());
+    private S3Client s3client;
+    private String bucket = "trebuchet-testing";
+
+    @Mock(lenient = true)
+    ApplicationConfiguration configuration;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws URISyntaxException
+    {
+        when(configuration.getDatabaseConfiguration())
+            .thenReturn(new DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
+                                                  postgres.getContainerIpAddress(),
+                                                  postgres.getMappedPort(5432),
+                                                  postgres.getDatabaseName(),
+                                                  postgres.getUsername(),
+                                                  postgres.getPassword()));
+
+        s3client = S3Client.builder()
+            .endpointOverride(new URI(s3.getEndpointConfiguration(S3).getServiceEndpoint()))
+            .credentialsProvider(credentialsProvider)
+            .region(Region.of(regionService.getRegion()))
+            .build();
+        CreateBucketRequest req = CreateBucketRequest.builder()
+            .bucket(bucket)
+            .build();
+        CreateBucketResponse resp = s3client.createBucket(req);
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+    }
+
+
+    @Test
+    void testDatabaseMigration()
+    {
+        DatabaseMigrationService service = new DatabaseMigrationService(configuration, credentialsProvider, regionService, tempDir,
+                                                                        URI.create(s3.getEndpointConfiguration(S3).getServiceEndpoint()));
+        service.performMigration();
+
+        HeadObjectRequest req = HeadObjectRequest.builder()
+            .bucket(bucket)
+            .key("db.dump/toc.dat")
+            .build();
+        HeadObjectResponse resp = s3client.headObject(req);
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+    }
+
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/db/PostgresMigrationIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/db/PostgresMigrationIT.java
@@ -54,7 +54,8 @@ class PostgresMigrationIT
     void setUp()
     {
         when(configuration.getDatabaseConfiguration())
-            .thenReturn(new DatabaseConfiguration(postgres.getContainerIpAddress(),
+            .thenReturn(new DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
+                                                  postgres.getContainerIpAddress(),
                                                   postgres.getMappedPort(5432),
                                                   postgres.getDatabaseName(),
                                                   postgres.getUsername(),

--- a/src/test/java/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
  */
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
-class PostgresMigrationIT
+class PostgresExtractorIT
 {
     @Container
     public static PostgreSQLContainer postgres = (PostgreSQLContainer) new PostgreSQLContainer("postgres:9.6")

--- a/src/test/java/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.java
@@ -1,4 +1,4 @@
-package com.atlassian.migration.datacenter.core.aws.db;
+package com.atlassian.migration.datacenter.core.db;
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
@@ -25,7 +25,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -89,7 +88,7 @@ class PostgresMigrationIT
     @Test
     void testDatabaseDump() throws InterruptedException, IOException
     {
-        PostgresMigration migration = new PostgresMigration(configuration);
+        PostgresExtractor migration = new PostgresExtractor(configuration);
         Path dumpFile = tempDir.resolve("dump.sql.gz");
 
         migration.dumpDatabase(dumpFile.toFile());

--- a/src/test/java/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.java
@@ -88,12 +88,12 @@ class PostgresExtractorIT
     }
 
     @Test
-    void testDatabaseDump() throws InterruptedException, IOException
+    void testDatabaseDump() throws IOException
     {
         PostgresExtractor migration = new PostgresExtractor(configuration);
         Path target = tempDir.resolve("database.dump");
 
-        migration.dumpDatabase(target.toFile());
+        migration.dumpDatabase(target);
         assertTrue(target.toFile().exists());
         assertTrue(target.toFile().isDirectory());
 

--- a/src/test/java/com/atlassian/migration/datacenter/util/AwsCredentialsProviderShim.java
+++ b/src/test/java/com/atlassian/migration/datacenter/util/AwsCredentialsProviderShim.java
@@ -1,0 +1,36 @@
+package com.atlassian.migration.datacenter.util;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+/**
+ * Copyright Atlassian: 12/03/2020
+ */
+public class AwsCredentialsProviderShim implements AwsCredentialsProvider, AwsCredentials
+{
+    private final AWSCredentialsProvider v1Creds;
+
+    public AwsCredentialsProviderShim(AWSCredentialsProvider v1Creds)
+    {
+        this.v1Creds = v1Creds;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials()
+    {
+        return this;
+    }
+
+    @Override
+    public String accessKeyId()
+    {
+        return v1Creds.getCredentials().getAWSAccessKeyId();
+    }
+
+    @Override
+    public String secretAccessKey()
+    {
+        return v1Creds.getCredentials().getAWSSecretKey();
+    }
+}


### PR DESCRIPTION
This add the DatabaseMigrationService and testing. As discussed IRL, this is slightly messy as the S3Uploader, etc. has slightly FS-migration-specific; the next step is to refactor-out the common areas into common components, but this is better as a 2-step process.