### PR TITLE
CHET-263: Fix DB upload + some other bugs

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/CfnApi.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/CfnApi.java
@@ -31,7 +31,6 @@ import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourc
 import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourcesResponse;
 import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest;
 import software.amazon.awssdk.services.cloudformation.model.DescribeStacksResponse;
-import software.amazon.awssdk.services.cloudformation.model.ListExportsRequest;
 import software.amazon.awssdk.services.cloudformation.model.ListExportsResponse;
 import software.amazon.awssdk.services.cloudformation.model.Parameter;
 import software.amazon.awssdk.services.cloudformation.model.Stack;
@@ -54,10 +53,13 @@ import java.util.stream.Collectors;
 public class CfnApi {
     private static final Logger logger = LoggerFactory.getLogger(CfnApi.class);
 
+    /**
+     * Stored client is only used for testing purposes
+     */
+    private final Optional<CloudFormationAsyncClient> client;
+
     private AwsCredentialsProvider credentialsProvider;
     private RegionService regionManager;
-
-    private Optional<CloudFormationAsyncClient> client;
 
     public CfnApi(AwsCredentialsProvider credentialsProvider, RegionService regionManager) {
         this.credentialsProvider = credentialsProvider;
@@ -66,7 +68,8 @@ public class CfnApi {
     }
 
     /**
-     * Package private constructor to consume a CFn Async Client. Currently used for testing. This will not be called by spring as no injectable <code>CloudFormationAsyncClient</code> instance exists in the container.
+     * Package private constructor to consume a CFn Async Client. Currently used for testing.
+     * his will not be called by spring as no injectable <code>CloudFormationAsyncClient</code> instance exists in the container.
      *
      * @param client An async CloudFormation client
      */
@@ -75,20 +78,15 @@ public class CfnApi {
     }
 
     /**
-     * Lazily create a CFN client; should only be called after necessary AWS information has been provided.
+     * Return a client should only be called after necessary AWS information has been provided.
      */
     private CloudFormationAsyncClient getClient() {
-        if (client.isPresent()) {
-            return client.get();
-        }
+        return client.orElseGet(
+                () -> CloudFormationAsyncClient.builder()
+                        .credentialsProvider(credentialsProvider)
+                        .region(Region.of(regionManager.getRegion()))
+                        .build());
 
-        CloudFormationAsyncClient client = CloudFormationAsyncClient.builder()
-                .credentialsProvider(credentialsProvider)
-                .region(Region.of(regionManager.getRegion()))
-                .build();
-
-        this.client = Optional.of(client);
-        return client;
     }
 
     public InfrastructureDeploymentStatus getStatus(String stackName) {
@@ -153,6 +151,7 @@ public class CfnApi {
 
     /**
      * Gets all Cloudformation exports. If there is an error retrieving the exports, an empty map will be returned
+     *
      * @return A map (of export name to export value) containing all cloudformation exports for the current region in the current account.
      */
     public Map<String, String> getExports() {
@@ -171,6 +170,7 @@ public class CfnApi {
 
     /**
      * Gets all resources for the given stack. If there is an error retrieving the resources, an empty map will be returned
+     *
      * @param stackName the name of the stack to get the resources of
      * @return a map of the logical resource ID to the resource for all resources in the given stack
      */

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
@@ -42,6 +42,7 @@ public class DatabaseArtifactS3UploadService {
     }
 
     public FileSystemMigrationReport upload(Path target, String targetBucketName, DatabaseUploadStageTransitionCallback callback) throws InvalidMigrationStageError, FilesystemUploader.FileUploadException {
+        s3AsyncClient = s3AsyncClientSupplier.get();
         callback.assertInStartingStage();
         FilesystemUploader filesystemUploader = buildFileSystemUploader(target, targetBucketName, fileSystemMigrationReport, s3AsyncClient);
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -39,8 +39,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class DatabaseMigrationService
-{
+public class DatabaseMigrationService {
     private static Logger logger = LoggerFactory.getLogger(DatabaseMigrationService.class);
 
     private final Path tempDirectory;
@@ -52,7 +51,7 @@ public class DatabaseMigrationService
     private final DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback;
     private final MigrationService migrationService;
     private final MigrationRunner migrationRunner;
-    private final AWSMigrationHelperDeploymentService  migrationHelperDeploymentService;
+    private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
 
     private final AtomicReference<Optional<LocalDateTime>> startTime = new AtomicReference<>(Optional.empty());
 
@@ -64,8 +63,8 @@ public class DatabaseMigrationService
                                     DatabaseArtifactS3UploadService s3UploadService,
                                     DatabaseUploadStageTransitionCallback uploadStageTransitionCallback,
                                     SsmPsqlDatabaseRestoreService restoreService,
-                                    DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback, AWSMigrationHelperDeploymentService migrationHelperDeploymentService)
-    {
+                                    DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback,
+                                    AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this.tempDirectory = tempDirectory;
         this.databaseArchivalService = databaseArchivalService;
         this.stageTransitionCallback = stageTransitionCallback;
@@ -82,8 +81,7 @@ public class DatabaseMigrationService
      * Start database dump and upload to S3 bucket. This is a blocking operation and should be started from ExecutorService
      * or preferably from ScheduledJob. The status of the migration can be queried via getStatus().
      */
-    public FileSystemMigrationErrorReport performMigration() throws DatabaseMigrationFailure, InvalidMigrationStageError
-    {
+    public FileSystemMigrationErrorReport performMigration() throws DatabaseMigrationFailure, InvalidMigrationStageError {
         migrationService.transition(MigrationStage.DB_MIGRATION_EXPORT);
         startTime.set(Optional.of(LocalDateTime.now()));
 
@@ -112,7 +110,7 @@ public class DatabaseMigrationService
             migrationService.error(e);
             throw new DatabaseMigrationFailure("Error when restoring database", e);
         }
-        migrationService.transition(MigrationStage.DB_MIGRATION_UPLOAD_WAIT);
+        migrationService.transition(MigrationStage.VALIDATE);
 
         return report;
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -28,7 +28,6 @@ import com.atlassian.migration.datacenter.spi.exceptions.DatabaseMigrationFailur
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationErrorReport;
 import com.atlassian.scheduler.config.JobId;
-import org.checkerframework.checker.nullness.Opt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +35,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class DatabaseMigrationService {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadServiceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.db;
+
+import com.atlassian.util.concurrent.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class DatabaseArtifactS3UploadServiceTest {
+
+    @TempDir
+    Path path;
+
+    @Mock
+    Supplier<S3AsyncClient> s3AsyncClientSupplier;
+
+    @Mock
+    DatabaseUploadStageTransitionCallback databaseUploadStageTransitionCallback;
+
+    @InjectMocks
+    DatabaseArtifactS3UploadService sut;
+
+    @Test
+    void serviceShouldInstantiateS3ClientFromSupplier() throws Exception {
+        sut.upload(path, "bucketName", databaseUploadStageTransitionCallback);
+        verify(s3AsyncClientSupplier).get();
+    }
+
+    @Test
+    void serviceShouldTransitionThroughExpectedStages() throws Exception {
+        sut.upload(path, "bucketName", databaseUploadStageTransitionCallback);
+        verify(databaseUploadStageTransitionCallback).assertInStartingStage();
+        verify(databaseUploadStageTransitionCallback).transitionToServiceWaitStage();
+        verify(databaseUploadStageTransitionCallback).transitionToServiceNextStage();
+    }
+}

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.db;
+
+import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService;
+import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
+import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFileSystemMigrationReport;
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.MigrationStage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DatabaseMigrationServiceTest {
+
+    @Mock
+    MigrationService migrationService;
+
+    @Mock
+    Path tempDirectory;
+
+    @Mock
+    AWSMigrationHelperDeploymentService awsMigrationHelperDeploymentService;
+
+    @Mock
+    SsmPsqlDatabaseRestoreService restoreService;
+
+    @Mock
+    DatabaseArchivalService databaseArchivalService;
+
+    @Mock
+    DatabaseArtifactS3UploadService s3UploadService;
+
+    @InjectMocks
+    DatabaseMigrationService sut;
+
+    @Test
+    void databaseMigrationShouldExecuteCorrectTransitions() throws Exception {
+        final String s3bucket = "s3bucket";
+        final Path filePath = Paths.get("path");
+        final DefaultFileSystemMigrationReport report = new DefaultFileSystemMigrationReport();
+
+        InOrder inOrder = inOrder(migrationService);
+        when(awsMigrationHelperDeploymentService.getMigrationS3BucketName()).thenReturn(s3bucket);
+        when(databaseArchivalService.archiveDatabase(eq(tempDirectory), any())).thenReturn(filePath);
+        when(s3UploadService.upload(eq(filePath), eq(s3bucket), any())).thenReturn(report);
+        sut.performMigration();
+
+        inOrder.verify(migrationService).transition(MigrationStage.DB_MIGRATION_EXPORT);
+        inOrder.verify(migrationService).transition(MigrationStage.DB_MIGRATION_EXPORT_WAIT);
+        inOrder.verify(migrationService).transition(MigrationStage.DB_MIGRATION_UPLOAD);
+        inOrder.verify(migrationService).transition(MigrationStage.DB_MIGRATION_UPLOAD_WAIT);
+        inOrder.verify(migrationService).transition(MigrationStage.DATA_MIGRATION_IMPORT);
+        inOrder.verify(migrationService).transition(MigrationStage.VALIDATE);
+        verifyNoMoreInteractions(migrationService);
+    }
+
+}


### PR DESCRIPTION
* Fix `S3AsyncClient` initialisation in `DatabaseArtifactS3UploadService` - the client was null because our `@PostConstruct` methods are not working so for now we need to init the client manually
* I've removed stored `CfnApi` client as it is storing a state that is possible to change and the client would be stale.
* Add tests to cover the case (+some more)