### PR TITLE
CHET-243: remote download status

### DIFF
--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
@@ -67,6 +67,7 @@ class FileSystemMigrationProgressEndpointTest {
             every { failedFiles } returns failedFilesCollection
             every { countOfUploadedFiles } returns 1L
             every { elapsedTime } returns Duration.ofMinutes(1)
+            every { countOfDownloadFiles } returns 1L
         }
 
         val response = endpoint.getFilesystemMigrationStatus()
@@ -80,11 +81,13 @@ class FileSystemMigrationProgressEndpointTest {
         val responseReason = tree.at("/failedFiles/0/reason").asText()
         val responseFailedFile = tree.at("/failedFiles/0/filePath").asText()
         val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
+        val responseDownloadFileCount = tree.at("/downloadedFiles").asLong()
 
         assertEquals(FilesystemMigrationStatus.RUNNING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)
         assertEquals(1, responseSuccessFileCount)
+        assertEquals(1, responseDownloadFileCount)
     }
 
     @Test
@@ -94,6 +97,7 @@ class FileSystemMigrationProgressEndpointTest {
         every { report.elapsedTime } returns Duration.ofMinutes(1)
         every { report.numberOfFilesFound } returns 1000000L
         every { report.numberOfCommencedFileUploads } returns 1000000L
+        every { report.countOfDownloadFiles } returns 1000000L
         val failedFiles: MutableSet<FailedFileMigration?> = HashSet()
         val testReason = "test reason"
         val testFile = Paths.get("file")
@@ -115,10 +119,13 @@ class FileSystemMigrationProgressEndpointTest {
         val responseReason = tree.at("/failedFiles/99/reason").asText()
         val responseFailedFile = tree.at("/failedFiles/99/filePath").asText()
         val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
+        val responseDownloadFileCount = tree.at("/downloadedFiles").asLong()
+
         assertEquals(FilesystemMigrationStatus.RUNNING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)
         assertEquals(1000000, responseSuccessFileCount)
+        assertEquals(1000000, responseDownloadFileCount)
     }
 
     @Test

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -143,7 +143,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
             fsUploader.uploadDirectory(getSharedHomeDir());
 
             logger.info("upload of shared home complete. commencing shared home download");
-            fileSystemDownloadManager.downloadFileSystem();
+            fileSystemDownloadManager.downloadFileSystem(report);
 
             report.setStatus(DONE);
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
@@ -16,6 +16,7 @@
 
 package com.atlassian.migration.datacenter.core.fs.download.s3sync;
 
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ public class S3SyncFileSystemDownloadManager {
         this.downloader = downloader;
     }
 
-    public void downloadFileSystem() throws S3SyncFileSystemDownloader.CannotLaunchCommandException {
+    public void downloadFileSystem(FileSystemMigrationProgress progress) throws S3SyncFileSystemDownloader.CannotLaunchCommandException {
         downloader.initiateFileSystemDownload();
 
         CompletableFuture<?> syncCompleteFuture = new CompletableFuture<>();
@@ -43,7 +44,10 @@ public class S3SyncFileSystemDownloadManager {
         ScheduledFuture<?> scheduledFuture = Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
             S3SyncCommandStatus status = downloader.getFileSystemDownloadStatus();
 
+            long remaining = status.getFilesRemainingToDownload();
+            long downloadedFiles = progress.getCountOfUploadedFiles() - remaining;
 
+            progress.setNumberOfFilesDownloaded(downloadedFiles);
 
             logger.debug("got status of file system download: " + status.toString());
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
@@ -43,6 +43,8 @@ public class S3SyncFileSystemDownloadManager {
         ScheduledFuture<?> scheduledFuture = Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
             S3SyncCommandStatus status = downloader.getFileSystemDownloadStatus();
 
+
+
             logger.debug("got status of file system download: " + status.toString());
 
             if (status.isComplete()) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -151,5 +151,15 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     public void reportFileUploaded() {
         progress.reportFileUploaded();
     }
+
+    @Override
+    public Long getCountOfDownloadFiles() {
+        return progress.getCountOfDownloadFiles();
+    }
+
+    @Override
+    public void setNumberOfFilesDownloaded(long downloadedFiles) {
+        progress.setNumberOfFilesDownloaded(downloadedFiles);
+    }
 }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -28,6 +28,8 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
 
     private AtomicLong fileUploadsCommenced = new AtomicLong(0);
 
+    private AtomicLong fileDownloadsCompleted = new AtomicLong(0);
+
     @Override
     public Long getNumberOfFilesFound() {
         return filesFound.get();
@@ -56,5 +58,15 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     @Override
     public void reportFileUploaded() {
         numFilesUploaded.incrementAndGet();
+    }
+
+    @Override
+    public Long getCountOfDownloadFiles() {
+        return fileDownloadsCompleted.get();
+    }
+
+    @Override
+    public void setNumberOfFilesDownloaded(long downloadedFiles) {
+        fileDownloadsCompleted.set(downloadedFiles);
     }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManagerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManagerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.download.s3sync;
+
+import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFilesystemMigrationProgress;
+import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3SyncFileSystemDownloadManagerTest {
+
+    @Mock
+    private S3SyncFileSystemDownloader mockDownloader;
+
+    @Mock
+    private S3SyncCommandStatus mockStatus;
+
+    @InjectMocks
+    private S3SyncFileSystemDownloadManager sut;
+
+    @Test
+    void shouldSetDownloadedFiles() throws S3SyncFileSystemDownloader.CannotLaunchCommandException, InterruptedException {
+        when(mockDownloader.getFileSystemDownloadStatus()).thenReturn(mockStatus);
+        when(mockStatus.getFilesRemainingToDownload()).thenReturn(100);
+
+        FileSystemMigrationProgress progress = new DefaultFilesystemMigrationProgress();
+        for (int i = 0; i < 110; i++) {
+            progress.reportFileUploaded();
+        }
+
+        sut.downloadFileSystem(progress);
+
+        Thread.sleep(1000);
+
+        assertEquals(10, progress.getCountOfDownloadFiles());
+    }
+
+}

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -52,4 +52,14 @@ public interface FileSystemMigrationProgress {
      * collection is thread safe as this may be called from multiple file upload threads.
      */
     void reportFileUploaded();
+
+    /**
+     * Gets the number of files that have been successfully downloaded on the remote application
+     */
+    Long getCountOfDownloadFiles();
+
+    /**
+     * Sets the number of files which were downloaded on the remote application
+     */
+    void setNumberOfFilesDownloaded(long downloadedFiles);
 }

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -56,6 +56,7 @@ public interface FileSystemMigrationProgress {
     /**
      * Gets the number of files that have been successfully downloaded on the remote application
      */
+    @JsonProperty("downloadedFiles")
     Long getCountOfDownloadFiles();
 
     /**


### PR DESCRIPTION
Computes the number of files downloaded on the remote application using the S3 sync output and the known number of files on the system.

## NB

Could fail if Jira is restarted during the migration as the report is not persisted to DB