### PR TITLE
CHET-280: Wire up start db transfer

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.kt
@@ -86,7 +86,7 @@ class DatabaseMigrationEndpoint(
         } catch (e: JsonProcessingException) {
             Response
                 .serverError()
-                .entity("Unable to get file system status. Please contact support and show them this error: ${e.message}")
+                .entity("Unable to get db migration status. Please contact support and show them this error: ${e.message}")
                 .build()
         }
     }
@@ -103,7 +103,7 @@ class DatabaseMigrationEndpoint(
         } catch (e: InvalidMigrationStageError) {
             Response
                 .status(Response.Status.CONFLICT)
-                .entity(mapOf("error" to "filesystem migration is not in progress"))
+                .entity(mapOf("error" to "db migration is not in progress"))
                 .build()
         }
     }

--- a/frontend/src/main/dc-migration-assistant-fe/api/db.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/db.ts
@@ -18,6 +18,7 @@ import { MigrationDuration } from './common';
 
 const dbAPIBase = 'migration/db';
 export const dbStatusReportEndpoint = `${dbAPIBase}/report`;
+export const dbStartEndpoint = `${dbAPIBase}/start`;
 
 export enum DBMigrationStatus {
     NOT_STARTED,

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -20,6 +20,7 @@ import { I18n } from '@atlassian/wrm-react-i18n';
 import { MigrationTransferPage } from '../../shared/MigrationTransferPage';
 import { ProgressBuilder, ProgressCallback } from '../../shared/Progress';
 import { provisioning, ProvisioningStatus } from '../../../api/provisioning';
+import { MigrationStage } from '../../../api/migration';
 
 const getDeploymentProgress: ProgressCallback = () => {
     return provisioning
@@ -62,12 +63,19 @@ const getDeploymentProgress: ProgressCallback = () => {
         });
 };
 
