### PR TITLE
FIX: de-dupe rest endpoints

### DIFF
--- a/src/main/java/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.java
+++ b/src/main/java/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-@Path("/migration/fs")
+@Path("/migration/db")
 public class DatabaseMigrationEndpoint
 {
 


### PR DESCRIPTION
DB migration endpoint had same REST path as the fs migration endpoint. This was causing the REST API filter instantiation to fail.