### PR TITLE
CHET-242: Correct "migrated files" count being inflated

### DIFF
--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
@@ -79,7 +79,7 @@ class FileSystemMigrationProgressEndpointTest {
         val responseStatus = tree.at("/status").asText()
         val responseReason = tree.at("/failedFiles/0/reason").asText()
         val responseFailedFile = tree.at("/failedFiles/0/filePath").asText()
-        val responseSuccessFileCount = tree.at("/migratedFiles").asLong()
+        val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
 
         assertEquals(FilesystemMigrationStatus.RUNNING.name, responseStatus)
         assertEquals(testReason, responseReason)
@@ -114,7 +114,7 @@ class FileSystemMigrationProgressEndpointTest {
         val responseStatus = tree.at("/status").asText()
         val responseReason = tree.at("/failedFiles/99/reason").asText()
         val responseFailedFile = tree.at("/failedFiles/99/filePath").asText()
-        val responseSuccessFileCount = tree.at("/migratedFiles").asLong()
+        val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
         assertEquals(FilesystemMigrationStatus.RUNNING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
@@ -65,7 +65,7 @@ class FileSystemMigrationProgressEndpointTest {
             every { numberOfCommencedFileUploads } returns 1L
             every { numberOfFilesFound } returns 1L
             every { failedFiles } returns failedFilesCollection
-            every { countOfMigratedFiles } returns 1L
+            every { countOfUploadedFiles } returns 1L
             every { elapsedTime } returns Duration.ofMinutes(1)
         }
 
@@ -102,7 +102,7 @@ class FileSystemMigrationProgressEndpointTest {
             failedFiles.add(failedFileMigration)
         }
         every { report.failedFiles } returns failedFiles
-        every { report.countOfMigratedFiles } returns 1000000L
+        every { report.countOfUploadedFiles } returns 1000000L
 
         val response = endpoint.getFilesystemMigrationStatus()
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -126,7 +126,7 @@ public class S3Uploader implements Uploader {
                 addFailedFile(operation.path, errorMessage);
             } else {
                 logger.trace("{} migrated successfully", operation.path);
-                report.reportFileMigrated();
+                report.reportFileUploaded();
             }
         } catch (InterruptedException | ExecutionException e) {
             addFailedFile(operation.path, e.getMessage());

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3Uploader.java
@@ -63,14 +63,15 @@ public class S3Uploader implements Uploader {
             logger.error(msg, e);
             throw new FilesystemUploader.FileUploadException(msg, e);
         }
-        responsesQueue.forEach(this::handlePutObjectResponse);
+        logger.debug("Finished uploading all files, acknowledging pending responses");
+        acknowledgeAndFlushResponses();
         logger.info("Finished uploading files to S3");
     }
 
     private void uploadFile(Path path) {
         if (responsesQueue.size() >= MAX_OPEN_CONNECTIONS) {
             logger.trace("Response queue greater than connection threshold. Acknowledging response queue");
-            responsesQueue.forEach(this::handlePutObjectResponse);
+            acknowledgeAndFlushResponses();
         }
 
         if (Files.exists(path)) {
@@ -99,6 +100,16 @@ public class S3Uploader implements Uploader {
             }
         } else {
             addFailedFile(path, String.format("File doesn't exist: %s", path));
+        }
+    }
+
+    private void acknowledgeAndFlushResponses() {
+        final int initialQueueSize = responsesQueue.size();
+        for (int i = 0; i < initialQueueSize; i++) {
+            S3UploadOperation operation = responsesQueue.poll();
+            if (operation != null) {
+                handlePutObjectResponse(operation);
+            }
         }
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -103,7 +103,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     public String toString() {
         return String.format("Filesystem migration report = { status: %s, migratedFiles: %d, erroredFiles: %d }",
                 currentStatus,
-                progress.getCountOfMigratedFiles(),
+                progress.getCountOfUploadedFiles(),
                 errorReport.getFailedFiles().size()
         );
     }
@@ -143,13 +143,13 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public Long getCountOfMigratedFiles() {
-        return progress.getCountOfMigratedFiles();
+    public Long getCountOfUploadedFiles() {
+        return progress.getCountOfUploadedFiles();
     }
 
     @Override
-    public void reportFileMigrated() {
-        progress.reportFileMigrated();
+    public void reportFileUploaded() {
+        progress.reportFileUploaded();
     }
 }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
 
-    private AtomicLong numFilesMigrated = new AtomicLong(0);
+    private AtomicLong numFilesUploaded = new AtomicLong(0);
 
     private AtomicLong filesFound = new AtomicLong(0);
 
@@ -49,12 +49,12 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     }
 
     @Override
-    public Long getCountOfMigratedFiles() {
-        return numFilesMigrated.get();
+    public Long getCountOfUploadedFiles() {
+        return numFilesUploaded.get();
     }
 
     @Override
-    public void reportFileMigrated() {
-        numFilesMigrated.incrementAndGet();
+    public void reportFileUploaded() {
+        numFilesUploaded.incrementAndGet();
     }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderIT.java
@@ -114,7 +114,7 @@ class S3UploaderIT {
                                                 failedMigration.getReason()), (acc, partial) -> acc + "\n" + partial)));
         assertEquals(objectSummaries.size(), 1);
         assertEquals(objectSummaries.get(0).getKey(), tempDir.relativize(file).toString());
-        assertEquals(1, report.getCountOfMigratedFiles());
+        assertEquals(1, report.getCountOfUploadedFiles());
     }
 
     Path addFileToQueue(String fileName) throws IOException, InterruptedException {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -126,7 +126,7 @@ class S3UploaderTest {
         });
 
         submit.get();
-        assertEquals(1, report.getCountOfMigratedFiles());
+        assertEquals(1, report.getCountOfUploadedFiles());
     }
 
     @Test

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -34,14 +34,14 @@ public class DefaultFileSystemMigrationProgressTest {
 
     @Test
     void shouldBeInitialisedWithNoCompleteFiles() {
-        assertEquals(0, sut.getCountOfMigratedFiles());
+        assertEquals(0, sut.getCountOfUploadedFiles());
     }
 
     @Test
     void shouldAddMigratedFileToMigratedFiles() {
-        sut.reportFileMigrated();
+        sut.reportFileUploaded();
 
-        assertEquals(1, sut.getCountOfMigratedFiles());
+        assertEquals(1, sut.getCountOfUploadedFiles());
     }
 
     @Test
@@ -61,8 +61,8 @@ public class DefaultFileSystemMigrationProgressTest {
     @Test
     void shouldHandleLargeNumberOfMigratedFiles() {
         int numFilesToMigrate = 1000000;
-        IntStream.range(0, numFilesToMigrate).forEach(i -> sut.reportFileMigrated());
+        IntStream.range(0, numFilesToMigrate).forEach(i -> sut.reportFileUploaded());
 
-        assertEquals(numFilesToMigrate, sut.getCountOfMigratedFiles());
+        assertEquals(numFilesToMigrate, sut.getCountOfUploadedFiles());
     }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -91,13 +91,13 @@ public class DefaultFileSystemMigrationReportTest {
     @Test
     void shouldDelegateToWrappedProgress() {
         final Path path = Paths.get("file");
-        sut.reportFileMigrated();
+        sut.reportFileUploaded();
 
-        verify(progress).reportFileMigrated();
+        verify(progress).reportFileUploaded();
 
-        sut.getCountOfMigratedFiles();
+        sut.getCountOfUploadedFiles();
 
-        verify(progress).getCountOfMigratedFiles();
+        verify(progress).getCountOfUploadedFiles();
     }
 
     @Test
@@ -151,7 +151,7 @@ public class DefaultFileSystemMigrationReportTest {
     void testToString() {
         final long successfullyMigrated = 888L;
         final int failedFiles = 666;
-        when(progress.getCountOfMigratedFiles()).thenReturn(successfullyMigrated);
+        when(progress.getCountOfUploadedFiles()).thenReturn(successfullyMigrated);
 
         final Set errorList = mock(Set.class);
         when(errorList.size()).thenReturn(failedFiles);

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -44,12 +44,12 @@ public interface FileSystemMigrationProgress {
     /**
      * Gets the number of files which have been successfully migrated
      */
-    @JsonProperty("migratedFiles")
-    Long getCountOfMigratedFiles();
+    @JsonProperty("uploadedFiles")
+    Long getCountOfUploadedFiles();
 
     /**
      * Reports that a file was migrated successfully. Implementers should be careful that the underlying
      * collection is thread safe as this may be called from multiple file upload threads.
      */
-    void reportFileMigrated();
+    void reportFileUploaded();
 }


### PR DESCRIPTION
The queue was not being emptied after "acknowledging" all the responses so we were repeating ourselves many times.