+const inProgressStages = [
+    MigrationStage.PROVISION_APPLICATION,
+    MigrationStage.PROVISION_APPLICATION_WAIT,
+    MigrationStage.PROVISION_MIGRATION_STACK,
+    MigrationStage.PROVISION_MIGRATION_STACK_WAIT,
+];
+
 export const ProvisioningStatusPage: FunctionComponent = () => {
     return (
         <MigrationTransferPage
             description={I18n.getText('atlassian.migration.datacenter.provision.aws.description')}
             getProgress={getDeploymentProgress}
-            hasStarted
+            inProgressStages={inProgressStages}
             heading={I18n.getText('atlassian.migration.datacenter.provision.aws.title')}
             nextText={I18n.getText('atlassian.migration.datacenter.generic.next')}
             // This page is only rendered when provisioning has already started. The deployment will be started by the QuickstartDeploy page

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -15,8 +15,8 @@
  */
 
 import React, { FunctionComponent } from 'react';
-
 import { I18n } from '@atlassian/wrm-react-i18n';
+
 import { MigrationTransferProps, MigrationTransferPage } from '../shared/MigrationTransferPage';
 import { Progress } from '../shared/Progress';
 import { callAppRest } from '../../utils/api';
@@ -26,7 +26,16 @@ import {
     DatabaseMigrationStatus,
     toI18nProp,
 } from '../../api/db';
-import 'moment';
+import { MigrationStage } from '../../api/migration';
+
+const dbMigrationInProgressStages = [
+    MigrationStage.DATA_MIGRATION_IMPORT,
+    MigrationStage.DATA_MIGRATION_IMPORT_WAIT,
+    MigrationStage.DB_MIGRATION_EXPORT,
+    MigrationStage.DB_MIGRATION_EXPORT_WAIT,
+    MigrationStage.DB_MIGRATION_UPLOAD,
+    MigrationStage.DB_MIGRATION_UPLOAD_WAIT,
+];
 
 const toProgress = (status: DatabaseMigrationStatus): Progress => {
     return {
@@ -51,8 +60,8 @@ const props: MigrationTransferProps = {
     heading: I18n.getText('atlassian.migration.datacenter.db.title'),
     description: I18n.getText('atlassian.migration.datacenter.db.description'),
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
-    hasStarted: false,
     startMigrationPhase: startDbMigration,
+    inProgressStages: dbMigrationInProgressStages,
     getProgress: getProgressFromStatus,
 };
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -20,7 +20,12 @@ import { I18n } from '@atlassian/wrm-react-i18n';
 import { MigrationTransferProps, MigrationTransferPage } from '../shared/MigrationTransferPage';
 import { Progress } from '../shared/Progress';
 import { callAppRest } from '../../utils/api';
-import { dbStatusReportEndpoint, DatabaseMigrationStatus, toI18nProp } from '../../api/db';
+import {
+    dbStatusReportEndpoint,
+    dbStartEndpoint,
+    DatabaseMigrationStatus,
+    toI18nProp,
+} from '../../api/db';
 import 'moment';
 
 const toProgress = (status: DatabaseMigrationStatus): Progress => {
@@ -34,6 +39,10 @@ const fetchDBMigrationStatus = (): Promise<DatabaseMigrationStatus> => {
     return callAppRest('GET', dbStatusReportEndpoint).then((result: any) => result.json());
 };
 
+const startDbMigration = (): Promise<void> => {
+    return callAppRest('PUT', dbStartEndpoint).then(result => result.json());
+};
+
 const getProgressFromStatus = (): Promise<Progress> => {
     return fetchDBMigrationStatus().then(toProgress);
 };
@@ -42,8 +51,8 @@ const props: MigrationTransferProps = {
     heading: I18n.getText('atlassian.migration.datacenter.db.title'),
     description: I18n.getText('atlassian.migration.datacenter.db.description'),
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
-    hasStarted: true,
-    startMigrationPhase: Promise.resolve,
+    hasStarted: false,
+    startMigrationPhase: startDbMigration,
     getProgress: getProgressFromStatus,
 };
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -120,7 +120,7 @@ const fsMigrationTranferPageProps: MigrationTransferProps = {
     heading: I18n.getText('atlassian.migration.datacenter.fs.title'),
     description: I18n.getText('atlassian.migration.datacenter.fs.description'),
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
-    hasStarted: false,
+    inProgressStages: [MigrationStage.FS_MIGRATION_COPY_WAIT],
     startMigrationPhase: fs.startFsMigration,
     getProgress: getFsMigrationProgress,
 };
@@ -147,5 +147,5 @@ export const FileSystemTransferPage: FunctionComponent = () => {
     if (loading) {
         return <Spinner />;
     }
-    return <MigrationTransferPage {...fsMigrationTranferPageProps} hasStarted={hasStarted} />;
+    return <MigrationTransferPage {...fsMigrationTranferPageProps} />;
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
@@ -20,14 +20,15 @@ import { BrowserRouter as Router } from 'react-router-dom';
 
 import moment from 'moment';
 import { MigrationTransferProps, MigrationTransferPage } from './MigrationTransferPage';
+import { MigrationStage } from '../../api/migration';
 
 const props: MigrationTransferProps = {
     heading: 'heading',
     description: 'description',
     nextText: 'nextText',
     startMoment: moment().subtract(20, 'minutes'),
-    hasStarted: true,
     startMigrationPhase: Promise.resolve,
+    inProgressStages: [MigrationStage.AUTHENTICATION],
     getProgress: () => {
         return new Promise(resolve => {
             setTimeout(() => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
@@ -22,6 +22,10 @@ import moment from 'moment';
 import { MigrationTransferProps, MigrationTransferPage } from './MigrationTransferPage';
 import { MigrationStage } from '../../api/migration';
 
+const mockFetch = jest.fn();
+mockFetch.mockReturnValue(Promise.resolve());
+window.fetch = mockFetch;
+
 const props: MigrationTransferProps = {
     heading: 'heading',
     description: 'description',

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -293,26 +293,34 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
             <TransferContentContainer>
                 <h1>{heading}</h1>
                 <p>{description}</p>
-                {transferError && (
-                    <SectionMessage appearance="error">{transferError}</SectionMessage>
-                )}
-                {started && renderMigrationProgress(progress, loading, startMoment)}
             </TransferContentContainer>
-            <TransferActionsContainer>
-                {renderMigrationActions(
-                    progress?.completeness,
-                    nextText,
-                    startMigration,
-                    updateProgress,
-                    started,
-                    loading
-                )}
-                <Link to={overviewPath}>
-                    <Button style={{ marginLeft: '20px', paddingLeft: '5px' }}>
-                        {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
-                    </Button>
-                </Link>
-            </TransferActionsContainer>
+            {loading ? (
+                <Spinner />
+            ) : (
+                <>
+                    <TransferContentContainer>
+                        {transferError && (
+                            <SectionMessage appearance="error">{transferError}</SectionMessage>
+                        )}
+                        {started && renderMigrationProgress(progress, loading, startMoment)}
+                    </TransferContentContainer>
+                    <TransferActionsContainer>
+                        {renderMigrationActions(
+                            progress?.completeness,
+                            nextText,
+                            startMigration,
+                            updateProgress,
+                            started,
+                            loading
+                        )}
+                        <Link to={overviewPath}>
+                            <Button style={{ marginLeft: '20px', paddingLeft: '5px' }}>
+                                {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
+                            </Button>
+                        </Link>
+                    </TransferActionsContainer>
+                </>
+            )}
         </TransferPageContainer>
     );
 };


### PR DESCRIPTION
## Summary

* Implement API call to start DB transfer
* Implement detecting if DB transfer is already in progress when loading page
* Refactor `MigrationTransferPage` to handle the "check if already started" logic

No appearance changes.