### PR TITLE
CHET-195: Open RDS Security group to migration helper

### DIFF
--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -11,6 +11,9 @@ Parameters:
   EFSSecurityGroup:
     Description: "The Security Group attached to EFS, access to NFS port will be open from Migration Helper Security Group"
     Type: String
+  RDSSecurityGroup:
+    Description: "The Security Group attached to RDS, access to PostgreSQL port will be open from Migration Helper Security Group"
+    Type: String
   HelperInstanceType:
     Description: "The Instance Type of Helper EC2 Instance"
     Type: String
@@ -308,16 +311,6 @@ Resources:
                 Effect: Allow
                 Resource: !Sub ['arn:aws:s3:::${MigrationBucket}', { MigrationBucket: !Ref MigrationBucket
            }]
-
-      # TODO: Reduce this to minimum required perms
-      #   - PolicyName: Administrator
-      #     PolicyDocument:
-      #       Version: 2012-10-17
-      #       Statement:
-      #         - Sid: Administrator
-      #           Action: '*'
-      #           Effect: Allow
-      #           Resource: '*'
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
@@ -327,7 +320,7 @@ Resources:
       GroupDescription: Allow SSH Port from Trusted
       VpcId: !Ref HelperVpcId
 
-  # OpenEFS to Helper security group
+  # OpenStack to Helper security group
   ExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -352,14 +345,15 @@ Resources:
               - Effect: "Allow"
                 Action: "*"
                 Resource: "*"
-  OpenEFSAccessCustom:
-    Type: Custom::OpenEFSAccessCustom
+  OpenStackAccessCustom:
+    Type: Custom::OpenStackAccessCustom
     Version: 1.0
     Properties:
-      ServiceToken: !GetAtt OpenEFSAccess.Arn
+      ServiceToken: !GetAtt OpenStackAccess.Arn
       HelperSG: !Ref HelperSecurityGroup
       EFSSG: !Ref EFSSecurityGroup
-  OpenEFSAccess:
+      RDSSG: !Ref RDSSecurityGroup
+  OpenStackAccess:
     Type: "AWS::Lambda::Function"
     Properties:
       Handler: index.lambda_handler
@@ -375,6 +369,7 @@ Resources:
           def lambda_handler(event, context):
             try:
                   efssg =  event['ResourceProperties']['EFSSG']
+                  rdssg =  event['ResourceProperties']['RDSSG']
                   evsg = event['ResourceProperties']['HelperSG']
                   if event['RequestType'] == 'Delete':
                       response = ec2client.revoke_security_group_ingress(
@@ -383,6 +378,16 @@ Resources:
                               {'IpProtocol': 'tcp',
                               'FromPort': 2049,
                               'ToPort': 2049,
+                              'UserIdGroupPairs': [{'GroupId': evsg}]}
+                          ]
+                      )
+                      print(response)
+                      response = ec2client.revoke_security_group_ingress(
+                          GroupId=rdssg,
+                          IpPermissions=[
+                              {'IpProtocol': 'tcp',
+                              'FromPort': 5432,
+                              'ToPort': 5432,
                               'UserIdGroupPairs': [{'GroupId': evsg}]}
                           ]
                       )
@@ -399,6 +404,15 @@ Resources:
                               'UserIdGroupPairs': [{'GroupId': evsg}]}
                           ]
                       )
+                      response = ec2client.authorize_security_group_ingress(
+                          GroupId=rdssg,
+                          IpPermissions=[
+                              {'IpProtocol': 'tcp',
+                              'FromPort': 5432,
+                              'ToPort': 5432,
+                              'UserIdGroupPairs': [{'GroupId': evsg}]}
+                          ]
+                      )
                       responseData = {'Create': 'SUCCESS'}
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
                   if event['RequestType'] == 'Update':
@@ -407,7 +421,7 @@ Resources:
             except Exception as e:
                 responseData = {'Error': str(e)}
                 cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
-  OpenEFSAccessExecutionRole:
+  OpenStackAccessExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -320,44 +320,20 @@ Resources:
       GroupDescription: Allow SSH Port from Trusted
       VpcId: !Ref HelperVpcId
 
