### PR TITLE
Add synchronisation points to state machine.

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -68,7 +68,8 @@ public class AWSMigrationService implements MigrationService {
     }
 
     @Override
-    public void transition(MigrationStage to) throws InvalidMigrationStageError {
+    public synchronized void transition(MigrationStage to) throws InvalidMigrationStageError
+    {
         Migration migration = findFirstOrCreateMigration();
         MigrationStage currentStage = migration.getStage();
 
@@ -85,12 +86,12 @@ public class AWSMigrationService implements MigrationService {
         setCurrentStage(migration, ERROR);
     }
 
-    protected void setCurrentStage(Migration migration, MigrationStage stage) {
+    protected synchronized void setCurrentStage(Migration migration, MigrationStage stage) {
         migration.setStage(stage);
         migration.save();
     }
 
-    protected Migration findFirstOrCreateMigration() {
+    protected synchronized Migration findFirstOrCreateMigration() {
         Migration[] migrations = ao.find(Migration.class);
         if (migrations.length == 1) {
             // In case we have interrupted migration (e.g. the node went down), we want to pick up where we've


### PR DESCRIPTION
Spring beans with mutable data are effectively global variables. We should synchronise any mutation points.