### PR TITLE
CHET-232: progress data callbacks

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
@@ -63,7 +63,7 @@ const RegionSelect: FunctionComponent<{ getRegions: QueryRegionFun }> = (props):
         <AsyncSelect
             {...props}
             styles={{
-                control: base => ({ ...base, width: '480.4px' }),
+                control: (base): React.CSSProperties => ({ ...base, width: '480.4px' }),
             }}
             cacheOptions
             defaultOptions

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartStatus.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartStatus.tsx
@@ -28,7 +28,7 @@ const QuickStartStatusContainer = styled.div`
 `;
 
 const stageStatusFlag = (currentProvisioningStatus: string): ReactElement => {
-    const renderProvisioningStatus = (status: string) => {
+    const renderProvisioningStatus = (status: string): ReactElement => {
         if (status === 'CREATE_COMPLETE') {
             return <SuccessIcon primaryColor="#36B37E" label="Success" />;
         }
@@ -91,7 +91,7 @@ export const QuickStartStatus: FunctionComponent = (): ReactElement => {
             getStackStatusFromApi(stackId).finally(() => clearInterval(intervalId));
         }, 5000);
 
-        return () => {
+        return (): void => {
             clearInterval(intervalId);
         };
     }, []);

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -17,8 +17,8 @@
 import React, { FunctionComponent } from 'react';
 
 import { I18n } from '@atlassian/wrm-react-i18n';
-import { MigrationTransferProps, MigrationTransferPage } from '../shared/MigrationTransferPage';
 import moment from 'moment';
+import { MigrationTransferProps, MigrationTransferPage } from '../shared/MigrationTransferPage';
 
 const dummyStarted = moment();
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -41,7 +41,11 @@ const fsMigrationTranferPageProps: MigrationTransferProps = {
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
     started: dummyStarted,
     getProgress: () =>
-        Promise.resolve({ completeness: 0.5, phase: 'upload', progress: '45 000 files copied' }),
+        Promise.resolve({
+            completeness: 0.5,
+            phase: 'uploading files...',
+            progress: '45 000 files copied',
+        }),
 };
 
 export const FileSystemTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -40,6 +40,8 @@ const fsMigrationTranferPageProps: MigrationTransferProps = {
     ],
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
     started: dummyStarted,
+    getProgress: () =>
+        Promise.resolve({ completeness: 0.5, phase: 'upload', progress: '45 000 files copied' }),
 };
 
 export const FileSystemTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -40,12 +40,17 @@ const fsMigrationTranferPageProps: MigrationTransferProps = {
     ],
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
     started: dummyStarted,
-    getProgress: () =>
-        Promise.resolve({
-            completeness: 0.5,
-            phase: 'uploading files...',
-            progress: '45 000 files copied',
-        }),
+    getProgress: () => {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve({
+                    completeness: 0.5,
+                    phase: 'uploading files...',
+                    progress: '45 020 files copied',
+                });
+            }, 500);
+        });
+    },
 };
 
 export const FileSystemTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -82,6 +82,46 @@ const TransferActionsContainer = styled.div`
     margin-top: 20px;
 `;
 
