### PR TITLE
CHET-169: Clean up migration service wireup & migration stage 

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -136,8 +136,6 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    //Can this be replaced by a primary annotation instead? Verify
-    @Profile("!allowAnyTransition")
     public MigrationService migrationService(ActiveObjects ao) {
         return new AWSMigrationService(ao);
     }

--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
@@ -17,13 +17,14 @@ import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationSe
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.env.Environment;
 
 @Configuration
 public class MigrationAssistantProfileSpecificConfiguration {
     @Bean
     @Profile("allowAnyTransition")
+    @Primary
     public MigrationService allowAnyTransitionMigrationService(ActiveObjects ao){
         return new AllowAnyTransitionMigrationServiceFacade(ao);
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -71,12 +71,12 @@ public class AWSMigrationService implements MigrationService {
     public void transition(MigrationStage to) throws InvalidMigrationStageError
     {
         Migration migration = findFirstOrCreateMigration();
+        MigrationStage currentStage = migration.getStage();
 
         // NOTE: This assumes that the state transitions from the start of the enum to the end.
-        if (!MigrationStage.isValidTransition(getCurrentStage(), to)) {
-            throw InvalidMigrationStageError.errorWithMessage(getCurrentStage(), to);
+        if (!currentStage.isValidTransition(to)) {
+            throw InvalidMigrationStageError.errorWithMessage(currentStage, to);
         }
-
         setCurrentStage(migration, to);
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -62,15 +62,9 @@ public enum MigrationStage {
         this.validFrom = Optional.of(validFrom);
     }
 
-    //TODO: Refactor away from static to an instance method.
-    public static boolean isValidTransition(MigrationStage from, MigrationStage to) {
-        return !to.validFrom.isPresent() || to.validFrom.get().equals(from);
+    public boolean isValidTransition(MigrationStage to) {
+        return !to.validFrom.isPresent() || to.validFrom.get().equals(this);
     }
-
-//    TODO: Review develop endpoint is see if migration stage will be (de)serialized
-//    If not, then create a JSON creator method to convert from string to enum type.
-//    @JsonProperty
-//    private String key;
 
     @Override
     public String toString() {

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationStage.java
@@ -63,7 +63,9 @@ public enum MigrationStage {
     }
 
     public boolean isValidTransition(MigrationStage to) {
-        return !to.validFrom.isPresent() || to.validFrom.get().equals(this);
+        return to.validFrom
+                .map(source -> source.equals(this))
+                .orElse(true);
     }
 
     @Override

--- a/src/test/java/com/atlassian/migration/datacenter/spi/MigrationStageTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/spi/MigrationStageTest.java
@@ -27,20 +27,20 @@ class MigrationStageTest
     @Test
     void testErrorFromAnywhere()
     {
-        assertTrue(MigrationStage.isValidTransition(MigrationStage.DB_MIGRATION_EXPORT, MigrationStage.ERROR));
-        assertTrue(MigrationStage.isValidTransition(MigrationStage.NOT_STARTED, MigrationStage.ERROR));
+        assertTrue(MigrationStage.DB_MIGRATION_EXPORT.isValidTransition(MigrationStage.ERROR));
+        assertTrue(MigrationStage.NOT_STARTED.isValidTransition(MigrationStage.ERROR));
     }
 
     @Test
     void testValidTransition()
     {
-        assertTrue(MigrationStage.isValidTransition(MigrationStage.PROVISION_APPLICATION, MigrationStage.PROVISION_APPLICATION_WAIT));
-        assertTrue(MigrationStage.isValidTransition(MigrationStage.DB_MIGRATION_EXPORT, MigrationStage.DB_MIGRATION_EXPORT_WAIT));
+        assertTrue(MigrationStage.PROVISION_APPLICATION.isValidTransition(MigrationStage.PROVISION_APPLICATION_WAIT));
+        assertTrue(MigrationStage.DB_MIGRATION_EXPORT.isValidTransition(MigrationStage.DB_MIGRATION_EXPORT_WAIT));
     }
 
     @Test
     void testInvalidTransition()
     {
-        assertFalse(MigrationStage.isValidTransition(MigrationStage.DB_MIGRATION_UPLOAD, MigrationStage.DB_MIGRATION_EXPORT));
+        assertFalse(MigrationStage.DB_MIGRATION_UPLOAD.isValidTransition(MigrationStage.DB_MIGRATION_EXPORT));
     }
 }


### PR DESCRIPTION
 A small PR that will make the profiled bean a primary. This is useful so that we do not need to create negated profile scoped beans like we have currently.

When the profile to allowTransitions is active, 2 migrations beans are registered, but the bean annotated with primary is the only one that is injected. 

Additionally, this cleans up migration state and removes the static method to check if transitions are valid