### PR TITLE
CHET-190: pass target DB credentials to secretsmanager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,10 @@
             <artifactId>ssm</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>2.10.3</version>

--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -60,6 +60,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.ssm.SsmClient;
 
 import java.nio.file.Paths;
@@ -80,6 +81,14 @@ public class MigrationAssistantBeanConfiguration {
     @Bean
     public Supplier<SsmClient> ssmClient(AwsCredentialsProvider credentialsProvider, RegionService regionService) {
         return () -> SsmClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(regionService.getRegion()))
+                .build();
+    }
+
+    @Bean
+    public Supplier<SecretsManagerClient> secretsManagerClient(AwsCredentialsProvider credentialsProvider, RegionService regionService) {
+        return () -> SecretsManagerClient.builder()
                 .credentialsProvider(credentialsProvider)
                 .region(Region.of(regionService.getRegion()))
                 .build();

--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -110,8 +110,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public TargetDbCredentialsStorageService targetDbCredentialsStorageService(MigrationService migrationService, EncryptionManager encryptionManager) {
-        return new TargetDbCredentialsStorageService(migrationService, encryptionManager);
+    public TargetDbCredentialsStorageService targetDbCredentialsStorageService(Supplier<SecretsManagerClient> clientSupplier, MigrationService migrationService) {
+        return new TargetDbCredentialsStorageService(clientSupplier, migrationService);
     }
 
     @Bean

--- a/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -101,8 +101,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public TargetDbCredentialsStorageService targetDbCredentialsStorageService(MigrationService migrationService, ActiveObjects ao, EncryptionManager encryptionManager) {
-        return new TargetDbCredentialsStorageService(migrationService, ao, encryptionManager);
+    public TargetDbCredentialsStorageService targetDbCredentialsStorageService(MigrationService migrationService, EncryptionManager encryptionManager) {
+        return new TargetDbCredentialsStorageService(migrationService, encryptionManager);
     }
 
     @Bean
@@ -217,7 +217,7 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public QuickstartDeploymentService quickstartDeploymentService(ActiveObjects ao, CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
-        return new QuickstartDeploymentService(ao, cfnApi, migrationService, dbCredentialsStorageService);
+    public QuickstartDeploymentService quickstartDeploymentService(CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
+        return new QuickstartDeploymentService(cfnApi, migrationService, dbCredentialsStorageService);
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -60,7 +60,7 @@ public class TargetDbCredentialsStorageService {
 
         SecretsManagerClient client = clientFactory.get();
         CreateSecretRequest request = CreateSecretRequest.builder()
-                .name(String.format("com.atlassian.migration.db.target.%s.applicationPassword", context.getApplicationDeploymentId()))
+                .name(String.format("atl-%s-app-rds-password", context.getApplicationDeploymentId()))
                 .secretString(password)
                 .description("password for the application user in you new AWS deployment")
                 .build();

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -49,6 +49,7 @@ public class TargetDbCredentialsStorageService {
      * Stores the given database password in AWS <a href="https://aws.amazon.com/secrets-manager/">Secrets Manager</a>
      * to be used later to restore the database. Will be stored under the key:
      *          com.atlassian.migration.db.target.[migration_deployment_id].applicationPassword
+     * @see MigrationContext#getApplicationDeploymentId()
      * @param password the database password
      * @throws NullPointerException if the password is null
      */

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/TargetDbCredentialsStorageService.java
@@ -34,12 +34,10 @@ public class TargetDbCredentialsStorageService {
     private static final String APPLICATION_DB_USER = System.getProperty("com.atlassian.migration.db.target.applicationUsername", "atljira");
 
     private final MigrationService migrationService;
-    private final ActiveObjects ao;
     private final EncryptionManager encryptionManager;
 
-    public TargetDbCredentialsStorageService(MigrationService migrationService, ActiveObjects ao, EncryptionManager encryptionManager) {
+    public TargetDbCredentialsStorageService(MigrationService migrationService, EncryptionManager encryptionManager) {
         this.migrationService = migrationService;
-        this.ao = ao;
         this.encryptionManager = encryptionManager;
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -42,11 +42,9 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
 
     private final CfnApi cfnApi;
     private final MigrationService migrationService;
-    private final ActiveObjects ao;
     private final TargetDbCredentialsStorageService dbCredentialsStorageService;
 
-    public QuickstartDeploymentService(ActiveObjects ao, CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
-        this.ao = ao;
+    public QuickstartDeploymentService(CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
         this.cfnApi = cfnApi;
         this.migrationService = migrationService;
         this.dbCredentialsStorageService = dbCredentialsStorageService;

--- a/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
@@ -28,8 +28,4 @@ public interface MigrationContext extends Entity {
 
     void setApplicationDeploymentId(String id);
 
-    String getTargetDbPasswordEncrypted();
-
-    void setTargetDbPasswordEncrypted(String encryptedPassword);
-
 }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -79,7 +79,6 @@ class QuickstartDeploymentServiceTest {
             properties.setProperty(passwordPropertyKey, invocation.getArgument(0));
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
-        lenient().doAnswer(invocation -> Pair.of(DEFAULT_DB_USER, properties.getProperty(passwordPropertyKey))).when(dbCredentialsStorageService).getCredentials();
         when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
     }
 
@@ -94,9 +93,7 @@ class QuickstartDeploymentServiceTest {
     void shouldStoreDBCredentials() throws InvalidMigrationStageError {
         deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
 
-        final Pair<String, String> credentials = dbCredentialsStorageService.getCredentials();
-        assertEquals(TEST_DB_PASSWORD, credentials.getRight());
-        assertEquals("atljira", credentials.getLeft());
+        verify(dbCredentialsStorageService).storeCredentials(TEST_DB_PASSWORD);
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -63,9 +63,6 @@ class QuickstartDeploymentServiceTest {
     MigrationService mockMigrationService;
 
     @Mock
-    ActiveObjects mockAo;
-
-    @Mock
     TargetDbCredentialsStorageService dbCredentialsStorageService;
 
     @InjectMocks


### PR DESCRIPTION
# Summary

* Store database password in AWS secrets manager instead of migration context

## Reason

Originally we were going to use the migration context to provide the DB password as a parameter to the migration stack CloudFormation template. However, this is not recommended by AWS ([source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/best-practices.html#creds)). Instead we store the credentials as a string with Secrets Manager under the name:
`com.atlassian.migration.db.target.[migration_deployment_id].applicationPassword`
where `migration_deployment_id` is the ApplicationDeploymentId of the current migration context