### PR TITLE
Fix duplicate transition between db export and import

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -62,6 +62,14 @@ public class AWSMigrationService implements MigrationService {
     }
 
     @Override
+    public void assertCurrentStage(MigrationStage expected) throws InvalidMigrationStageError {
+        MigrationStage currentStage = getCurrentStage();
+        if (currentStage != expected) {
+            throw new InvalidMigrationStageError(String.format("wanted to be in stage %s but was in stage %s", expected, currentStage));
+        }
+    }
+
+    @Override
     public Migration getCurrentMigration() {
         Migration migration = findFirstOrCreateMigration();
         return (Migration) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{Migration.class}, new ReadOnlyEntityInvocationHandler<>(migration));

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/MigrationStageCallback.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/MigrationStageCallback.java
@@ -15,7 +15,7 @@ package com.atlassian.migration.datacenter.core.aws;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 
 public interface MigrationStageCallback {
-    void transitionToServiceStartStage() throws InvalidMigrationStageError;
+    void assertInStartingStage() throws InvalidMigrationStageError;
 
     void transitionToServiceWaitStage() throws InvalidMigrationStageError;
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalService.java
@@ -30,7 +30,7 @@ public class DatabaseArchivalService {
     public Path archiveDatabase(Path tempDirectory, MigrationStageCallback archiveStageCallback) throws InvalidMigrationStageError {
         Path target = tempDirectory.resolve("db.dump");
 
-        archiveStageCallback.transitionToServiceStartStage();
+        archiveStageCallback.assertInStartingStage();
 
         Process extractorProcess = this.databaseExtractor.startDatabaseDump(target);
         archiveStageCallback.transitionToServiceWaitStage();

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchiveStageTransitionCallback.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchiveStageTransitionCallback.java
@@ -25,8 +25,8 @@ public class DatabaseArchiveStageTransitionCallback implements MigrationStageCal
     }
 
     @Override
-    public void transitionToServiceStartStage() throws InvalidMigrationStageError {
-        this.migrationService.transition(MigrationStage.DB_MIGRATION_EXPORT);
+    public void assertInStartingStage() throws InvalidMigrationStageError {
+        this.migrationService.assertCurrentStage(MigrationStage.DB_MIGRATION_EXPORT);
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
@@ -42,7 +42,7 @@ public class DatabaseArtifactS3UploadService {
     }
 
     public FileSystemMigrationReport upload(Path target, String targetBucketName, DatabaseUploadStageTransitionCallback callback) throws InvalidMigrationStageError, FilesystemUploader.FileUploadException {
-        callback.transitionToServiceStartStage();
+        callback.assertInStartingStage();
         FilesystemUploader filesystemUploader = buildFileSystemUploader(target, targetBucketName, fileSystemMigrationReport, s3AsyncClient);
 
         callback.transitionToServiceWaitStage();

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseUploadStageTransitionCallback.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseUploadStageTransitionCallback.java
@@ -25,8 +25,8 @@ public class DatabaseUploadStageTransitionCallback implements MigrationStageCall
     }
 
     @Override
-    public void transitionToServiceStartStage() throws InvalidMigrationStageError {
-        this.migrationService.transition(MigrationStage.DB_MIGRATION_UPLOAD);
+    public void assertInStartingStage() throws InvalidMigrationStageError {
+        this.migrationService.assertCurrentStage(MigrationStage.DB_MIGRATION_UPLOAD);
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
@@ -38,6 +38,11 @@ public interface MigrationService {
      */
     MigrationStage getCurrentStage();
 
+    /**
+     * @param expected the migration stage that the caller expects the migration to be in
+     * @throws InvalidMigrationStageError when there is a mismatch between the expected stage and the current stage
+     */
+    void assertCurrentStage(MigrationStage expected) throws InvalidMigrationStageError;
 
     /**
      * Gets the Migration Object that can only be read. Setter invocation must to happen through the {@link MigrationService} interface

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalServiceTest.java
@@ -56,14 +56,14 @@ class DatabaseArchivalServiceTest {
         Path target = service.archiveDatabase(tempDir, migrationStageCallback);
         assertTrue(target.endsWith("db.dump"));
 
-        verify(this.migrationStageCallback).transitionToServiceStartStage();
+        verify(this.migrationStageCallback).assertInStartingStage();
         verify(this.migrationStageCallback).transitionToServiceWaitStage();
         verify(this.migrationStageCallback).transitionToServiceNextStage();
     }
 
     @Test
     void shouldThrowExceptionWhenStateTransitionToStartStageIsNotSuccessful() throws Exception {
-        doThrow(InvalidMigrationStageError.class).when(migrationStageCallback).transitionToServiceStartStage();
+        doThrow(InvalidMigrationStageError.class).when(migrationStageCallback).assertInStartingStage();
 
         assertThrows(InvalidMigrationStageError.class, () -> {
             service.archiveDatabase(tempDir, migrationStageCallback);
@@ -77,7 +77,7 @@ class DatabaseArchivalServiceTest {
         assertThrows(InvalidMigrationStageError.class, () -> {
             service.archiveDatabase(tempDir, migrationStageCallback);
         });
-        verify(migrationStageCallback).transitionToServiceStartStage();
+        verify(migrationStageCallback).assertInStartingStage();
     }
 
 
@@ -91,7 +91,7 @@ class DatabaseArchivalServiceTest {
             service.archiveDatabase(tempDir, migrationStageCallback);
         });
 
-        verify(migrationStageCallback).transitionToServiceStartStage();
+        verify(migrationStageCallback).assertInStartingStage();
         verify(migrationStageCallback).transitionToServiceWaitStage();
     }
 
@@ -104,7 +104,7 @@ class DatabaseArchivalServiceTest {
             service.archiveDatabase(tempDir, migrationStageCallback);
         });
 
-        verify(migrationStageCallback).transitionToServiceStartStage();
+        verify(migrationStageCallback).assertInStartingStage();
         verify(migrationStageCallback).transitionToServiceWaitStage();
         verify(migrationStageCallback).transitionToServiceErrorStage();
     }


### PR DESCRIPTION
The `transitionToNext` of database archive was the same as `transitionToStart` of the database restore which would have caused an exception. I've refactored the callbacks so that they simply assert they are in the expected stage before starting instead of transitioning to the start stage. The transition to the start stage of any operation will be done by the `transitionToNext` of the previous operation.