+const renderContentIfLoading = (
+    loading: boolean,
+    progress: Progress,
+    started: Moment
+): ReactElement => {
+    if (loading) {
+        return (
+            <>
+                <Spinner />
+                <ProgressBar isIndeterminate />
+            </>
+        );
+    } else {
+        const elapsedTime = moment.duration(moment.now() - started.valueOf());
+        const elapsedDays = elapsedTime.days();
+        const elapsedHours = elapsedTime.hours();
+        const elapsedMins = elapsedTime.minutes();
+        return (
+            <>
+                <h4>{progress.phase}</h4>
+                <SuccessProgressBar value={progress.completeness} />
+                <p>
+                    {I18n.getText(
+                        'atlassian.migration.datacenter.common.progress.started',
+                        started.format('D/MMM/YY h:m A')
+                    )}
+                </p>
+                <p>
+                    {I18n.getText(
+                        'atlassian.migration.datacenter.common.progress.mins_elapsed',
+                        `${elapsedDays * 24 + elapsedHours}`,
+                        `${elapsedMins}`
+                    )}
+                </p>
+                <p>{loading ? <Spinner /> : progress?.progress}</p>
+            </>
+        );
+    }
+};
+
 export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = ({
     description,
     heading,
@@ -128,34 +168,13 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                 <SectionMessage title={infoTitle} actions={infoActions || []}>
                     {infoContent}
                 </SectionMessage>
-                {loading ? <Spinner /> : <h4>{progress?.phase}</h4>}
-                {loading ? (
-                    <ProgressBar isIndeterminate />
-                ) : progress.completeness == 1 ? (
-                    <SuccessProgressBar value={1} />
-                ) : (
-                    <ProgressBar isIndeterminate={loading} value={progress?.completeness} />
-                )}
-                <p>
-                    {I18n.getText(
-                        'atlassian.migration.datacenter.common.progress.started',
-                        started.format('D/MMM/YY h:m A')
-                    )}
-                </p>
-                <p>
-                    {I18n.getText(
-                        'atlassian.migration.datacenter.common.progress.mins_elapsed',
-                        `${elapsedDays * 24 + elapsedHours}`,
-                        `${elapsedMins}`
-                    )}
-                </p>
-                <p>{loading ? <Spinner /> : progress?.progress}</p>
+                {renderContentIfLoading(loading, progress, started)}
             </TransferContentContainer>
             <TransferActionsContainer>
                 <Link to={overviewPath}>
                     <Button>{I18n.getText('atlassian.migration.datacenter.generic.cancel')}</Button>
                 </Link>
-                <Button appearance="primary" isDisabled={progress?.completeness != 1}>
+                <Button appearance="primary" isDisabled={progress?.completeness !== 1}>
                     {nextText}
                 </Button>
             </TransferActionsContainer>

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -155,7 +155,9 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                 <Link to={overviewPath}>
                     <Button>{I18n.getText('atlassian.migration.datacenter.generic.cancel')}</Button>
                 </Link>
-                <Button appearance="primary">{nextText}</Button>
+                <Button appearance="primary" isDisabled={progress?.completeness != 1}>
+                    {nextText}
+                </Button>
             </TransferActionsContainer>
         </TransferPageContainer>
     );

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -20,10 +20,11 @@ import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 import { Button } from '@atlaskit/button/dist/cjs/components/Button';
 import { Link } from 'react-router-dom';
-import { overviewPath } from '../../utils/RoutePaths';
-import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import moment from 'moment';
 import Spinner from '@atlaskit/spinner';
+
+import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { overviewPath } from '../../utils/RoutePaths';
 
 const POLL_INTERVAL_MILLIS = 60000;
 
@@ -99,8 +100,8 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
             setLoading(true);
             return getProgress()
                 .then(result => {
-                    setLoading(false);
                     setProgress(result);
+                    setLoading(false);
                 })
                 .catch(console.error);
         };
@@ -128,7 +129,13 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                     {infoContent}
                 </SectionMessage>
                 {loading ? <Spinner /> : <h4>{progress?.phase}</h4>}