-  # OpenStack to Helper security group
-  ExecutionRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-                - Fn::Join:
-                    - ""
-                    - - "states."
-                      - Ref: "AWS::Region"
-                      - ".amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      Policies:
-        - PolicyName: "Policies"
-          PolicyDocument:
-            Statement:
-              - Effect: "Allow"
-                Action: "*"
-                Resource: "*"
-  OpenStackAccessCustom:
-    Type: Custom::OpenStackAccessCustom
+  # Open EFS and RDS to Helper security group
+  MigrationStackResourceAccessCustom:
+    Type: Custom::MigrationStackResourceAccessCustom
     Version: 1.0
     Properties:
-      ServiceToken: !GetAtt OpenStackAccess.Arn
+      ServiceToken: !GetAtt MigrationStackResourceAccess.Arn
       HelperSG: !Ref HelperSecurityGroup
       EFSSG: !Ref EFSSecurityGroup
       RDSSG: !Ref RDSSecurityGroup
-  OpenStackAccess:
+  MigrationStackResourceAccess:
     Type: "AWS::Lambda::Function"
     Properties:
       Handler: index.lambda_handler
-      Role: !GetAtt ExecutionRole.Arn
+      Role: !GetAtt MigrationStackResourceAccessExecutionRole.Arn
       Runtime: python3.7
       Timeout: 120
       Code:
@@ -421,7 +397,7 @@ Resources:
             except Exception as e:
                 responseData = {'Error': str(e)}
                 cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
-  OpenStackAccessExecutionRole:
+  MigrationStackResourceAccessExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -11,6 +11,9 @@ Parameters:
   EFSSecurityGroup:
     Description: "The Security Group attached to EFS, access to NFS port will be open from Migration Helper Security Group"
     Type: String
+  RDSSecurityGroup:
+    Description: "The Security Group attached to RDS, access to PostgreSQL port will be open from Migration Helper Security Group"
+    Type: String
   HelperInstanceType:
     Description: "The Instance Type of Helper EC2 Instance"
     Type: String
@@ -216,16 +219,6 @@ Resources:
                 Effect: Allow
                 Resource: !Sub ['arn:aws:s3:::${MigrationBucket}', { MigrationBucket: !Ref MigrationBucket
            }]
-
-      # TODO: Reduce this to minimum required perms
-      #   - PolicyName: Administrator
-      #     PolicyDocument:
-      #       Version: 2012-10-17
-      #       Statement:
-      #         - Sid: Administrator
-      #           Action: '*'
-      #           Effect: Allow
-      #           Resource: '*'
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
@@ -235,7 +228,7 @@ Resources:
       GroupDescription: Allow SSH Port from Trusted
       VpcId: !Ref HelperVpcId
 
-  # OpenEFS to Helper security group
+  # OpenStack to Helper security group
   ExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -260,14 +253,15 @@ Resources:
               - Effect: "Allow"
                 Action: "*"
                 Resource: "*"
-  OpenEFSAccessCustom:
-    Type: Custom::OpenEFSAccessCustom
+  OpenStackAccessCustom:
+    Type: Custom::OpenStackAccessCustom
     Version: 1.0
     Properties:
-      ServiceToken: !GetAtt OpenEFSAccess.Arn
+      ServiceToken: !GetAtt OpenStackAccess.Arn
       HelperSG: !Ref HelperSecurityGroup
       EFSSG: !Ref EFSSecurityGroup
-  OpenEFSAccess:
+      RDSSG: !Ref RDSSecurityGroup
+  OpenStackAccess:
     Type: "AWS::Lambda::Function"
     Properties:
       Handler: index.lambda_handler
@@ -283,6 +277,7 @@ Resources:
           def lambda_handler(event, context):
             try:
                   efssg =  event['ResourceProperties']['EFSSG']
