### PR TITLE
CHET-187: fs migration ssm download cleanup

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
@@ -41,7 +41,7 @@ public class DatabaseArtifactS3UploadService {
         this.s3AsyncClient = this.s3AsyncClientSupplier.get();
     }
 
-    public FileSystemMigrationReport upload(Path target, String targetBucketName, DatabaseUploadStageTransitionCallback callback) throws InvalidMigrationStageError {
+    public FileSystemMigrationReport upload(Path target, String targetBucketName, DatabaseUploadStageTransitionCallback callback) throws InvalidMigrationStageError, FilesystemUploader.FileUploadException {
         callback.transitionToServiceStartStage();
         FilesystemUploader filesystemUploader = buildFileSystemUploader(target, targetBucketName, fileSystemMigrationReport, s3AsyncClient);
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.core.aws.db;
 
 import com.atlassian.migration.datacenter.core.exceptions.DatabaseMigrationFailure;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.core.fs.FilesystemUploader;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 
 import java.nio.file.Path;
@@ -51,7 +52,11 @@ public class DatabaseMigrationService
      */
     public FileSystemMigrationErrorReport performMigration() throws DatabaseMigrationFailure, InvalidMigrationStageError {
         Path pathToDatabaseFile = databaseArchivalService.archiveDatabase(tempDirectory, stageTransitionCallback);
-        return s3UploadService.upload(pathToDatabaseFile, TARGET_BUCKET_NAME, this.uploadStageTransitionCallback);
+        try {
+            return s3UploadService.upload(pathToDatabaseFile, TARGET_BUCKET_NAME, this.uploadStageTransitionCallback);
+        } catch (FilesystemUploader.FileUploadException e) {
+            throw new DatabaseMigrationFailure("Error when uploading database dump to S3", e);
+        }
     }
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
@@ -55,7 +55,11 @@ public abstract class SuccessfulSSMCommandConsumer<T> {
                 throw new UnsuccessfulSSMCommandInvocationException("Interrupted while waiting to check command status", e);
             }
         }
-        throw new UnsuccessfulSSMCommandInvocationException("Command never completed successfully. Latest status is: " + command.status().toString());
+        throw new UnsuccessfulSSMCommandInvocationException(
+                String.format(
+                        "Command never completed successfully. Latest status is: %s. Latest response from SSM API is: %s",
+                        command.status().toString(),
+                        command.sdkHttpResponse().statusText()));
     }
 
     protected abstract T handleSuccessfulCommand(GetCommandInvocationResponse commandInvocation) throws SSMCommandInvocationProcessingError;

--- a/src/main/java/com/atlassian/migration/datacenter/core/exceptions/FileSystemMigrationFailure.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/exceptions/FileSystemMigrationFailure.java
@@ -16,15 +16,12 @@
 
 package com.atlassian.migration.datacenter.core.exceptions;
 
