### PR TITLE
CHET-115: deploy migration stack service

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.api.aws;
 
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ public class CloudFormationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getInfrastructureStatus() {
         try {
-            ApplicationDeploymentService.ApplicationDeploymentStatus status = deploymentService.getDeploymentStatus();
+            InfrastructureDeploymentStatus status = deploymentService.getDeploymentStatus();
             return Response.ok(ImmutableMap.of("status", status)).build();
         } catch (Exception e) {
             return Response.status(Response.Status.NOT_FOUND).entity(ImmutableMap.of("error", e.getMessage())).build();

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -16,6 +16,7 @@
 
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureDeploymentService;
@@ -27,9 +28,18 @@ import java.util.Map;
  * application deployment with data.
  */
 public class AWSMigrationHelperDeploymentService implements MigrationInfrastructureDeploymentService {
+
+    private static final String MIGRATION_HELPER_TEMPLATE_URL = "https://trebuchet-aws-resources.s3.amazonaws.com/migration-helper.yml";
+
+    private final CfnApi cfnApi;
+
+    public AWSMigrationHelperDeploymentService(CfnApi cfnApi) {
+        this.cfnApi = cfnApi;
+    }
+
     @Override
     public void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
-
+        cfnApi.provisionStack(MIGRATION_HELPER_TEMPLATE_URL, deploymentId, params);
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureDeploymentService;
@@ -42,6 +43,10 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
     @Override
     public void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
         super.deployCloudformationStack(MIGRATION_HELPER_TEMPLATE_URL, deploymentId, params);
+
+        final MigrationContext context = migrationService.getCurrentContext();
+        context.setHelperStackDeploymentId(deploymentId);
+        context.save();
     }
 
     @Override

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureDeploymentService;
 
@@ -27,23 +28,34 @@ import java.util.Map;
  * Manages the deployment of the migration helper stack which is used to hydrate the new
  * application deployment with data.
  */
-public class AWSMigrationHelperDeploymentService implements MigrationInfrastructureDeploymentService {
+public class AWSMigrationHelperDeploymentService extends CloudformationDeploymentService implements MigrationInfrastructureDeploymentService {
 
     private static final String MIGRATION_HELPER_TEMPLATE_URL = "https://trebuchet-aws-resources.s3.amazonaws.com/migration-helper.yml";
 
-    private final CfnApi cfnApi;
+    private final MigrationService migrationService;
 
-    public AWSMigrationHelperDeploymentService(CfnApi cfnApi) {
-        this.cfnApi = cfnApi;
+    public AWSMigrationHelperDeploymentService(CfnApi cfnApi, MigrationService migrationService) {
+        super(cfnApi);
+        this.migrationService = migrationService;
     }
 
     @Override
     public void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
-        cfnApi.provisionStack(MIGRATION_HELPER_TEMPLATE_URL, deploymentId, params);
+        super.deployCloudformationStack(MIGRATION_HELPER_TEMPLATE_URL, deploymentId, params);
+    }
+
+    @Override
+    protected void handleSuccessfulDeployment() {
+
+    }
+
+    @Override
+    protected void handleFailedDeployment() {
+
     }
 
     @Override
     public InfrastructureDeploymentStatus getDeploymentStatus() {
-        return null;
+        return super.getDeploymentStatus();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -61,6 +61,6 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
 
     @Override
     public InfrastructureDeploymentStatus getDeploymentStatus() {
-        return super.getDeploymentStatus();
+        return super.getDeploymentStatus(migrationService.getCurrentContext().getHelperStackDeploymentId());
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -41,11 +41,13 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
     }
 
     @Override
-    public void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
-        super.deployCloudformationStack(MIGRATION_HELPER_TEMPLATE_URL, deploymentId, params);
+    public void deployMigrationInfrastructure(Map<String, String> params) throws InvalidMigrationStageError {
+        String applicationDeploymentId = migrationService.getCurrentContext().getApplicationDeploymentId();
+        String migrationStackDeploymentId = applicationDeploymentId + "-migration";
+        super.deployCloudformationStack(MIGRATION_HELPER_TEMPLATE_URL, migrationStackDeploymentId, params);
 
         final MigrationContext context = migrationService.getCurrentContext();
-        context.setHelperStackDeploymentId(deploymentId);
+        context.setHelperStackDeploymentId(migrationStackDeploymentId);
         context.save();
     }
 

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureDeploymentService;
+
+import java.util.Map;
+
+/**
+ * Manages the deployment of the migration helper stack which is used to hydrate the new
+ * application deployment with data.
+ */
+public class AWSMigrationHelperDeploymentService implements MigrationInfrastructureDeploymentService {
+    @Override
+    public void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError {
+
+    }
+
+    @Override
+    public InfrastructureDeploymentStatus getDeploymentStatus() {
+        return null;
+    }
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.cloudformation.model.StackStatus;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public abstract class CloudformationDeploymentService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CloudformationDeploymentService.class);
+
+    private final CfnApi cfnApi;
+
+    private String currentStack;
+
+    protected CloudformationDeploymentService(CfnApi cfnApi) {
+        this.cfnApi = cfnApi;
+    }
+
+    protected void deployCloudformationStack(String templateUrl, String stackName, Map<String, String> params) {
+        currentStack = stackName;
+        cfnApi.provisionStack(templateUrl, stackName, params);
+        beginWatchingDeployment(stackName);
+    }
+
+    protected InfrastructureDeploymentStatus getDeploymentStatus() {
+        StackStatus status = cfnApi.getStatus(currentStack);
+
+        switch (status) {
+            case CREATE_COMPLETE:
+                return InfrastructureDeploymentStatus.CREATE_COMPLETE;
+            case CREATE_FAILED:
+                return InfrastructureDeploymentStatus.CREATE_FAILED;
+            case CREATE_IN_PROGRESS:
+                return InfrastructureDeploymentStatus.CREATE_IN_PROGRESS;
+            default:
+                throw new RuntimeException("Unexpected stack status");
+        }
+    }
+
+    private void beginWatchingDeployment(String stackName) {
+        CompletableFuture<String> stackCompleteFuture = new CompletableFuture<>();
+
+        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        ScheduledFuture<?> ticker = scheduledExecutorService.scheduleAtFixedRate(() -> {
+            final StackStatus status = cfnApi.getStatus(stackName);
+            if (status.equals(StackStatus.CREATE_COMPLETE)) {
+                logger.info("stack {} creation succeeded", stackName);
+                handleSuccessfulDeployment();
+                stackCompleteFuture.complete("");
+            }
+            if (status.equals(StackStatus.CREATE_FAILED)) {
+                logger.error("stack {} creation failed", stackName);
+                handleFailedDeployment();
+                stackCompleteFuture.complete("");
+            }
+        }, 0, 30, TimeUnit.SECONDS);
+
+        ScheduledFuture<?> canceller = scheduledExecutorService.scheduleAtFixedRate(() -> {
+            logger.error("timed out while waiting for stack {} to deploy", stackName);
+            handleFailedDeployment();
+            ticker.cancel(true);
+            // Need to have non-zero period otherwise we get illegal argument exception
+        }, 1, 100, TimeUnit.HOURS);
+
+        stackCompleteFuture.whenComplete((result, thrown) -> {
+            ticker.cancel(true);
+            canceller.cancel(true);
+        });
+    }
+
+    protected abstract void handleFailedDeployment();
+
+    protected abstract void handleSuccessfulDeployment();
+}

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -17,8 +17,6 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
-import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
-import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +29,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Superclass for classes which manage the deployment of cloudformation templates.
+ */
 public abstract class CloudformationDeploymentService {
 
     private static final Logger logger = LoggerFactory.getLogger(CloudformationDeploymentService.class);
@@ -43,6 +44,22 @@ public abstract class CloudformationDeploymentService {
         this.cfnApi = cfnApi;
     }
 
+    /**
+     * Method that will be called if the deployment {@link this#deployCloudformationStack(String, String, Map)} fails
+     */
+    protected abstract void handleSuccessfulDeployment();
+
+    /**
+     * Method that will be called if the deployment succeeds
+     */
+    protected abstract void handleFailedDeployment();
+
+    /**
+     * Deploys a cloudformation stack and starts a thread to monitor the deployment.
+     * @param templateUrl the S3 url of the cloudformation template to deploy
+     * @param stackName the name for the cloudformation stack
+     * @param params the parameters for the cloudformation template
+     */
     protected void deployCloudformationStack(String templateUrl, String stackName, Map<String, String> params) {
         currentStack = stackName;
         cfnApi.provisionStack(templateUrl, stackName, params);
@@ -94,8 +111,4 @@ public abstract class CloudformationDeploymentService {
             canceller.cancel(true);
         });
     }
-
-    protected abstract void handleFailedDeployment();
-
-    protected abstract void handleSuccessfulDeployment();
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -29,6 +29,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Superclass for classes which manage the deployment of cloudformation templates.
  */
@@ -37,8 +39,6 @@ public abstract class CloudformationDeploymentService {
     private static final Logger logger = LoggerFactory.getLogger(CloudformationDeploymentService.class);
 
     private final CfnApi cfnApi;
-
-    private String currentStack;
 
     protected CloudformationDeploymentService(CfnApi cfnApi) {
         this.cfnApi = cfnApi;
@@ -61,13 +61,13 @@ public abstract class CloudformationDeploymentService {
      * @param params the parameters for the cloudformation template
      */
     protected void deployCloudformationStack(String templateUrl, String stackName, Map<String, String> params) {
-        currentStack = stackName;
         cfnApi.provisionStack(templateUrl, stackName, params);
         beginWatchingDeployment(stackName);
     }
 
-    protected InfrastructureDeploymentStatus getDeploymentStatus() {
-        StackStatus status = cfnApi.getStatus(currentStack);
+    protected InfrastructureDeploymentStatus getDeploymentStatus(String stackName) {
+        requireNonNull(stackName);
+        StackStatus status = cfnApi.getStatus(stackName);
 
         switch (status) {
             case CREATE_COMPLETE:

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -50,22 +50,6 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         this.dbCredentialsStorageService = dbCredentialsStorageService;
     }
 
-    @Override
-    protected void handleFailedDeployment() {
-        logger.error("application stack deployment failed");
-        migrationService.error();
-    }
-
-    @Override
-    protected void handleSuccessfulDeployment() {
-        try {
-            logger.debug("application stack deployment succeeded");
-            migrationService.transition(MigrationStage.PROVISION_MIGRATION_STACK);
-        } catch (InvalidMigrationStageError invalidMigrationStageError) {
-            logger.error("tried to transition migration from {} but got error: {}.", MigrationStage.PROVISION_APPLICATION_WAIT, invalidMigrationStageError.getMessage());
-        }
-    }
-
     /**
      * Commences the deployment of the AWS Quick Start. It will transition the state machine upon completion of the
      * deployment. If the deployment finishes successfully we transition to the next stage, otherwise we transition
@@ -86,6 +70,22 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         addDeploymentIdToMigrationContext(deploymentId);
 
         storeDbCredentials(params);
+    }
+
+    @Override
+    protected void handleFailedDeployment() {
+        logger.error("application stack deployment failed");
+        migrationService.error();
+    }
+
+    @Override
+    protected void handleSuccessfulDeployment() {
+        try {
+            logger.debug("application stack deployment succeeded");
+            migrationService.transition(MigrationStage.PROVISION_MIGRATION_STACK);
+        } catch (InvalidMigrationStageError invalidMigrationStageError) {
+            logger.error("tried to transition migration from {} but got error: {}.", MigrationStage.PROVISION_APPLICATION_WAIT, invalidMigrationStageError.getMessage());
+        }
     }
 
     private void storeDbCredentials(Map<String, String> params) {

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -35,19 +35,35 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-public class QuickstartDeploymentService implements ApplicationDeploymentService {
+public class QuickstartDeploymentService extends CloudformationDeploymentService implements ApplicationDeploymentService {
 
     private final Logger logger = LoggerFactory.getLogger(QuickstartDeploymentService.class);
     private static final String QUICKSTART_TEMPLATE_URL = "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml";
 
-    private final CfnApi cfnApi;
     private final MigrationService migrationService;
     private final TargetDbCredentialsStorageService dbCredentialsStorageService;
 
     public QuickstartDeploymentService(CfnApi cfnApi, MigrationService migrationService, TargetDbCredentialsStorageService dbCredentialsStorageService) {
-        this.cfnApi = cfnApi;
+        super(cfnApi);
+
         this.migrationService = migrationService;
         this.dbCredentialsStorageService = dbCredentialsStorageService;
+    }
+
+    @Override
+    protected void handleFailedDeployment() {
+        logger.error("application stack deployment failed");
+        migrationService.error();
+    }
+
+    @Override
+    protected void handleSuccessfulDeployment() {
+        try {
+            logger.debug("application stack deployment succeeded");
+            migrationService.transition(MigrationStage.PROVISION_MIGRATION_STACK);
+        } catch (InvalidMigrationStageError invalidMigrationStageError) {
+            logger.error("tried to transition migration from {} but got error: {}.", MigrationStage.PROVISION_APPLICATION_WAIT, invalidMigrationStageError.getMessage());
+        }
     }
 
     /**
@@ -65,11 +81,9 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
         migrationService.transition(MigrationStage.PROVISION_APPLICATION_WAIT);
 
         logger.info("deploying application stack");
-        cfnApi.provisionStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
+        super.deployCloudformationStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
 
         addDeploymentIdToMigrationContext(deploymentId);
-
-        scheduleMigrationServiceTransition(deploymentId);
 
         storeDbCredentials(params);
     }
@@ -78,68 +92,16 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
         dbCredentialsStorageService.storeCredentials(params.get("DBPassword"));
     }
 
-    @Override
-    public InfrastructureDeploymentStatus getDeploymentStatus() {
-        MigrationContext context = getMigrationContext();
-        StackStatus status = cfnApi.getStatus(context.getApplicationDeploymentId());
-
-        switch (status) {
-            case CREATE_COMPLETE:
-                return InfrastructureDeploymentStatus.CREATE_COMPLETE;
-            case CREATE_FAILED:
-                return InfrastructureDeploymentStatus.CREATE_FAILED;
-            case CREATE_IN_PROGRESS:
-                return InfrastructureDeploymentStatus.CREATE_IN_PROGRESS;
-            default:
-                migrationService.error();
-                throw new RuntimeException("Unexpected stack status");
-        }
-    }
-
     private void addDeploymentIdToMigrationContext(String deploymentId) {
         logger.info("Storing stack name in migration context");
 
-        MigrationContext context = getMigrationContext();
+        MigrationContext context = migrationService.getCurrentContext();
         context.setApplicationDeploymentId(deploymentId);
         context.save();
     }
 
-    private MigrationContext getMigrationContext() {
-        return migrationService.getCurrentContext();
-    }
-
-    private void scheduleMigrationServiceTransition(String deploymentId) {
-        logger.info("scheduling transition of migration status when application stack deployment is completed");
-        CompletableFuture<String> stackCompleteFuture = new CompletableFuture<>();
-
-        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        ScheduledFuture<?> ticker = scheduledExecutorService.scheduleAtFixedRate(() -> {
-            final StackStatus status = cfnApi.getStatus(deploymentId);
-            if (status.equals(StackStatus.CREATE_COMPLETE)) {
-                try {
-                    migrationService.transition(MigrationStage.PROVISION_MIGRATION_STACK);
-                } catch (InvalidMigrationStageError invalidMigrationStageError) {
-                    logger.error("tried to transition migration from {} but got error: {}.", MigrationStage.PROVISION_APPLICATION_WAIT, invalidMigrationStageError.getMessage());
-                }
-                stackCompleteFuture.complete("");
-            }
-            if (status.equals(StackStatus.CREATE_FAILED)) {
-                logger.error("application stack deployment failed");
-                migrationService.error();
-                stackCompleteFuture.complete("");
-            }
-        }, 0, 30, TimeUnit.SECONDS);
-
-        ScheduledFuture<?> canceller = scheduledExecutorService.scheduleAtFixedRate(() -> {
-            logger.error("timed out while waiting for application stack to deploy");
-            migrationService.error();
-            ticker.cancel(true);
-            // Need to have non-zero period otherwise we get illegal argument exception
-        }, 1, 100, TimeUnit.HOURS);
-
-        stackCompleteFuture.whenComplete((result, thrown) -> {
-            ticker.cancel(true);
-            canceller.cancel(true);
-        });
+    @Override
+    public InfrastructureDeploymentStatus getDeploymentStatus() {
+        return super.getDeploymentStatus();
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -102,6 +102,6 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
 
     @Override
     public InfrastructureDeploymentStatus getDeploymentStatus() {
-        return super.getDeploymentStatus();
+        return super.getDeploymentStatus(migrationService.getCurrentContext().getApplicationDeploymentId());
     }
 }

--- a/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -16,7 +16,6 @@
 
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
-import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.aws.db.restore.TargetDbCredentialsStorageService;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
@@ -24,6 +23,7 @@ import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.cloudformation.model.StackStatus;
@@ -79,17 +79,17 @@ public class QuickstartDeploymentService implements ApplicationDeploymentService
     }
 
     @Override
-    public ApplicationDeploymentStatus getDeploymentStatus() {
+    public InfrastructureDeploymentStatus getDeploymentStatus() {
         MigrationContext context = getMigrationContext();
         StackStatus status = cfnApi.getStatus(context.getApplicationDeploymentId());
 
         switch (status) {
             case CREATE_COMPLETE:
-                return ApplicationDeploymentStatus.CREATE_COMPLETE;
+                return InfrastructureDeploymentStatus.CREATE_COMPLETE;
             case CREATE_FAILED:
-                return ApplicationDeploymentStatus.CREATE_FAILED;
+                return InfrastructureDeploymentStatus.CREATE_FAILED;
             case CREATE_IN_PROGRESS:
-                return ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
+                return InfrastructureDeploymentStatus.CREATE_IN_PROGRESS;
             default:
                 migrationService.error();
                 throw new RuntimeException("Unexpected stack status");

--- a/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
+++ b/src/main/java/com/atlassian/migration/datacenter/dto/MigrationContext.java
@@ -28,4 +28,8 @@ public interface MigrationContext extends Entity {
 
     void setApplicationDeploymentId(String id);
 
+    String getHelperStackDeploymentId();
+
+    void setHelperStackDeploymentId(String deploymentId);
+
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureDeploymentStatus.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureDeploymentStatus.java
@@ -16,13 +16,9 @@
 
 package com.atlassian.migration.datacenter.spi.infrastructure;
 
-import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
-
-import java.util.Map;
-
-public interface ApplicationDeploymentService {
-
-    void deployApplication(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError;
-
-    InfrastructureDeploymentStatus getDeploymentStatus();
+/**
+ * Represents the status of the deployment of infrastructure
+ */
+public enum InfrastructureDeploymentStatus {
+    CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILED
 }

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureDeploymentService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.spi.infrastructure;
+
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+
+import java.util.Map;
+
+/**
+ * This service should be implemented if a migration requires any additional infrastructure to facilitate
+ * the migration.
+ */
+public interface MigrationInfrastructureDeploymentService {
+
+    void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError;
+
+    InfrastructureDeploymentStatus getDeploymentStatus();
+
+}

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureDeploymentService.java
@@ -26,6 +26,12 @@ import java.util.Map;
  */
 public interface MigrationInfrastructureDeploymentService {
 
+    /**
+     * Deploys any infrastructure required to facilitate the migration. Leaves naming of the infrastructure
+     * group to the implementor
+     * @param params Any parameters for the deployment
+     * @throws InvalidMigrationStageError when the current stage is not {@link com.atlassian.migration.datacenter.spi.MigrationStage#PROVISION_MIGRATION_STACK}
+     */
     void deployMigrationInfrastructure(Map<String, String> params) throws InvalidMigrationStageError;
 
     InfrastructureDeploymentStatus getDeploymentStatus();

--- a/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureDeploymentService.java
+++ b/src/main/java/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureDeploymentService.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 public interface MigrationInfrastructureDeploymentService {
 
-    void deployMigrationInfrastructure(String deploymentId, Map<String, String> params) throws InvalidMigrationStageError;
+    void deployMigrationInfrastructure(Map<String, String> params) throws InvalidMigrationStageError;
 
     InfrastructureDeploymentStatus getDeploymentStatus();
 

--- a/src/test/java/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpointTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpointTest.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.api.aws;
 
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +73,7 @@ class CloudFormationEndpointTest {
 
     @Test
     public void shouldGetCurrentProvisioningStatusForGivenStackId() {
-        ApplicationDeploymentService.ApplicationDeploymentStatus expectedStatus = ApplicationDeploymentService.ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
+        InfrastructureDeploymentStatus expectedStatus = InfrastructureDeploymentStatus.CREATE_IN_PROGRESS;
         when(this.deploymentService.getDeploymentStatus()).thenReturn(expectedStatus);
 
         Response response = endpoint.getInfrastructureStatus();

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
@@ -16,24 +16,46 @@
 
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AWSMigrationHelperDeploymentServiceTest {
 
-    void shouldProvisionCloudformationStack() {
+    @Mock
+    CfnApi mockCfn;
 
+    @InjectMocks
+    AWSMigrationHelperDeploymentService sut;
+
+    @Test
+    void shouldProvisionCloudformationStack() throws InvalidMigrationStageError {
+        final String deploymentId = "test-deployment";
+        sut.deployMigrationInfrastructure(deploymentId, Collections.emptyMap());
+
+        verify(mockCfn).provisionStack("https://trebuchet-aws-resources.s3.amazonaws.com/migration-helper.yml", deploymentId, Collections.emptyMap());
     }
 
+    @Test
     void shouldReturnInProgressWhileCloudformationDeploymentIsOngoing() {
 
     }
 
+    @Test
     void shouldReturnCompleteWhenCloudformationDeploymentSucceeds() {
 
     }
 
+    @Test
     void shouldReturnErrorWhenCloudformationDeploymentFails() {
 
     }

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AWSMigrationHelperDeploymentServiceTest {
+
+    void shouldProvisionCloudformationStack() {
+
+    }
+
+    void shouldReturnInProgressWhileCloudformationDeploymentIsOngoing() {
+
+    }
+
+    void shouldReturnCompleteWhenCloudformationDeploymentSucceeds() {
+
+    }
+
+    void shouldReturnErrorWhenCloudformationDeploymentFails() {
+
+    }
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
@@ -78,7 +78,7 @@ class CloudformationDeploymentServiceTest {
 
         deploySimpleStack();
 
-        assertEquals(InfrastructureDeploymentStatus.CREATE_IN_PROGRESS, sut.getDeploymentStatus());
+        assertEquals(InfrastructureDeploymentStatus.CREATE_IN_PROGRESS, sut.getDeploymentStatus(STACK_NAME));
     }
 
     @Test

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudformation.model.StackStatus;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloudformationDeploymentServiceTest {
+
+    final static String TEMPLATE_URL = "https://fake-url.com";
+    final static String STACK_NAME = "test-stack";
+    final static Map<String, String> STACK_PARAMS = Collections.emptyMap();
+
+    @Mock
+    CfnApi mockCfnApi;
+
+    CloudformationDeploymentService sut;
+
+    boolean deploymentFailed = false;
+    boolean deploymentSucceeded = false;
+
+    @BeforeEach
+    void setup() {
+        sut = new CloudformationDeploymentService(mockCfnApi) {
+            @Override
+            protected void handleFailedDeployment() {
+                deploymentFailed = true;
+            }
+
+            @Override
+            protected void handleSuccessfulDeployment() {
+                deploymentSucceeded = true;
+            }
+        };
+    }
+
+    @Test
+    void shouldDeployQuickStart() {
+        deploySimpleStack();
+
+        verify(mockCfnApi).provisionStack(TEMPLATE_URL, STACK_NAME, STACK_PARAMS);
+    }
+
+    @Test
+    void shouldReturnInProgressWhileDeploying() throws InvalidMigrationStageError {
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
+
+        deploySimpleStack();
+
+        assertEquals(InfrastructureDeploymentStatus.CREATE_IN_PROGRESS, sut.getDeploymentStatus());
+    }
+
+    @Test
+    void shouldCallHandleFailedDeploymentWhenDeploymentFails() throws InterruptedException {
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_FAILED);
+
+        deploySimpleStack();
+
+        Thread.sleep(100);
+
+        assertTrue(deploymentFailed);
+        assertFalse(deploymentSucceeded);
+    }
+
+    @Test
+    void shouldCallHandleSuccessfulDeploymentWhenDeploymentFails() throws InterruptedException {
+        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_COMPLETE);
+
+        deploySimpleStack();
+
+        Thread.sleep(100);
+
+        assertTrue(deploymentSucceeded);
+        assertFalse(deploymentFailed);
+    }
+
+    private void deploySimpleStack() {
+        sut.deployCloudformationStack(TEMPLATE_URL, STACK_NAME, STACK_PARAMS);
+    }
+
+}

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -45,7 +45,6 @@ class QuickstartDeploymentServiceTest {
 
     static final String STACK_NAME = "my-stack";
     static final String TEST_DB_PASSWORD = "myDatabasePassword";
-    static final String DEFAULT_DB_USER = "atljira";
     static final HashMap<String, String> STACK_PARAMS = new HashMap<String, String>() {{
         put("parameter", "value");
         put("DBPassword", TEST_DB_PASSWORD);
@@ -93,7 +92,6 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldReturnInProgressWhileDeploying() throws InvalidMigrationStageError {
-        when(mockContext.getApplicationDeploymentId()).thenReturn(STACK_NAME);
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
 
         deploySimpleStack();

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -93,6 +93,7 @@ class QuickstartDeploymentServiceTest {
     @Test
     void shouldReturnInProgressWhileDeploying() throws InvalidMigrationStageError {
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(StackStatus.CREATE_IN_PROGRESS);
+        when(mockContext.getApplicationDeploymentId()).thenReturn(STACK_NAME);
 
         deploySimpleStack();
 

--- a/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -16,14 +16,13 @@
 
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
-import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.aws.db.restore.TargetDbCredentialsStorageService;
 import com.atlassian.migration.datacenter.core.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.dto.MigrationContext;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
-import org.apache.commons.lang3.tuple.Pair;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,13 +34,9 @@ import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 import java.util.HashMap;
 import java.util.Properties;
 
-import static com.atlassian.migration.datacenter.spi.infrastructure.ApplicationDeploymentService.ApplicationDeploymentStatus.CREATE_IN_PROGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -103,7 +98,7 @@ class QuickstartDeploymentServiceTest {
 
         deploySimpleStack();
 
-        assertEquals(CREATE_IN_PROGRESS, deploymentService.getDeploymentStatus());
+        assertEquals(InfrastructureDeploymentStatus.CREATE_IN_PROGRESS, deploymentService.getDeploymentStatus());
     }
 
     @Test


### PR DESCRIPTION
# Summary

* Takes logic from quick start deployment and hoists it into a superclass
* Quickstart and migration template deployment inherit from this class
* Use template method to handle migration stage transitions

## Follow-ups
* Integrating migration stack deployment with state machine