### PR TITLE
Expose migration context via migration service

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -76,6 +76,11 @@ public class AWSMigrationService implements MigrationService {
     }
 
     @Override
+    public MigrationContext getCurrentContext() {
+        return getCurrentMigration().getContext();
+    }
+
+    @Override
     public synchronized void transition(MigrationStage to) throws InvalidMigrationStageError
     {
         Migration migration = findFirstOrCreateMigration();

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -55,6 +55,7 @@ public class TargetDbCredentialsStorageService {
         MigrationContext context = getMigrationContext();
 
         context.setTargetDbPasswordEncrypted(encryptionManager.encryptString(password));
+        context.save();
     }
 
     /**
@@ -66,14 +67,8 @@ public class TargetDbCredentialsStorageService {
         return Pair.of(APPLICATION_DB_USER, decryptedPassword);
     }
 
-    // TODO: put this behind the migration service
     private MigrationContext getMigrationContext() {
-        MigrationContext[] migrationContexts = ao.find(MigrationContext.class);
-        if (migrationContexts.length == 0) {
-            migrationService.error();
-            throw new RuntimeException("No migration context exists, are you really in a migration?");
-        }
-        return migrationContexts[0];
+        return migrationService.getCurrentContext();
     }
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -107,12 +107,7 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     }
 
     private MigrationContext getMigrationContext() {
-        MigrationContext[] migrationContexts = ao.find(MigrationContext.class);
-        if (migrationContexts.length == 0) {
-            migrationService.error();
-            throw new RuntimeException("No migration context exists, are you really in a migration?");
-        }
-        return migrationContexts[0];
+        return migrationService.getCurrentContext();
     }
 
     private void scheduleMigrationServiceTransition(String deploymentId) {

--- a/src/main/java/com/atlassian/migration/datacenter/dto/Migration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/Migration.java
@@ -18,11 +18,15 @@ package com.atlassian.migration.datacenter.dto;
 
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import net.java.ao.Entity;
+import net.java.ao.OneToOne;
 
 public interface Migration extends Entity {
 
     MigrationStage getStage();
 
     void setStage(MigrationStage stage);
+
+    @OneToOne(reverse = "getMigration")
+    MigrationContext getContext();
 
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
@@ -19,6 +19,7 @@ package com.atlassian.migration.datacenter.spi;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.core.exceptions.MigrationAlreadyExistsException;
 import com.atlassian.migration.datacenter.dto.Migration;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
 
 /**
  * Manages the lifecycle of the migration
@@ -51,6 +52,12 @@ public interface MigrationService {
      */
     Migration getCurrentMigration();
 
+    /**
+     * Gets the current migration context. The migration context can be used to store or query specific data
+     * about this migration.
+     * @return The migration context Entity for this migration.
+     */
+    MigrationContext getCurrentContext();
 
     /**
      * Tries to transition the migration state from one to another

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -83,12 +83,11 @@ class QuickstartDeploymentServiceTest {
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
         lenient().doAnswer(invocation -> Pair.of(DEFAULT_DB_USER, properties.getProperty(passwordPropertyKey))).when(dbCredentialsStorageService).getCredentials();
+        when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
     }
 
     @Test
     void shouldDeployQuickStart() throws InvalidMigrationStageError {
-        initialiseValidMigration();
-
         deploySimpleStack();
 
         verify(mockCfnApi).provisionStack("https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml", STACK_NAME, STACK_PARAMS);
@@ -96,8 +95,6 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldStoreDBCredentials() throws InvalidMigrationStageError {
-        initialiseValidMigration();
-
         deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
 
         final Pair<String, String> credentials = dbCredentialsStorageService.getCredentials();
@@ -107,7 +104,6 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldReturnInProgressWhileDeploying() throws InvalidMigrationStageError {
-        initialiseValidMigration();
         when(mockContext.getApplicationDeploymentId()).thenReturn(STACK_NAME);
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
 
@@ -118,7 +114,6 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldTransitionToWaitingForDeploymentWhileDeploymentIsCompleting() throws InvalidMigrationStageError, InterruptedException {
-        initialiseValidMigration();
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
 
         deploySimpleStack();
@@ -130,7 +125,6 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldTransitionMigrationServiceStateWhenDeploymentFinishes() throws InterruptedException, InvalidMigrationStageError {
-        initialiseValidMigration();
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_COMPLETE);
 
         deploySimpleStack();
@@ -142,7 +136,6 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldTransitionMigrationServiceToErrorWhenDeploymentFails() throws InterruptedException, InvalidMigrationStageError {
-        initialiseValidMigration();
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_FAILED);
 
         deploySimpleStack();
@@ -152,18 +145,7 @@ class QuickstartDeploymentServiceTest {
         verify(mockMigrationService).error();
     }
 
-//    @Test
-//    void shouldNotInitiateDeploymentIfNotInProvisionApplicationStage() throws InvalidMigrationStageError {
-//        doThrow(new InvalidMigrationStageError("")).when(mockMigrationService).transition(argThat(argument -> argument.equals(MigrationStage.PROVISION_APPLICATION)), any(MigrationStage.class));
-//
-//        assertThrows(InvalidMigrationStageError.class, this::deploySimpleStack);
-//    }
-
     private void deploySimpleStack() throws InvalidMigrationStageError {
         deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
-    }
-
-    private void initialiseValidMigration() {
-        when(mockAo.find(MigrationContext.class)).thenReturn(new MigrationContext[]{mockContext});
     }
 }


### PR DESCRIPTION
# Summary

* Creaet bidirectional link between Migration and Migration Context
* Create method in migration service for accessing migration context
* Refactor dependents on migration context to use the new method