### PR TITLE
CHET-183: Update dogfooding on each merge to master

### DIFF
--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -43,3 +43,38 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Test with maven
         run: mvn -B clean verify -P ${{ matrix.profile}}
+      - name: Upload
+        if: github.ref == 'refs/heads/CHET-183-update-dogfooding'
+        uses: actions/upload-artifact@v1
+        with:
+          name: plugin-jar
+          path: jira-plugin/target/jira-plugin-1.0.0.jar
+
+
+  deploy:
+    name: Deploy to dogfooding instance
+    if: github.ref == 'refs/heads/CHET-183-update-dogfooding'
+    runs-on: ubuntu-latest
+    needs: run_tests
+
+    steps:
+      - name: Download plugin jar file from the previous job
+        uses: actions/download-artifact@v1
+        with:
+          name: plugin-jar
+      - name: Deploy to dogfooding
+        env:
+          DOGFOODING_URL: ${{ secrets.DOGFOODING_URL }}
+          DOGFOODING_USER: ${{ secrets.DOGFOODING_USER }}
+          DOGFOODING_PASSWORD: ${{ secrets.DOGFOODING_PASSWORD }}
+        run: |
+          url="$DOGFOODING_URL/rest/plugins/1.0/"
+          token=$(curl -u "$DOGFOODING_USER:$DOGFOODING_PASSWORD" -Is ${url}?os_authType=basic | grep upm-token | cut -d: -f2- | tr -d '[[:space:]]')
+          if [[ -z "$token" ]]; then
+            echo "Token is not set"
+            exit 1
+          else
+            curl -vvv -u "$DOGFOODING_USER:$DOGFOODING_PASSWORD" -POST "${url}?token=${token}" -F plugin=@plugin-jar/jira-plugin-1.0.0.jar | tee install.log
+            grep -E '"type":"INSTALL".*"statusCode":200' install.log
+            exit $?
+          fi

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test with maven
         run: mvn -B clean verify -P ${{ matrix.profile}}
       - name: Upload
-        if: github.ref == 'refs/heads/CHET-183-update-dogfooding'
+        if: github.ref == 'refs/heads/CHET-183-update-dogfooding' && matrix.profile == '!integration' && matrix.java == 11
         uses: actions/upload-artifact@v1
         with:
           name: plugin-jar

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -53,16 +53,17 @@ jobs:
 
   deploy:
     name: Deploy to dogfooding instance
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: run_tests
 
     steps:
       - name: Download plugin jar file from the previous job
+        if: github.ref == 'refs/heads/master'
         uses: actions/download-artifact@v1
         with:
           name: plugin-jar
       - name: Deploy to dogfooding
+        if: github.ref == 'refs/heads/master'
         env:
           DOGFOODING_URL: ${{ secrets.DOGFOODING_URL }}
           DOGFOODING_USER: ${{ secrets.DOGFOODING_USER }}

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test with maven
         run: mvn -B clean verify -P ${{ matrix.profile}}
       - name: Upload
-        if: github.ref == 'refs/heads/CHET-183-update-dogfooding' && matrix.profile == '!integration' && matrix.java == 11
+        if: github.ref == 'refs/heads/master' && matrix.profile == '!integration' && matrix.java == 11
         uses: actions/upload-artifact@v1
         with:
           name: plugin-jar
@@ -53,7 +53,7 @@ jobs:
 
   deploy:
     name: Deploy to dogfooding instance
-    if: github.ref == 'refs/heads/CHET-183-update-dogfooding'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: run_tests
 

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push]
 
+env:
+  DOGFOODING_REF: ${{ secrets.DOGFOODING_REF }}
+
 jobs:
   run_tests:
     name: Java${{ matrix.java }} ${{ matrix.profile }} test
@@ -44,7 +47,7 @@ jobs:
       - name: Test with maven
         run: mvn -B clean verify -P ${{ matrix.profile}}
       - name: Upload
-        if: github.ref == 'refs/heads/master' && matrix.profile == '!integration' && matrix.java == 11
+        if: github.ref == env.DOGFOODING_REF && matrix.profile == '!integration' && matrix.java == 11
         uses: actions/upload-artifact@v1
         with:
           name: plugin-jar
@@ -58,12 +61,12 @@ jobs:
 
     steps:
       - name: Download plugin jar file from the previous job
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == env.DOGFOODING_REF
         uses: actions/download-artifact@v1
         with:
           name: plugin-jar
       - name: Deploy to dogfooding
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == env.DOGFOODING_REF
         env:
           DOGFOODING_URL: ${{ secrets.DOGFOODING_URL }}
           DOGFOODING_USER: ${{ secrets.DOGFOODING_USER }}


### PR DESCRIPTION
I've cleaned up the history of this branch, it was a lot of mess with Github Actions trial and error.

* We need to upload an artifact to share it across jobs
* It needs to be uploaded only from one step from the strategy matrix. I've picked unit tests on Java 11
* The variables are managed from Github secrets
* So far we are doing just a basic check whether the plugin was installed, more extensive tests are coming.
* Branch is now configurable via DOGFOODING_REF github secrets (`refs/heads/master` by default)