-                <ProgressBar isIndeterminate={loading} value={progress?.completeness} />
+                {loading ? (
+                    <ProgressBar isIndeterminate />
+                ) : progress.completeness == 1 ? (
+                    <SuccessProgressBar value={1} />
+                ) : (
+                    <ProgressBar isIndeterminate={loading} value={progress?.completeness} />
+                )}
                 <p>
                     {I18n.getText(
                         'atlassian.migration.datacenter.common.progress.started',

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -24,13 +24,23 @@ import { overviewPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import moment from 'moment';
 
-type Action = {
+export type Progress = {
+    phase: string;
+    completeness: 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1.0;
+    progress: string;
+};
+
+export interface ProgressCallback {
+    (): Promise<Progress>;
+}
+
+interface Action {
     text: React.ReactNode;
     onClick?: () => void;
     href?: string;
     key: string;
     testId?: string;
-};
+}
 
 export type MigrationTransferProps = {
     heading: string;
@@ -40,6 +50,7 @@ export type MigrationTransferProps = {
     infoActions?: Action[];
     nextText: string;
     started: moment.Moment;
+    getProgress: ProgressCallback;
 };
 
 const TransferPageContainer = styled.div`

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, useState, useEffect } from 'react';
+import React, { FunctionComponent, useState, useEffect, ReactElement } from 'react';
 import ProgressBar, { SuccessProgressBar } from '@atlaskit/progress-bar';
 import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 import { Button } from '@atlaskit/button/dist/cjs/components/Button';
 import { Link } from 'react-router-dom';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import Spinner from '@atlaskit/spinner';
 
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
@@ -96,7 +96,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
-        const updateProgress = () => {
+        const updateProgress = (): Promise<void> => {
             setLoading(true);
             return getProgress()
                 .then(result => {
@@ -112,7 +112,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
 
         updateProgress();
 
-        return () => clearInterval(id);
+        return (): void => clearInterval(id);
     }, []);
 
     const elapsedTime = moment.duration(moment.now() - started.valueOf());

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -92,34 +92,34 @@ const renderContentIfLoading = (
             <>
                 <Spinner />
                 <ProgressBar isIndeterminate />
-            </>
-        );
-    } else {
-        const elapsedTime = moment.duration(moment.now() - started.valueOf());
-        const elapsedDays = elapsedTime.days();
-        const elapsedHours = elapsedTime.hours();
-        const elapsedMins = elapsedTime.minutes();
-        return (
-            <>
-                <h4>{progress.phase}</h4>
-                <SuccessProgressBar value={progress.completeness} />
-                <p>
-                    {I18n.getText(
-                        'atlassian.migration.datacenter.common.progress.started',
-                        started.format('D/MMM/YY h:m A')
-                    )}
-                </p>
-                <p>
-                    {I18n.getText(
-                        'atlassian.migration.datacenter.common.progress.mins_elapsed',
-                        `${elapsedDays * 24 + elapsedHours}`,
-                        `${elapsedMins}`
-                    )}
-                </p>
-                <p>{loading ? <Spinner /> : progress?.progress}</p>
+                <Spinner />
             </>
         );
     }
+    const elapsedTime = moment.duration(moment.now() - started.valueOf());
+    const elapsedDays = elapsedTime.days();
+    const elapsedHours = elapsedTime.hours();
+    const elapsedMins = elapsedTime.minutes();
+    return (
+        <>
+            <h4>{progress.phase}</h4>
+            <SuccessProgressBar value={progress.completeness} />
+            <p>
+                {I18n.getText(
+                    'atlassian.migration.datacenter.common.progress.started',
+                    started.format('D/MMM/YY h:m A')
+                )}
+            </p>
+            <p>
+                {I18n.getText(
+                    'atlassian.migration.datacenter.common.progress.mins_elapsed',
+                    `${elapsedDays * 24 + elapsedHours}`,
+                    `${elapsedMins}`
+                )}
+            </p>
+            <p>{progress.progress}</p>
+        </>
+    );
 };
 
 export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = ({
@@ -154,11 +154,6 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
 
         return (): void => clearInterval(id);
     }, []);
-
-    const elapsedTime = moment.duration(moment.now() - started.valueOf());
-    const elapsedDays = elapsedTime.days();
-    const elapsedHours = elapsedTime.hours();
-    const elapsedMins = elapsedTime.minutes();
 
     return (
         <TransferPageContainer>

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -23,6 +23,7 @@ import { Link } from 'react-router-dom';
 import { overviewPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import moment from 'moment';
+import Spinner from '@atlaskit/spinner';
 
 const POLL_INTERVAL_MILLIS = 60000;
 
@@ -91,12 +92,16 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     getProgress,
 }) => {
     const [progress, setProgress] = useState<Progress>();
-    const [loading, setLoading] = useState<Boolean>(true);
+    const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
         const updateProgress = () => {
+            setLoading(true);
             return getProgress()
-                .then(setProgress)
+                .then(result => {
+                    setLoading(false);
+                    setProgress(result);
+                })
                 .catch(console.error);
         };
 
@@ -122,8 +127,8 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                 <SectionMessage title={infoTitle} actions={infoActions || []}>
                     {infoContent}
                 </SectionMessage>
-                <h4>{progress?.phase}</h4>
-                <ProgressBar value={progress?.completeness} />
+                {loading ? <Spinner /> : <h4>{progress?.phase}</h4>}
+                <ProgressBar isIndeterminate={loading} value={progress?.completeness} />
                 <p>
                     {I18n.getText(
                         'atlassian.migration.datacenter.common.progress.started',
@@ -137,7 +142,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                         `${elapsedMins}`
                     )}
                 </p>
-                <p>{progress?.progress}</p>
+                <p>{loading ? <Spinner /> : progress?.progress}</p>
             </TransferContentContainer>
             <TransferActionsContainer>
                 <Link to={overviewPath}>


### PR DESCRIPTION
# Summary

* Interface for marking up progress page with actual progress
* Periodically update the data (every minute)
* Handle loading state
* Dummy function in FS page
* "Next" button is disabled until progress is complete

## Follow up

* Actually implement it for the FS page

## Incomplete
![image](https://user-images.githubusercontent.com/21027663/78868850-f56d2a80-7a86-11ea-93a4-3d855358539a.png)


## Complete
![image](https://user-images.githubusercontent.com/21027663/78868816-ea19ff00-7a86-11ea-90f8-a21711b4f44a.png)