+                  rdssg =  event['ResourceProperties']['RDSSG']
                   evsg = event['ResourceProperties']['HelperSG']
                   if event['RequestType'] == 'Delete':
                       response = ec2client.revoke_security_group_ingress(
@@ -291,6 +286,16 @@ Resources:
                               {'IpProtocol': 'tcp',
                               'FromPort': 2049,
                               'ToPort': 2049,
+                              'UserIdGroupPairs': [{'GroupId': evsg}]}
+                          ]
+                      )
+                      print(response)
+                      response = ec2client.revoke_security_group_ingress(
+                          GroupId=rdssg,
+                          IpPermissions=[
+                              {'IpProtocol': 'tcp',
+                              'FromPort': 5432,
+                              'ToPort': 5432,
                               'UserIdGroupPairs': [{'GroupId': evsg}]}
                           ]
                       )
@@ -307,6 +312,15 @@ Resources:
                               'UserIdGroupPairs': [{'GroupId': evsg}]}
                           ]
                       )
+                      response = ec2client.authorize_security_group_ingress(
+                          GroupId=rdssg,
+                          IpPermissions=[
+                              {'IpProtocol': 'tcp',
+                              'FromPort': 5432,
+                              'ToPort': 5432,
+                              'UserIdGroupPairs': [{'GroupId': evsg}]}
+                          ]
+                      )
                       responseData = {'Create': 'SUCCESS'}
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
                   if event['RequestType'] == 'Update':
@@ -315,7 +329,7 @@ Resources:
             except Exception as e:
                 responseData = {'Error': str(e)}
                 cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
-  OpenEFSAccessExecutionRole:
+  OpenStackAccessExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -228,44 +228,20 @@ Resources:
       GroupDescription: Allow SSH Port from Trusted
       VpcId: !Ref HelperVpcId
 
-  # OpenStack to Helper security group
-  ExecutionRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-                - Fn::Join:
-                    - ""
-                    - - "states."
-                      - Ref: "AWS::Region"
-                      - ".amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      Policies:
-        - PolicyName: "Policies"
-          PolicyDocument:
-            Statement:
-              - Effect: "Allow"
-                Action: "*"
-                Resource: "*"
-  OpenStackAccessCustom:
-    Type: Custom::OpenStackAccessCustom
+  # Open EFS and RDS to Helper security group
+  MigrationStackResourceAccessCustom:
+    Type: Custom::MigrationStackResourceAccessCustom
     Version: 1.0
     Properties:
-      ServiceToken: !GetAtt OpenStackAccess.Arn
+      ServiceToken: !GetAtt MigrationStackResourceAccess.Arn
       HelperSG: !Ref HelperSecurityGroup
       EFSSG: !Ref EFSSecurityGroup
       RDSSG: !Ref RDSSecurityGroup
-  OpenStackAccess:
+  MigrationStackResourceAccess:
     Type: "AWS::Lambda::Function"
     Properties:
       Handler: index.lambda_handler
-      Role: !GetAtt ExecutionRole.Arn
+      Role: !GetAtt MigrationStackResourceAccessExecutionRole.Arn
       Runtime: python3.7
       Timeout: 120
       Code:
@@ -329,7 +305,7 @@ Resources:
             except Exception as e:
                 responseData = {'Error': str(e)}
                 cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
-  OpenStackAccessExecutionRole:
+  MigrationStackResourceAccessExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:


### PR DESCRIPTION
This extends the existing custom resource used to open the EFS security group up to the migration stack to also update the RDS security group.

Screenshots for proof:
**The helper stack security group**
![Screen Shot 2020-03-31 at 3 49 47 pm](https://user-images.githubusercontent.com/21027663/77988314-c577a600-7367-11ea-9def-7cde795b52cb.png)
**The RDS security group provided as a parameter**
![Screen Shot 2020-03-31 at 3 49 51 pm](https://user-images.githubusercontent.com/21027663/77988316-c7416980-7367-11ea-9cc4-9784c07dccd0.png)
**The RDS security group opened up for postgresql after deployment**
![Screen Shot 2020-03-31 at 3 49 41 pm](https://user-images.githubusercontent.com/21027663/77988304-c01a5b80-7367-11ea-9a75-e423c9369702.png)
**The RDS security group closed after destroying the migration stack**
![Screen Shot 2020-03-31 at 3 51 53 pm](https://user-images.githubusercontent.com/21027663/77988371-ed670980-7367-11ea-9ada-22b3a341ca2d.png)

