### PR TITLE
CHET-244: expose when fs crawl is complete

### DIFF
--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
@@ -38,6 +38,7 @@ import java.nio.file.Paths
 import java.time.Duration
 import java.util.HashSet
 import javax.ws.rs.core.Response
+import kotlin.test.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class FileSystemMigrationProgressEndpointTest {
@@ -68,6 +69,7 @@ class FileSystemMigrationProgressEndpointTest {
             every { countOfUploadedFiles } returns 1L
             every { elapsedTime } returns Duration.ofMinutes(1)
             every { countOfDownloadFiles } returns 1L
+            every { isCrawlingFinished } returns true
         }
 
         val response = endpoint.getFilesystemMigrationStatus()
@@ -82,12 +84,14 @@ class FileSystemMigrationProgressEndpointTest {
         val responseFailedFile = tree.at("/failedFiles/0/filePath").asText()
         val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
         val responseDownloadFileCount = tree.at("/downloadedFiles").asLong()
+        val responseAllFilesFound = tree.at("/crawlingFinished").asBoolean()
 
         assertEquals(FilesystemMigrationStatus.UPLOADING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)
         assertEquals(1, responseSuccessFileCount)
         assertEquals(1, responseDownloadFileCount)
+        assertTrue(responseAllFilesFound)
     }
 
     @Test
@@ -98,6 +102,7 @@ class FileSystemMigrationProgressEndpointTest {
         every { report.numberOfFilesFound } returns 1000000L
         every { report.numberOfCommencedFileUploads } returns 1000000L
         every { report.countOfDownloadFiles } returns 1000000L
+        every { report.isCrawlingFinished } returns true
         val failedFiles: MutableSet<FailedFileMigration?> = HashSet()
         val testReason = "test reason"
         val testFile = Paths.get("file")
@@ -120,12 +125,14 @@ class FileSystemMigrationProgressEndpointTest {
         val responseFailedFile = tree.at("/failedFiles/99/filePath").asText()
         val responseSuccessFileCount = tree.at("/uploadedFiles").asLong()
         val responseDownloadFileCount = tree.at("/downloadedFiles").asLong()
+        val responseAllFilesFound = tree.at("/crawlingFinished").asBoolean()
 
         assertEquals(FilesystemMigrationStatus.UPLOADING.name, responseStatus)
         assertEquals(testReason, responseReason)
         assertEquals(testFile.toUri().toString(), responseFailedFile)
         assertEquals(1000000, responseSuccessFileCount)
         assertEquals(1000000, responseDownloadFileCount)
+        assertTrue(responseAllFilesFound)
     }
 
     @Test

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -53,7 +53,7 @@ public class DirectoryStreamCrawler implements Crawler {
         } finally {
             try {
                 logger.info("Crawled and added {} files for upload.", report.getNumberOfFilesFound());
-                report.reportAllFilesFound();
+                report.reportCrawlingFinished();
                 queue.finish();
             } catch (InterruptedException e) {
                 logger.error("Failed to finalise upload queue.", e);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -44,8 +44,6 @@ public class DirectoryStreamCrawler implements Crawler {
             final DirectoryStream<Path> paths;
             paths = Files.newDirectoryStream(start);
             listDirectories(queue, paths);
-            logger.info("Crawled and added {} files for upload.", report.getNumberOfFilesFound());
-
         } catch (NoSuchFileException e) {
             logger.error("Failed to find path " + start, e);
             report.reportFileNotMigrated(new FailedFileMigration(start, e.getMessage()));
@@ -54,6 +52,8 @@ public class DirectoryStreamCrawler implements Crawler {
 
         } finally {
             try {
+                logger.info("Crawled and added {} files for upload.", report.getNumberOfFilesFound());
+                report.reportAllFilesFound();
                 queue.finish();
             } catch (InterruptedException e) {
                 logger.error("Failed to finalise upload queue.", e);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -133,6 +133,16 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
+    public boolean allFilesFound() {
+        return progress.allFilesFound();
+    }
+
+    @Override
+    public void reportAllFilesFound() {
+        progress.reportAllFilesFound();
+    }
+
+    @Override
     public Long getNumberOfCommencedFileUploads() {
         return progress.getNumberOfCommencedFileUploads();
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationReport.java
@@ -134,13 +134,13 @@ public class DefaultFileSystemMigrationReport implements FileSystemMigrationRepo
     }
 
     @Override
-    public boolean allFilesFound() {
-        return progress.allFilesFound();
+    public boolean isCrawlingFinished() {
+        return progress.isCrawlingFinished();
     }
 
     @Override
-    public void reportAllFilesFound() {
-        progress.reportAllFilesFound();
+    public void reportCrawlingFinished() {
+        progress.reportCrawlingFinished();
     }
 
     @Override

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -44,12 +44,12 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     }
 
     @Override
-    public boolean allFilesFound() {
+    public boolean isCrawlingFinished() {
         return allFilesFound.get();
     }
 
     @Override
-    public void reportAllFilesFound() {
+    public void reportCrawlingFinished() {
         allFilesFound.set(true);
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFilesystemMigrationProgress.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.core.fs.reporting;
 
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationProgress;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DefaultFilesystemMigrationProgress implements FileSystemMigrationProgress {
@@ -25,6 +26,8 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     private AtomicLong numFilesUploaded = new AtomicLong(0);
 
     private AtomicLong filesFound = new AtomicLong(0);
+
+    private AtomicBoolean allFilesFound = new AtomicBoolean(false);
 
     private AtomicLong fileUploadsCommenced = new AtomicLong(0);
 
@@ -38,6 +41,16 @@ public class DefaultFilesystemMigrationProgress implements FileSystemMigrationPr
     @Override
     public void reportFileFound() {
         filesFound.incrementAndGet();
+    }
+
+    @Override
+    public boolean allFilesFound() {
+        return allFilesFound.get();
+    }
+
+    @Override
+    public void reportAllFilesFound() {
+        allFilesFound.set(true);
     }
 
     @Override

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
@@ -79,6 +79,14 @@ class DirectoryStreamCrawlerTest {
     }
 
     @Test
+    void shouldReportAllFilesFoundWhenComplete() throws IOException {
+        directoryStreamCrawler = new DirectoryStreamCrawler(report);
+        directoryStreamCrawler.crawlDirectory(tempDir, queue);
+
+        assertTrue(report.allFilesFound());
+    }
+
+    @Test
     @Disabled("Simulating AccessDenied permission proved complicated in an unit test")
     void inaccessibleSubdirectoryIsReportedAsFailed() throws IOException {
         final Path directory = Files.createDirectory(tempDir.resolve("non-readable-subdir"),

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
@@ -83,7 +83,7 @@ class DirectoryStreamCrawlerTest {
         directoryStreamCrawler = new DirectoryStreamCrawler(report);
         directoryStreamCrawler.crawlDirectory(tempDir, queue);
 
-        assertTrue(report.allFilesFound());
+        assertTrue(report.isCrawlingFinished());
     }
 
     @Test

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -69,7 +69,7 @@ public class DefaultFileSystemMigrationProgressTest {
 
     @Test
     void shouldNoteWhenAllFilesAreFound() {
-        sut.reportAllFilesFound();
-        assertTrue(sut.allFilesFound());
+        sut.reportCrawlingFinished();
+        assertTrue(sut.isCrawlingFinished());
     }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/reporting/DefaultFileSystemMigrationProgressTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultFileSystemMigrationProgressTest {
 
@@ -64,5 +65,11 @@ public class DefaultFileSystemMigrationProgressTest {
         IntStream.range(0, numFilesToMigrate).forEach(i -> sut.reportFileUploaded());
 
         assertEquals(numFilesToMigrate, sut.getCountOfUploadedFiles());
+    }
+
+    @Test
+    void shouldNoteWhenAllFilesAreFound() {
+        sut.reportAllFilesFound();
+        assertTrue(sut.allFilesFound());
     }
 }

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -34,6 +34,17 @@ public interface FileSystemMigrationProgress {
     void reportFileFound();
 
     /**
+     * @return true if all files have been discovered by the migration, false otherwise. At this point, {@link FileSystemMigrationProgress#getNumberOfFilesFound()}
+     * should return the number of files that will be migrated
+     */
+    boolean allFilesFound();
+
+    /**
+     * Reports that the migration has finished discovering files to be migrated
+     */
+    void reportAllFilesFound();
+
+    /**
      * Gets the number of files which have had their upload commenced
      */
     @JsonProperty("filesInFlight")

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -37,12 +37,12 @@ public interface FileSystemMigrationProgress {
      * @return true if all files have been discovered by the migration, false otherwise. At this point, {@link FileSystemMigrationProgress#getNumberOfFilesFound()}
      * should return the number of files that will be migrated
      */
-    boolean allFilesFound();
+    boolean isCrawlingFinished();
 
     /**
      * Reports that the migration has finished discovering files to be migrated
      */
-    void reportAllFilesFound();
+    void reportCrawlingFinished();
 
     /**
      * Gets the number of files which have had their upload commenced

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/fs/reporting/FileSystemMigrationProgress.java
@@ -37,6 +37,7 @@ public interface FileSystemMigrationProgress {
      * @return true if all files have been discovered by the migration, false otherwise. At this point, {@link FileSystemMigrationProgress#getNumberOfFilesFound()}
      * should return the number of files that will be migrated
      */
+    @JsonProperty("crawlingFinished")
     boolean isCrawlingFinished();
 
     /**


### PR DESCRIPTION
We expose when FS crawl is complete because at that point you can determine the exact progress of the migration by checking the `filesFound` of the fs migration status.