-public class FileUploadException extends RuntimeException
-{
-    public FileUploadException(String message)
-    {
+public class FileSystemMigrationFailure extends Exception {
+    public FileSystemMigrationFailure(String message) {
         super(message);
     }
 
-    public FileUploadException(String message, Throwable cause)
-    {
+    public FileSystemMigrationFailure(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -157,15 +157,14 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
             fileSystemDownloadManager.downloadFileSystem();
 
             report.setStatus(DONE);
+
+            logger.info("Completed file system migration. Transitioning to next stage.");
+            migrationService.transition(MigrationStage.OFFLINE_WARNING);
         } catch (FileSystemMigrationFailure e) {
             logger.error("Encountered critical error during file system migration");
             report.setStatus(FAILED);
             migrationService.error();
-            return;
         }
-
-        logger.info("Completed file system migration. Transitioning to next stage.");
-        migrationService.transition(MigrationStage.OFFLINE_WARNING);
     }
 
     private String getS3Bucket() {

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -151,7 +151,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
 
         FilesystemUploader fsUploader = new FilesystemUploader(homeCrawler, s3Uploader);
 
-        logger.trace("commencing upload of shared home");
+        logger.info("commencing upload of shared home");
         try {
             fsUploader.uploadDirectory(getSharedHomeDir());
         } catch (FileUploadException e) {
@@ -159,7 +159,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
         }
 
         if (!report.getStatus().equals(FAILED)) {
-            logger.trace("upload of shared home complete. commencing shared home download");
+            logger.info("upload of shared home complete. commencing shared home download");
             try {
                 fileSystemDownloadManager.downloadFileSystem();
                 report.setStatus(DONE);
@@ -170,8 +170,8 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
         }
 
         if (report.getStatus().equals(DONE)) {
-            logger.trace("Completed file system migration. Transitioning to next stage.");
-            this.migrationService.transition(MigrationStage.OFFLINE_WARNING);
+            logger.info("Completed file system migration. Transitioning to next stage.");
+            this.migrationService.transition(MigrationStage.WAIT_FS_MIGRATION_COPY, MigrationStage.OFFLINE_WARNING);
         } else if (report.getStatus().equals(FAILED)) {
             logger.error("Encountered error during file system migration. Transitioning to error state.");
             this.migrationService.error();

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -16,11 +16,8 @@
 
 package com.atlassian.migration.datacenter.core.fs;
 
-import com.atlassian.migration.datacenter.core.exceptions.FileUploadException;
 import com.atlassian.migration.datacenter.core.util.UploadQueue;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
-import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -57,7 +54,7 @@ public class S3Uploader implements Uploader {
     }
 
     @Override
-    public void upload(UploadQueue<Path> queue) throws FileUploadException
+    public void upload(UploadQueue<Path> queue) throws FilesystemUploader.FileUploadException
     {
         try {
             for (Optional<Path> opt = queue.take(); opt.isPresent(); opt = queue.take()) {
@@ -66,7 +63,7 @@ public class S3Uploader implements Uploader {
         } catch (InterruptedException e) {
             String msg = "InterruptedException while fetching file from queue";
             logger.error(msg, e);
-            throw new FileUploadException(msg,e);
+            throw new FilesystemUploader.FileUploadException(msg,e);
         }
         responsesQueue.forEach(this::handlePutObjectResponse);
         logger.info("Finished uploading files to S3");

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/Uploader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/Uploader.java
@@ -16,12 +16,11 @@
 
 package com.atlassian.migration.datacenter.core.fs;
 
-import com.atlassian.migration.datacenter.core.exceptions.FileUploadException;
 import com.atlassian.migration.datacenter.core.util.UploadQueue;
 
 import java.nio.file.Path;
 
 public interface Uploader {
-    void upload(UploadQueue<Path> queue) throws FileUploadException;
+    void upload(UploadQueue<Path> queue) throws FilesystemUploader.FileUploadException;
     Integer maxConcurrent();
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
@@ -41,17 +41,13 @@ public class S3SyncFileSystemDownloadManager {
 
 
         ScheduledFuture<?> scheduledFuture = Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-            try {
-                S3SyncCommandStatus status = downloader.getFileSystemDownloadStatus();
+            S3SyncCommandStatus status = downloader.getFileSystemDownloadStatus();
 
-                logger.debug("got status of file system download: " + status.toString());
+            logger.debug("got status of file system download: " + status.toString());
 
-                if (status.isComplete()) {
-                    logger.debug("file system download is complete");
-                    syncCompleteFuture.complete(null);
-                }
-            } catch (S3SyncFileSystemDownloader.IndeterminateS3SyncStatusException e) {
-                logger.error("error when retrieving s3 sync status", e);
+            if (status.isComplete()) {
+                logger.debug("file system download is complete");
+                syncCompleteFuture.complete(null);
             }
         }, 0 , 5, TimeUnit.MINUTES);
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloader.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloader.java
@@ -18,7 +18,7 @@ package com.atlassian.migration.datacenter.core.fs.download.s3sync;
 
 import com.atlassian.migration.datacenter.core.aws.ssm.SSMApi;
 import com.atlassian.migration.datacenter.core.aws.ssm.SuccessfulSSMCommandConsumer;
-import jdk.internal.jline.internal.Nullable;
+import com.atlassian.migration.datacenter.core.exceptions.FileSystemMigrationFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +68,6 @@ public class S3SyncFileSystemDownloader {
      *
      * @return the status of the S3 sync or null if the status was not able to be retrieved.
      */
-    @Nullable
     public S3SyncCommandStatus getFileSystemDownloadStatus() {
         String statusCommandId = ssmApi.runSSMDocument(STATUS_SSM_PLAYBOOK, MIGRATION_STACK_INSTANCE, Collections.emptyMap());
 
@@ -85,13 +84,17 @@ public class S3SyncFileSystemDownloader {
         }
     }
 
-    public static class IndeterminateS3SyncStatusException extends Exception {
+    public static class IndeterminateS3SyncStatusException extends FileSystemMigrationFailure {
         IndeterminateS3SyncStatusException(String message) {
             super(message);
         }
+
+        public IndeterminateS3SyncStatusException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 
-    public static class CannotLaunchCommandException extends Exception {
+    public static class CannotLaunchCommandException extends FileSystemMigrationFailure {
         CannotLaunchCommandException(String message) {
             super(message);
         }

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
@@ -95,7 +95,7 @@ class S3UploaderIT {
     }
 
     @Test
-    void uploadShouldUploadPathsFromQueueToS3() throws IOException, InterruptedException {
+    void uploadShouldUploadPathsFromQueueToS3() throws IOException, InterruptedException, FilesystemUploader.FileUploadException {
         final Path file = addFileToQueue("file");
         queue.finish();
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -82,7 +82,11 @@ class S3UploaderTest {
         addFileToQueue("file1");
 
         final Future<?> submit = Executors.newFixedThreadPool(1).submit(() -> {
-            uploader.upload(queue);
+            try {
+                uploader.upload(queue);
+            } catch (FilesystemUploader.FileUploadException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         // verify consumption of the first path
@@ -114,7 +118,11 @@ class S3UploaderTest {
         queue.finish();
 
         final Future<?> submit = Executors.newFixedThreadPool(1).submit(() -> {
-            uploader.upload(queue);
+            try {
+                uploader.upload(queue);
+            } catch (FilesystemUploader.FileUploadException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         submit.get();
@@ -122,7 +130,7 @@ class S3UploaderTest {
     }
 
     @Test
-    void uploadNonExistentDirectoryShouldReturnFailedCollection() throws InterruptedException {
+    void uploadNonExistentDirectoryShouldReturnFailedCollection() throws InterruptedException, FilesystemUploader.FileUploadException {
         final Path nonExistentFile = tempDir.resolve("non-existent");
         queue.put(nonExistentFile);
         queue.finish();
@@ -142,7 +150,11 @@ class S3UploaderTest {
         addFileToQueue("file1");
 
         final Future<?> submit = Executors.newFixedThreadPool(1).submit(() -> {
-            uploader.upload(queue);
+            try {
+                uploader.upload(queue);
+            } catch (FilesystemUploader.FileUploadException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         Thread.sleep(100);

--- a/src/test/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloaderTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloaderTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.ssm.model.CommandInvocationStatus;
 import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 
@@ -86,8 +87,9 @@ class S3SyncFileSystemDownloaderTest {
     @Test
     void shouldThrowWhenCommandDoesNotSucceedWithinTimeout() {
         when(mockSsmApi.getSSMCommand(any(), anyString())).thenReturn(
-                GetCommandInvocationResponse.builder()
+                (GetCommandInvocationResponse) GetCommandInvocationResponse.builder()
                         .status(CommandInvocationStatus.DELAYED)
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusText("whoopsie dooopsie").build())
                         .build());
 
         assertThrows(S3SyncFileSystemDownloader.CannotLaunchCommandException.class, () -> sut.initiateFileSystemDownload());

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -210,6 +210,7 @@ Resources:
                     except ValueError:
                         progress = {}
                     
+                    result['status'] = progress
                     
                     print(json.dumps(result))
                     exit(0)

--- a/templates/migration-stack/pkg/parse_sync_output.py
+++ b/templates/migration-stack/pkg/parse_sync_output.py
@@ -86,6 +86,7 @@ try:
 except ValueError:
     progress = {}
 
+result['status'] = progress
 
 print(json.dumps(result))
 exit(0)


### PR DESCRIPTION
This addresses some PR feedback and does a minor refactor so that the s3 file system migration service does fewer things.

# Summary

* Use exception from file system upload and download as the source of truth for migration failure.
* Add more details to exceptions thrown during file system migration