### PR TITLE
CHET-142: Dev endpoint to set stage

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.java
@@ -1,0 +1,60 @@
+package com.atlassian.migration.datacenter.api.develop;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/develop")
+public class DevelopEndpoint {
+    private MigrationService migrationService;
+
+    public DevelopEndpoint(MigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    @PUT
+    @Path("/migration/stage")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response setMigrationStage(Stage stage) {
+        try {
+            final MigrationStage targetStage = MigrationStage.valueOf(stage.getStage());
+            final MigrationStage currentStage = migrationService.getCurrentStage();
+            migrationService.transition(currentStage, targetStage);
+            return Response
+                    .ok(ImmutableMap.of("stage", migrationService.getCurrentStage()))
+                    .build();
+        } catch (InvalidMigrationStageError | IllegalArgumentException e) {
+            return Response
+                    .status(Response.Status.CONFLICT)
+                    .entity(ImmutableMap.of("error", String.format("Unable to transition migration to %s", stage.getStage())))
+                    .build();
+        }
+    }
+
+    @JsonAutoDetect
+    static class Stage {
+        private String stage;
+
+        public Stage(String stage) {
+            this.stage = stage;
+        }
+
+        public String getStage() {
+            return stage;
+        }
+
+        public void setStage(String stage) {
+            this.stage = stage;
+        }
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.java
@@ -1,10 +1,10 @@
 package com.atlassian.migration.datacenter.api.develop;
 
-import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/develop")
 public class DevelopEndpoint {
+    private static final Logger logger = LoggerFactory.getLogger(DevelopEndpoint.class);
     private MigrationService migrationService;
 
     public DevelopEndpoint(MigrationService migrationService) {
@@ -25,38 +26,19 @@ public class DevelopEndpoint {
     @Path("/migration/stage")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response setMigrationStage(Stage stage) {
+    public Response setMigrationStage(MigrationStage targetStage) {
         try {
-            final MigrationStage targetStage = MigrationStage.valueOf(stage.getStage());
             final MigrationStage currentStage = migrationService.getCurrentStage();
             migrationService.transition(currentStage, targetStage);
             return Response
-                    .ok(ImmutableMap.of("stage", migrationService.getCurrentStage()))
+                    .ok(ImmutableMap.of("targetStage", migrationService.getCurrentStage().toString()))
                     .build();
-        } catch (InvalidMigrationStageError | IllegalArgumentException e) {
+        } catch (Exception e) {
+            logger.warn("Cannot parse the migration stage", e);
             return Response
                     .status(Response.Status.CONFLICT)
-                    .entity(ImmutableMap.of("error", String.format("Unable to transition migration to %s", stage.getStage())))
+                    .entity(ImmutableMap.of("error", String.format("Unable to transition migration to %s", targetStage)))
                     .build();
-        }
-    }
-
-    @JsonAutoDetect
-    static class Stage {
-        private String stage;
-
-        public Stage() {}
-        
-        public Stage(String stage) {
-            this.stage = stage;
-        }
-
-        public String getStage() {
-            return stage;
-        }
-
-        public void setStage(String stage) {
-            this.stage = stage;
         }
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.java
@@ -45,6 +45,8 @@ public class DevelopEndpoint {
     static class Stage {
         private String stage;
 
+        public Stage() {}
+        
         public Stage(String stage) {
             this.stage = stage;
         }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -1,5 +1,7 @@
 package com.atlassian.migration.datacenter.spi;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Represents all possible states of an on-premise to cloud migration.
  */
@@ -16,6 +18,7 @@ public enum MigrationStage {
     AUTHENTICATION("authentication"),
     NOT_STARTED("");
 
+    @JsonProperty
     private String key;
 
     MigrationStage(String key) {

--- a/src/test/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpointTest.java
@@ -2,6 +2,7 @@ package com.atlassian.migration.datacenter.api.develop;
 
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,11 +28,13 @@ class DevelopEndpointTest {
     void shouldSetStageWithCorrectTargetStage() throws Exception {
         final MigrationStage initialStage = MigrationStage.AUTHENTICATION;
         when(migrationService.getCurrentStage()).thenReturn(initialStage);
-        String param = "FS_MIGRATION_COPY";
 
-        endpoint.setMigrationStage(new DevelopEndpoint.Stage(param));
 
-        MigrationStage expectedStage = MigrationStage.valueOf(param);
-        verify(migrationService).transition(initialStage, expectedStage);
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final MigrationStage migrationStage = objectMapper.readValue("\"FS_MIGRATION_COPY\"", MigrationStage.class);
+
+        endpoint.setMigrationStage(migrationStage);
+
+        verify(migrationService).transition(initialStage, MigrationStage.FS_MIGRATION_COPY);
     }
 }

--- a/src/test/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/develop/DevelopEndpointTest.java
@@ -1,0 +1,37 @@
+package com.atlassian.migration.datacenter.api.develop;
+
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DevelopEndpointTest {
+    @Mock
+    MigrationService migrationService;
+
+    DevelopEndpoint endpoint;
+
+    @BeforeEach
+    void setup() {
+        endpoint = new DevelopEndpoint(migrationService);
+    }
+
+    @Test
+    void shouldSetStageWithCorrectTargetStage() throws Exception {
+        final MigrationStage initialStage = MigrationStage.AUTHENTICATION;
+        when(migrationService.getCurrentStage()).thenReturn(initialStage);
+        String param = "FS_MIGRATION_COPY";
+
+        endpoint.setMigrationStage(new DevelopEndpoint.Stage(param));
+
+        MigrationStage expectedStage = MigrationStage.valueOf(param);
+        verify(migrationService).transition(initialStage, expectedStage);
+    }
+}


### PR DESCRIPTION
The JSON payload is for example `"FS_MIGRATION_COPY"`.

Jackson is very picky with enums. Other option is to use `@PathParam` but I will push this forward and it is also availble from Postman.