### PR TITLE
CHET-245: Remove FS progress strings; increase poll rate of FS progress

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -37,7 +37,7 @@ const getFsMigrationProgress = (): Promise<Progress> => {
             if (result.status === 'UPLOADING') {
                 const progress: Progress = {
                     phase: 'Uploading files to AWS',
-                    progress: `${result.uploadedFiles} files uploaded`,
+                    progress: '',
                 };
 
                 if (result.crawlingFinished) {
@@ -55,7 +55,7 @@ const getFsMigrationProgress = (): Promise<Progress> => {
                 const weightedProgress = 0.5 + 0.5 * downloadProgress;
                 return {
                     phase: 'Loading files into target application',
-                    progress: `${result.downloadedFiles} files loaded`,
+                    progress: '',
                     completeness: weightedProgress,
                 };
             }
@@ -69,13 +69,13 @@ const getFsMigrationProgress = (): Promise<Progress> => {
             if (result.status === 'NOT_STARTED') {
                 return {
                     phase: 'Preparing to migrate files',
-                    progress: '...',
+                    progress: '',
                 };
             }
             return {
                 phase: 'error',
                 completeness: 0,
-                progress: 'error',
+                progress: '',
             };
         })
         .catch(err => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -26,7 +26,7 @@ import Spinner from '@atlaskit/spinner';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { overviewPath } from '../../utils/RoutePaths';
 
-const POLL_INTERVAL_MILLIS = 10000;
+const POLL_INTERVAL_MILLIS = 3000;
 
 export type Progress = {
     phase: string;


### PR DESCRIPTION
This is after getting feedack from Hanna. Having the file progress going from a large number to zero then counting up again is confusing. We will just use the progress bar.