### PR TITLE
CHET-202: Securely store new db credentials

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -49,10 +49,10 @@ import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSyst
 import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSystemDownloader;
 import com.atlassian.migration.datacenter.core.util.EncryptionManager;
 import com.atlassian.migration.datacenter.core.util.MigrationRunner;
-import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.scheduler.SchedulerService;
 import com.atlassian.util.concurrent.Supplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -204,6 +204,11 @@ public class MigrationAssistantBeanConfiguration {
     @Bean
     public CfnApi cfnApi(AwsCredentialsProvider awsCredentialsProvider, RegionService regionService) {
         return new CfnApi(awsCredentialsProvider, regionService);
+    }
+
+    @Bean
+    public MigrationRunner migrationRunner(SchedulerService schedulerService) {
+        return new MigrationRunner(schedulerService);
     }
 
     @Bean

--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -36,6 +36,7 @@ import com.atlassian.migration.datacenter.core.aws.db.DatabaseMigrationService;
 import com.atlassian.migration.datacenter.core.aws.db.DatabaseUploadStageTransitionCallback;
 import com.atlassian.migration.datacenter.core.aws.db.restore.DatabaseRestoreStageTransitionCallback;
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService;
+import com.atlassian.migration.datacenter.core.aws.db.restore.TargetDbCredentialsStorageService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.QuickstartDeploymentService;
 import com.atlassian.migration.datacenter.core.aws.region.AvailabilityZoneManager;
 import com.atlassian.migration.datacenter.core.aws.region.PluginSettingsRegionManager;
@@ -48,6 +49,7 @@ import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSyst
 import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSystemDownloader;
 import com.atlassian.migration.datacenter.core.util.EncryptionManager;
 import com.atlassian.migration.datacenter.core.util.MigrationRunner;
+import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
@@ -96,6 +98,11 @@ public class MigrationAssistantBeanConfiguration {
     @Bean
     public EncryptedCredentialsStorage encryptedCredentialsStorage(Supplier<PluginSettingsFactory> pluginSettingsFactorySupplier, EncryptionManager encryptionManager) {
         return new EncryptedCredentialsStorage(pluginSettingsFactorySupplier, encryptionManager);
+    }
+
+    @Bean
+    public TargetDbCredentialsStorageService targetDbCredentialsStorageService(MigrationService migrationService, ActiveObjects ao, EncryptionManager encryptionManager) {
+        return new TargetDbCredentialsStorageService(migrationService, ao, encryptionManager);
     }
 
     @Bean

--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -217,7 +217,7 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public QuickstartDeploymentService quickstartDeploymentService(ActiveObjects ao, CfnApi cfnApi, MigrationService migrationService) {
-        return new QuickstartDeploymentService(ao, cfnApi, migrationService);
+    public QuickstartDeploymentService quickstartDeploymentService(ActiveObjects ao, CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
+        return new QuickstartDeploymentService(ao, cfnApi, migrationService, dbCredentialsStorageService);
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -54,7 +54,7 @@ public class TargetDbCredentialsStorageService {
 
         MigrationContext context = getMigrationContext();
 
-        context.setTargetDatabasePasswordEncrypted(encryptionManager.encryptString(password));
+        context.setTargetDbPasswordEncrypted(encryptionManager.encryptString(password));
     }
 
     /**
@@ -62,7 +62,7 @@ public class TargetDbCredentialsStorageService {
      */
     public Pair<String, String> getCredentials() {
         MigrationContext context = getMigrationContext();
-        String decryptedPassword = encryptionManager.decryptString(context.getTargetDatabasePasswordEncrypted());
+        String decryptedPassword = encryptionManager.decryptString(context.getTargetDbPasswordEncrypted());
         return Pair.of(APPLICATION_DB_USER, decryptedPassword);
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.db.restore;
+
+import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.migration.datacenter.core.util.EncryptionManager;
+import com.atlassian.migration.datacenter.dto.Migration;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class TargetDbCredentialsStorageService {
+
+    private final MigrationService migrationService;
+    private final ActiveObjects ao;
+    private final EncryptionManager encryptionManager;
+
+    public TargetDbCredentialsStorageService(MigrationService migrationService, ActiveObjects ao, EncryptionManager encryptionManager) {
+        this.migrationService = migrationService;
+        this.ao = ao;
+        this.encryptionManager = encryptionManager;
+    }
+
+    /**
+     * Stores the given database credentials in the {@link com.atlassian.migration.datacenter.dto.MigrationContext}
+     * to be used later to restore the database. The password will be encrypted before storage.
+     * @param username the database username
+     * @param password the database password
+     */
+    public void storeCredentials(String username, String password) {
+        MigrationContext context = getMigrationContext();
+        context.setTargetDatabaseUsername(username);
+        context.setTargetDatabasePasswordEncrypted(encryptionManager.encryptString(password));
+    }
+
+    /**
+     * @return a pair where the left element is the database username and the right element is the database password
+     */
+    public Pair<String, String> getCredentials() {
+        MigrationContext context = getMigrationContext();
+        String decryptedPassword = encryptionManager.decryptString(context.getTargetDatabasePasswordEncrypted());
+        return Pair.of(context.getTargetDatabaseUsername(), decryptedPassword);
+    }
+
+    // TODO: put this behind the migration service
+    private MigrationContext getMigrationContext() {
+        MigrationContext[] migrationContexts = ao.find(MigrationContext.class);
+        if (migrationContexts.length == 0) {
+            migrationService.error();
+            throw new RuntimeException("No migration context exists, are you really in a migration?");
+        }
+        return migrationContexts[0];
+    }
+
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -26,6 +26,8 @@ import static java.util.Objects.requireNonNull;
 
 public class TargetDbCredentialsStorageService {
 
+    private static final String APPLICATION_DB_USER = System.getProperty("com.atlassian.migration.db.target.applicationUsername", "atljira");
+
     private final MigrationService migrationService;
     private final ActiveObjects ao;
     private final EncryptionManager encryptionManager;
@@ -37,19 +39,17 @@ public class TargetDbCredentialsStorageService {
     }
 
     /**
-     * Stores the given database credentials in the {@link com.atlassian.migration.datacenter.dto.MigrationContext}
+     * Stores the given database password in the {@link com.atlassian.migration.datacenter.dto.MigrationContext}
      * to be used later to restore the database. The password will be encrypted before storage.
-     * @param username the database username
      * @param password the database password
-     * @throws NullPointerException if either parameter is null
+     * @throws NullPointerException if the password is null
      */
-    public void storeCredentials(String username, String password) {
-        requireNonNull(username);
+    public void storeCredentials(String password) {
         requireNonNull(password);
 
         MigrationContext context = getMigrationContext();
 
-        context.setTargetDatabaseUsername(username);
+        context.setTargetDatabaseUsername(APPLICATION_DB_USER);
         context.setTargetDatabasePasswordEncrypted(encryptionManager.encryptString(password));
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -18,10 +18,11 @@ package com.atlassian.migration.datacenter.core.aws.db.restore;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.util.EncryptionManager;
-import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import org.apache.commons.lang3.tuple.Pair;
+
+import static java.util.Objects.requireNonNull;
 
 public class TargetDbCredentialsStorageService {
 
@@ -40,9 +41,14 @@ public class TargetDbCredentialsStorageService {
      * to be used later to restore the database. The password will be encrypted before storage.
      * @param username the database username
      * @param password the database password
+     * @throws NullPointerException if either parameter is null
      */
     public void storeCredentials(String username, String password) {
+        requireNonNull(username);
+        requireNonNull(password);
+
         MigrationContext context = getMigrationContext();
+
         context.setTargetDatabaseUsername(username);
         context.setTargetDatabasePasswordEncrypted(encryptionManager.encryptString(password));
     }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -24,6 +24,11 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Service for managing credentials for the target database in the migrated environment.
+ * The migration should store the target database password with this service. It will be stored securely.
+ * The database username is managed as it is constant in Quick Start environments.
+ */
 public class TargetDbCredentialsStorageService {
 
     private static final String APPLICATION_DB_USER = System.getProperty("com.atlassian.migration.db.target.applicationUsername", "atljira");
@@ -49,17 +54,16 @@ public class TargetDbCredentialsStorageService {
 
         MigrationContext context = getMigrationContext();
 
-        context.setTargetDatabaseUsername(APPLICATION_DB_USER);
         context.setTargetDatabasePasswordEncrypted(encryptionManager.encryptString(password));
     }
 
     /**
-     * @return a pair where the left element is the database username and the right element is the database password
+     * @return a pair where the left element is the target database username and the right element is the target database password
      */
     public Pair<String, String> getCredentials() {
         MigrationContext context = getMigrationContext();
         String decryptedPassword = encryptionManager.decryptString(context.getTargetDatabasePasswordEncrypted());
-        return Pair.of(context.getTargetDatabaseUsername(), decryptedPassword);
+        return Pair.of(APPLICATION_DB_USER, decryptedPassword);
     }
 
     // TODO: put this behind the migration service

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -77,7 +77,7 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     }
 
     private void storeDbCredentials(Map<String, String> params) {
-        dbCredentialsStorageService.storeCredentials("atljira", params.get("DBPassword"));
+        dbCredentialsStorageService.storeCredentials(params.get("DBPassword"));
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.core.aws.db.restore.TargetDbCredentialsStorageService;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationService;
@@ -42,11 +43,13 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     private final CfnApi cfnApi;
     private final MigrationService migrationService;
     private final ActiveObjects ao;
+    private final TargetDbCredentialsStorageService dbCredentialsStorageService;
 
-    public QuickstartDeploymentService(ActiveObjects ao, CfnApi cfnApi, MigrationService migrationService) {
+    public QuickstartDeploymentService(ActiveObjects ao, CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
         this.ao = ao;
         this.cfnApi = cfnApi;
         this.migrationService = migrationService;
+        this.dbCredentialsStorageService = dbCredentialsStorageService;
     }
 
     /**

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -72,6 +72,12 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
         addDeploymentIdToMigrationContext(deploymentId);
 
         scheduleMigrationServiceTransition(deploymentId);
+
+        storeDbCredentials(params);
+    }
+
+    private void storeDbCredentials(Map<String, String> params) {
+        dbCredentialsStorageService.storeCredentials("atljira", params.get("DBPassword"));
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
@@ -28,8 +28,8 @@ public interface MigrationContext extends Entity {
 
     void setApplicationDeploymentId(String id);
 
-    String getTargetDatabasePasswordEncrypted();
+    String getTargetDbPasswordEncrypted();
 
-    void setTargetDatabasePasswordEncrypted(String encryptedPassword);
+    void setTargetDbPasswordEncrypted(String encryptedPassword);
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
@@ -27,4 +27,12 @@ public interface MigrationContext extends Entity {
     String getApplicationDeploymentId();
 
     void setApplicationDeploymentId(String id);
+
+    String getTargetDatabasePasswordEncrypted();
+
+    void setTargetDatabasePasswordEncrypted(String encryptedPassword);
+
+    String getTargetDatabaseUsername();
+
+    void setTargetDatabaseUsername(String username);
 }

--- a/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
@@ -32,7 +32,4 @@ public interface MigrationContext extends Entity {
 
     void setTargetDatabasePasswordEncrypted(String encryptedPassword);
 
-    String getTargetDatabaseUsername();
-
-    void setTargetDatabaseUsername(String username);
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -82,7 +82,7 @@ class QuickstartDeploymentServiceTest {
             properties.setProperty(passwordPropertyKey, invocation.getArgument(1));
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString(), anyString());
-        when(dbCredentialsStorageService.getCredentials()).thenReturn(Pair.of(properties.getProperty(usernamePropertyKey), properties.getProperty(passwordPropertyKey)));
+        doAnswer(invocation -> Pair.of(properties.getProperty(usernamePropertyKey), properties.getProperty(passwordPropertyKey))).when(dbCredentialsStorageService).getCredentials();
     }
 
     @Test


### PR DESCRIPTION
# Summary

- Stores database password encrypted in the migration context.
- Hardcodes the database user

## Fast Follow

- Refactor access to the migration context so it goes through the MigrationService
- Make the relationship between migration context and migration bidirectional
