### PR TITLE
CHET-236: expose fs migration meta status

### DIFF
--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
@@ -61,7 +61,7 @@ class FileSystemMigrationProgressEndpointTest {
         val failedFilesCollection = hashSetOf<FailedFileMigration>()
         failedFilesCollection.add(failedFileMigration)
         every { fsMigrationService.report } returns mockk {
-            every { status } returns FilesystemMigrationStatus.RUNNING
+            every { status } returns FilesystemMigrationStatus.UPLOADING
             every { numberOfCommencedFileUploads } returns 1L
             every { numberOfFilesFound } returns 1L
             every { failedFiles } returns failedFilesCollection
@@ -83,7 +83,7 @@ class FileSystemMigrationProgressEndpointTest {
         val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
         val responseDownloadFileCount = tree.at("/downloadedFiles").asLong()
 
-        assertEquals(FilesystemMigrationStatus.RUNNING.name, responseStatus)
+        assertEquals(FilesystemMigrationStatus.UPLOADING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)
         assertEquals(1, responseSuccessFileCount)
@@ -93,7 +93,7 @@ class FileSystemMigrationProgressEndpointTest {
     @Test
     fun shouldHandleVeryLargeReport() {
         every { fsMigrationService.report } returns report
-        every { report.status } returns FilesystemMigrationStatus.RUNNING
+        every { report.status } returns FilesystemMigrationStatus.UPLOADING
         every { report.elapsedTime } returns Duration.ofMinutes(1)
         every { report.numberOfFilesFound } returns 1000000L
         every { report.numberOfCommencedFileUploads } returns 1000000L
@@ -121,7 +121,7 @@ class FileSystemMigrationProgressEndpointTest {
         val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
         val responseDownloadFileCount = tree.at("/downloadedFiles").asLong()
 
-        assertEquals(FilesystemMigrationStatus.RUNNING.name, responseStatus)
+        assertEquals(FilesystemMigrationStatus.UPLOADING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)
         assertEquals(1000000, responseSuccessFileCount)
@@ -144,14 +144,14 @@ class FileSystemMigrationProgressEndpointTest {
     @Test
     fun shouldNotRunFileMigrationWhenExistingMigrationIsInProgress() {
         val reportMock = mockk<FileSystemMigrationReport>()
-        every { reportMock.status } returns FilesystemMigrationStatus.RUNNING
+        every { reportMock.status } returns FilesystemMigrationStatus.UPLOADING
         every { fsMigrationService.isRunning } returns true
         every { fsMigrationService.report } returns reportMock
 
         val response = endpoint.runFileMigration()
 
         assertEquals(Response.Status.CONFLICT.statusCode, response.status)
-        assertEquals(FilesystemMigrationStatus.RUNNING, (response.entity as MutableMap<*, *>)["status"])
+        assertEquals(FilesystemMigrationStatus.UPLOADING, (response.entity as MutableMap<*, *>)["status"])
     }
 
     @Test

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
@@ -49,7 +49,7 @@ public abstract class SuccessfulSSMCommandConsumer<T> {
             }
 
             try {
-                Thread.sleep(1000);
+                Thread.sleep(10000);
             } catch (InterruptedException e) {
                 logger.error("interrupted while waiting for s3 sync ssm command to be delivered", e);
                 throw new UnsuccessfulSSMCommandInvocationException("Interrupted while waiting to check command status", e);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -40,8 +40,9 @@ import java.nio.file.Paths;
 
 import static com.atlassian.migration.datacenter.spi.MigrationStage.FS_MIGRATION_COPY;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DOWNLOADING;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
-import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.UPLOADING;
 
 public class S3FilesystemMigrationService implements FilesystemMigrationService {
     private static final Logger logger = LoggerFactory.getLogger(S3FilesystemMigrationService.class);
@@ -129,7 +130,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
         report = new DefaultFileSystemMigrationReport();
 
         migrationService.transition(MigrationStage.FS_MIGRATION_COPY_WAIT);
-        report.setStatus(RUNNING);
+        report.setStatus(UPLOADING);
 
         Crawler homeCrawler = new DirectoryStreamCrawler(report);
 
@@ -143,6 +144,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
             fsUploader.uploadDirectory(getSharedHomeDir());
 
             logger.info("upload of shared home complete. commencing shared home download");
+            report.setStatus(DOWNLOADING);
             fileSystemDownloadManager.downloadFileSystem();
 
             report.setStatus(DONE);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/download/s3sync/S3SyncFileSystemDownloadManager.java
@@ -49,7 +49,7 @@ public class S3SyncFileSystemDownloadManager {
                 logger.debug("file system download is complete");
                 syncCompleteFuture.complete(null);
             }
-        }, 0, 5, TimeUnit.MINUTES);
+        }, 0, 10, TimeUnit.SECONDS);
 
         syncCompleteFuture.whenComplete((_i, _j) -> scheduledFuture.cancel(true));
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -28,9 +28,10 @@ import java.time.Instant;
 import java.util.Set;
 
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DOWNLOADING;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
-import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.UPLOADING;
 
 public class DefaultFileSystemMigrationReport implements FileSystemMigrationReport {
 
@@ -80,7 +81,7 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     private boolean isRunning() {
-        return currentStatus == RUNNING;
+        return currentStatus == UPLOADING || currentStatus == DOWNLOADING;
     }
 
     public void setClock(Clock clock) {
@@ -88,11 +89,11 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     private boolean isStartingMigration(FilesystemMigrationStatus toStatus) {
-        return this.currentStatus != RUNNING && toStatus == RUNNING;
+        return !isRunning() && toStatus == UPLOADING;
     }
 
     private boolean isEndingMigration(FilesystemMigrationStatus toStatus) {
-        return this.currentStatus == RUNNING && isTerminalState(toStatus);
+        return isRunning() && isTerminalState(toStatus);
     }
 
     private boolean isTerminalState(FilesystemMigrationStatus toStatus) {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReportTest.java
@@ -40,7 +40,7 @@ import java.util.Set;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.NOT_STARTED;
-import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.RUNNING;
+import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.UPLOADING;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -105,7 +105,7 @@ public class DefaultFileSystemMigrationReportTest {
         Clock testClock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
         sut.setClock(testClock);
 
-        sut.setStatus(RUNNING);
+        sut.setStatus(UPLOADING);
 
         assertEquals(Duration.ZERO, sut.getElapsedTime());
 
@@ -119,12 +119,12 @@ public class DefaultFileSystemMigrationReportTest {
         Clock testClock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
         sut.setClock(testClock);
 
-        sut.setStatus(RUNNING);
+        sut.setStatus(UPLOADING);
 
         sut.setClock(Clock.offset(testClock, Duration.ofSeconds(10)));
         assertEquals(10L, sut.getElapsedTime().getSeconds());
 
-        sut.setStatus(RUNNING);
+        sut.setStatus(UPLOADING);
         assertEquals(10L, sut.getElapsedTime().getSeconds());
 
         sut.setClock(Clock.offset(testClock, Duration.ofSeconds(20)));
@@ -137,7 +137,7 @@ public class DefaultFileSystemMigrationReportTest {
         Clock testClock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
         sut.setClock(testClock);
 
-        sut.setStatus(RUNNING);
+        sut.setStatus(UPLOADING);
 
         sut.setClock(Clock.offset(testClock, Duration.ofSeconds(10)));
         assertEquals(10L, sut.getElapsedTime().getSeconds());

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FilesystemMigrationStatus.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FilesystemMigrationStatus.java
@@ -19,6 +19,7 @@ package com.atlassian.migration.datacenter.spi.fs.reporting;
 public enum FilesystemMigrationStatus {
     NOT_STARTED,
     FAILED,
-    RUNNING,
+    UPLOADING,
+    DOWNLOADING,
     DONE
 }


### PR DESCRIPTION
* When uploading to S3 set status of FS migration to "UPLOADING"
* When downloading on remote host, set status to "DOWNLOADING".
* This allows us to expose more state in the UI.