### PR TITLE
CHET-223: Fix kotlin test maven configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,8 +252,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <sourceDirs>${project.basedir}/src/main/java</sourceDirs>
-                            <sourceDirs>${project.basedir}/src/main/kotlin</sourceDirs>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                            </sourceDirs>
                         </configuration>
                     </execution>
                     <execution>
@@ -263,8 +265,10 @@
                             <goal>test-compile</goal>
                         </goals>
                         <configuration>
-                            <sourceDirs>${project.basedir}/src/test/java</sourceDirs>
-                            <sourceDirs>${project.basedir}/src/test/kotlin</sourceDirs>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
                 <version>3.0.0-M4</version>
                 <configuration>
                     <includes>
-                        <include>**/*Test*.java</include>
+                        <include>**/*Test*</include>
                     </includes>
                 </configuration>
             </plugin>
@@ -263,8 +263,8 @@
                             <goal>test-compile</goal>
                         </goals>
                         <configuration>
-                            <sourceDirs>${project.basedir}/src/main/java</sourceDirs>
-                            <sourceDirs>${project.basedir}/src/main/kotlin</sourceDirs>
+                            <sourceDirs>${project.basedir}/src/test/java</sourceDirs>
+                            <sourceDirs>${project.basedir}/src/test/kotlin</sourceDirs>
                         </configuration>
                     </execution>
                 </executions>
@@ -313,7 +313,7 @@
                         <version>3.0.0-M4</version>
                         <configuration>
                             <includes>
-                                <include>**/*IT.java</include>
+                                <include>**/*IT*</include>
                             </includes>
                         </configuration>
                     </plugin>
@@ -387,5 +387,7 @@
         <jackson.version>2.10.3</jackson.version>
         <mockk.version>1.9.3</mockk.version>
         <amps.jvm.args/>
+
+        <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>
 </project>


### PR DESCRIPTION
* Fix the `sourceDirs` for kotlin tests - this is then propagated to child modules
* Removed `.java` qualifier for tests
* Tested also `-Pintegration` profile - even though interestingly we don't have an integration test in `api` package (I had created dummy one for the test)
* Added kotlin incremental compilation - https://kotlinlang.org/docs/reference/using-maven.html#incremental-compilation