### PR TITLE
CHET-173: Refactor S3FilesystemMigrationService to be more testable, and expand integration tests

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -30,28 +30,21 @@ import java.util.concurrent.atomic.AtomicReference;
 public class DatabaseMigrationService
 {
     private final ApplicationConfiguration applicationConfiguration;
-    private final Optional<URI> endpointOverride;
     private final Path tempDirectory;
     private final S3AsyncClient s3AsyncClient;
 
     private Process extractorProcess;
     private AtomicReference<MigrationStatus> status = new AtomicReference();
 
+
     //TODO: Move tempdirectory away from the constructor and pass that into the method instead
     public DatabaseMigrationService(ApplicationConfiguration applicationConfiguration,
-                                    Path tempDirectory, S3AsyncClient client)
+                                    Path tempDirectory,
+                                    S3AsyncClient s3AsyncClient)
     {
-        this(applicationConfiguration, tempDirectory, client, null);
-    }
-
-    DatabaseMigrationService(ApplicationConfiguration applicationConfiguration,
-                             Path tempDirectory,
-                             S3AsyncClient s3AsyncClient,
-                             URI endpointOverride) {
         this.applicationConfiguration = applicationConfiguration;
         this.tempDirectory = tempDirectory;
         this.s3AsyncClient = s3AsyncClient;
-        this.endpointOverride = Optional.ofNullable(endpointOverride);
         this.setStatus(MigrationStatus.NOT_STARTED);
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -60,7 +60,9 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
     //TODO: Region Service and provider will be replaced by the S3 Client
     public S3FilesystemMigrationService(S3AsyncClient s3AsyncClient,
                                         JiraHome jiraHome,
-                                        MigrationService migrationService, SchedulerService schedulerService) {
+                                        MigrationService migrationService,
+                                        SchedulerService schedulerService)
+    {
         this.s3AsyncClient = s3AsyncClient;
         this.jiraHome = jiraHome;
         this.migrationService = migrationService;

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -47,8 +47,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
     private static final int NUM_UPLOAD_THREADS = Integer.getInteger("NUM_UPLOAD_THREADS", 1);
     private static final String BUCKET_NAME = System.getProperty("S3_TARGET_BUCKET_NAME", "trebuchet-testing");
 
-    private final AwsCredentialsProvider credentialsProvider;
-    private final RegionService regionService;
+    private final S3AsyncClient s3AsyncClient;
     private final JiraHome jiraHome;
     private final MigrationService migrationService;
     private final SchedulerService schedulerService;
@@ -59,12 +58,10 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
     private S3UploadConfig s3UploadConfig;
 
     //TODO: Region Service and provider will be replaced by the S3 Client
-    public S3FilesystemMigrationService(RegionService regionService,
-                                        AwsCredentialsProvider credentialsProvider,
+    public S3FilesystemMigrationService(S3AsyncClient s3AsyncClient,
                                         JiraHome jiraHome,
                                         MigrationService migrationService, SchedulerService schedulerService) {
-        this.regionService = regionService;
-        this.credentialsProvider = credentialsProvider;
+        this.s3AsyncClient = s3AsyncClient;
         this.jiraHome = jiraHome;
         this.migrationService = migrationService;
         this.schedulerService = schedulerService;
@@ -143,15 +140,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
 
         report.setStatus(RUNNING);
 
-        S3AsyncClient s3AsyncClient = buildS3Client();
         s3UploadConfig = new S3UploadConfig(getS3Bucket(), s3AsyncClient, getSharedHomeDir());
-    }
-
-    private S3AsyncClient buildS3Client() {
-        return S3AsyncClient.builder()
-                .credentialsProvider(credentialsProvider)
-                .region(Region.of(regionService.getRegion()))
-                .build();
     }
 
     private CompletionService<Void> startUploadingFromQueue() {

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -4,6 +4,7 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
 import com.atlassian.migration.datacenter.util.AwsCredentialsProviderShim;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,6 +33,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * Copyright Atlassian: 12/03/2020
  */
+@Tag("integration")
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
 class DatabaseMigrationServiceIT
@@ -81,8 +83,7 @@ class DatabaseMigrationServiceIT
 
     @Test
     void testDatabaseMigration() throws ExecutionException, InterruptedException {
-        URI localStackS3Endpoint = URI.create(s3.getEndpointConfiguration(S3).getServiceEndpoint());
-        DatabaseMigrationService service = new DatabaseMigrationService(configuration, tempDir,s3client, localStackS3Endpoint);
+        DatabaseMigrationService service = new DatabaseMigrationService(configuration, tempDir, s3client);
         service.performMigration();
 
         HeadObjectRequest req = HeadObjectRequest.builder()

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceIT.java
@@ -1,7 +1,5 @@
 package com.atlassian.migration.datacenter.core.fs;
 
-import cloud.localstack.docker.LocalstackDockerExtension;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.atlassian.jira.config.util.JiraHome;
 import com.atlassian.migration.datacenter.core.aws.auth.AtlassianPluginAWSCredentialsProvider;
 import com.atlassian.migration.datacenter.core.aws.region.RegionService;
@@ -10,6 +8,7 @@ import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus;
+import com.atlassian.migration.datacenter.util.AwsCredentialsProviderShim;
 import com.atlassian.scheduler.SchedulerService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,54 +18,90 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.*;
 
+import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 @Tag("integration")
-@ExtendWith({LocalstackDockerExtension.class, MockitoExtension.class})
-@LocalstackDockerProperties(services = {"s3"})
+@Testcontainers
+@ExtendWith({MockitoExtension.class})
 class S3FilesystemMigrationServiceIT {
-    @TempDir
-    Path dir;
-    @Mock
-    RegionService regionService;
+    @TempDir Path dir;
+    @Mock RegionService regionService;
+    @Mock MigrationService migrationService;
+    @Mock JiraHome jiraHome;
+    @Mock SchedulerService schedulerService;
 
-    @Mock
+    private S3AsyncClient s3AsyncClient;
+    private String bucket = "trebuchet-testing";
+
+    @Container
+    public LocalStackContainer s3 = new LocalStackContainer()
+        .withServices(S3)
+        .withEnv("DEFAULT_REGION", Region.US_EAST_1.toString());
+
     AtlassianPluginAWSCredentialsProvider credentialsProvider;
-
-    @Mock
-    MigrationService migrationService;
-
-    @Mock
-    JiraHome jiraHome;
-
-    @Mock
-    private SchedulerService schedulerService;
 
     @BeforeEach
     void setup() throws Exception {
+        credentialsProvider = new AtlassianPluginAWSCredentialsProvider(new AwsCredentialsProviderShim(s3.getDefaultCredentialsProvider()));
+
+        s3AsyncClient = S3AsyncClient.builder()
+            .endpointOverride(new URI(s3.getEndpointConfiguration(S3).getServiceEndpoint()))
+            .credentialsProvider(new AwsCredentialsProviderShim(s3.getDefaultCredentialsProvider()))
+            .region(Region.US_EAST_1)
+            .build();
+        CreateBucketRequest req = CreateBucketRequest.builder()
+            .bucket(bucket)
+            .build();
+        CreateBucketResponse resp = s3AsyncClient.createBucket(req).get();
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+    }
+
+    private Path genRandFile() throws IOException
+    {
         Path file = dir.resolve(UUID.randomUUID().toString());
         String rand = String.format("Testing string %s", Instant.now());
         Files.write(file, Collections.singleton(rand));
+        return file;
     }
 
     @Test
-    void testSuccessfulDirectoryMigration(@TempDir Path dir) throws InvalidMigrationStageError {
-        when(regionService.getRegion()).thenReturn(Region.US_EAST_1.toString());
+    void testSuccessfulDirectoryMigration(@TempDir Path dir) throws Exception
+    {
         when(jiraHome.getHome()).thenReturn(dir.toFile());
         when(migrationService.getCurrentStage()).thenReturn(MigrationStage.FS_MIGRATION_COPY);
 
-        FilesystemMigrationService fsService = new S3FilesystemMigrationService(regionService, credentialsProvider, jiraHome, migrationService, schedulerService);
+        Path file = genRandFile();
+
+        FilesystemMigrationService fsService = new S3FilesystemMigrationService(s3AsyncClient, jiraHome, migrationService, schedulerService);
 
         fsService.startMigration();
 
         Assertions.assertNotEquals(FilesystemMigrationStatus.FAILED, fsService.getReport().getStatus());
+
+        HeadObjectRequest req = HeadObjectRequest.builder()
+            .bucket(bucket)
+            .key(file.getFileName().toString())
+            .build();
+        HeadObjectResponse resp = s3AsyncClient.headObject(req).get();
+        assertTrue(resp.sdkHttpResponse().isSuccessful());
+
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,18 +36,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class S3FilesystemMigrationServiceTest {
-    @Mock
-    RegionService regionService;
-
-    @Mock
-    AtlassianPluginAWSCredentialsProvider credentialsProvider;
 
     @Mock
     JiraHome jiraHome;
 
     @Mock
     MigrationService migrationService;
-
 
     @Mock
     SchedulerService schedulerService;
@@ -59,7 +54,6 @@ class S3FilesystemMigrationServiceTest {
         Path nonexistentDir = Paths.get(UUID.randomUUID().toString());
         when(this.migrationService.getCurrentStage()).thenReturn(MigrationStage.FS_MIGRATION_COPY);
         when(jiraHome.getHome()).thenReturn(nonexistentDir.toFile());
-        when(regionService.getRegion()).thenReturn(Region.US_EAST_1.toString());
 
         fsService.startMigration();
 

--- a/src/test/java/com/atlassian/migration/datacenter/util/AwsCredentialsProviderShim.java
+++ b/src/test/java/com/atlassian/migration/datacenter/util/AwsCredentialsProviderShim.java
@@ -1,13 +1,14 @@
 package com.atlassian.migration.datacenter.util;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.atlassian.migration.datacenter.core.aws.auth.ReadCredentialsService;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Copyright Atlassian: 12/03/2020
  */
-public class AwsCredentialsProviderShim implements AwsCredentialsProvider, AwsCredentials
+public class AwsCredentialsProviderShim implements AwsCredentialsProvider, AwsCredentials, ReadCredentialsService
 {
     private final AWSCredentialsProvider v1Creds;
 
@@ -30,6 +31,18 @@ public class AwsCredentialsProviderShim implements AwsCredentialsProvider, AwsCr
 
     @Override
     public String secretAccessKey()
+    {
+        return v1Creds.getCredentials().getAWSSecretKey();
+    }
+
+    @Override
+    public String getAccessKeyId()
+    {
+        return v1Creds.getCredentials().getAWSAccessKeyId();
+    }
+
+    @Override
+    public String getSecretAccessKey()
     {
         return v1Creds.getCredentials().getAWSSecretKey();
     }


### PR DESCRIPTION
This is separate from the service refactoring; this one ensures that we have a working baseline for the S3FilesystemMigrationService tests.