### PR TITLE
CHET-284: start migration

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
@@ -1,7 +1,7 @@
 import { callAppRest } from '../utils/api';
 
 enum RestApiPathConstants {
-    getMigrationRestPath = `migration`,
+    migrationRestPath = `migration`,
 }
 
 export enum MigrationStage {
@@ -32,11 +32,19 @@ type GetMigrationResult = {
 
 export const migration = {
     getMigrationStage: (): Promise<MigrationStage> => {
-        return callAppRest('GET', RestApiPathConstants.getMigrationRestPath)
+        return callAppRest('GET', RestApiPathConstants.migrationRestPath)
             .then(res => res.json())
             .then(res => {
                 const response = res as GetMigrationResult;
                 return response.stage;
             });
+    },
+    createMigration: (): Promise<void> => {
+        return callAppRest('POST', RestApiPathConstants.migrationRestPath).then(res => {
+            if (res.ok) {
+                return Promise.resolve();
+            }
+            return res.json().then(json => Promise.reject(json.error));
+        });
     },
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import Button from '@atlaskit/button';
 import InlineMessage from '@atlaskit/inline-message';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { I18n } from '@atlassian/wrm-react-i18n';
 
-import { overviewPath, fsPath, dbPath, startPath } from '../utils/RoutePaths';
+import { startPath } from '../utils/RoutePaths';
+import { migration } from '../api/migration';
+import { ErrorFlag } from './shared/ErrorFlag';
 
 type HomeProps = {
     title: string;
@@ -46,15 +48,41 @@ const InfoProps = {
 };
 
 export const Home = ({ title, synopsis, startButtonText }: HomeProps): ReactElement => {
+    const [error, setError] = useState<string>();
+    const [loading, setLoading] = useState<boolean>(false);
+
+    const createMigration = (): void => {
+        setLoading(true);
+        migration
+            .createMigration()
+            .then(() => {
+                // Route to next page
+            })
+            .catch(err => {
+                setError(err);
+            })
+            .finally(() => {
+                setLoading(false);
+            });
+    };
+
     return (
         <HomeContainer>
             <h2>{title}</h2>
             <p>{synopsis}</p>
+            <ErrorFlag
+                showError={error && error !== ''}
+                dismissErrorFunc={(): void => setError('')}
+                // FIXME: Internationalisation
+                title="Unable to create migration"
+                description={error}
+                id="migration-creation-error"
+            />
             <InlineMessage {...InfoProps} />
             <ButtonContainer>
-                <Link to={startPath}>
-                    <Button appearance="primary">{startButtonText}</Button>
-                </Link>
+                <Button isLoading={loading} appearance="primary" onClick={createMigration}>
+                    {startButtonText}
+                </Button>
             </ButtonContainer>
         </HomeContainer>
     );

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
@@ -17,15 +17,12 @@
 import React, { FunctionComponent, ReactElement, useState } from 'react';
 import Form, { ErrorMessage, Field, FormFooter, HelperMessage } from '@atlaskit/form';
 import Button, { ButtonGroup } from '@atlaskit/button';
-import styled from 'styled-components';
 import TextField from '@atlaskit/textfield';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { AsyncSelect, OptionType } from '@atlaskit/select';
-import Flag from '@atlaskit/flag';
-import ErrorIcon from '@atlaskit/icon/glyph/error';
-import { colors } from '@atlaskit/theme';
 import { useHistory } from 'react-router-dom';
 import { quickstartPath } from '../../../utils/RoutePaths';
+import { ErrorFlag } from '../../shared/ErrorFlag';
 
 export type AWSCreds = {
     accessKeyId: string;
@@ -50,19 +47,6 @@ export type AuthenticateAWSProps = {
     getRegions: QueryRegionFun;
 };
 
-type AuthenticationErrorProps = {
-    showError: boolean;
-    dismissErrorFunc: () => void;
-};
-
-const AwsAuthErrorContainer = styled.div`
-    position: fixed;
-    top: 70px;
-    left: 75%;
-    right: 1%;
-    overflow: inherit;
-`;
-
 const RegionSelect: FunctionComponent<{ getRegions: QueryRegionFun }> = (props): ReactElement => {
     const { getRegions } = props;
     const regionListPromiseOptions = (): Promise<Array<OptionType>> => {
@@ -83,33 +67,6 @@ const RegionSelect: FunctionComponent<{ getRegions: QueryRegionFun }> = (props):
             loadOptions={regionListPromiseOptions}
         />
     );
-};
-
-const AuthenticationErrorFlag: FunctionComponent<AuthenticationErrorProps> = (
-    props
-): ReactElement => {
-    const { showError, dismissErrorFunc } = props;
-
-    if (showError) {
-        return (
-            <AwsAuthErrorContainer>
-                <Flag
-                    actions={[
-                        {
-                            content: 'Dismiss',
-                            onClick: dismissErrorFunc,
-                        },
-                    ]}
-                    icon={<ErrorIcon primaryColor={colors.R400} label="Info" />}
-                    description="You may not have permissions to connect to the AWS account with the supplied credentials. Please try again with a different set of credentials to continue with the migration."
-                    id="aws-auth-connect-error-flag"
-                    key="connect-error"
-                    title="AWS Credentials Error"
-                />
-            </AwsAuthErrorContainer>
-        );
-    }
-    return null;
 };
 
 export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
@@ -151,11 +108,15 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
         <>
             <h1>{I18n.getText('atlassian.migration.datacenter.step.authenticate.phrase')}</h1>
             <h1>{I18n.getText('atlassian.migration.datacenter.authenticate.aws.title')}</h1>
-            <AuthenticationErrorFlag
+            <ErrorFlag
                 showError={credentialPersistError}
                 dismissErrorFunc={(): void => {
                     setCredentialPersistError(false);
                 }}
+                // FIXME: Internationalisation
+                description="You may not have permissions to connect to the AWS account with the supplied credentials. Please try again with a different set of credentials to continue with the migration."
+                id="aws-auth-connect-error-flag"
+                title="AWS Credentials Error"
             />
             <Form onSubmit={submitCreds}>
                 {({ formProps }: any): ReactElement => (

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/ErrorFlag.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/ErrorFlag.tsx
@@ -1,0 +1,66 @@
+import styled, { keyframes } from 'styled-components';
+import React, { FunctionComponent, ReactElement } from 'react';
+import Flag from '@atlaskit/flag';
+import ErrorIcon from '@atlaskit/icon/glyph/error';
+import { colors } from '@atlaskit/theme';
+
+type AuthenticationErrorProps = {
+    /**
+     * whether the flag should be rendered or not
+     */
+    showError: boolean;
+    /**
+     * callback that will be invoked when the "dimiss" button on the flag is clicked
+     */
+    dismissErrorFunc: () => void;
+
+    /**
+     * Title for the flag. Should describe the error
+     */
+    title: string;
+    /**
+     * Text that appears below the flag. Should be a call to action on how to resolve the error
+     */
+    description: string;
+    /**
+     * Unique identifier for the error
+     */
+    id: string;
+};
+
+const ErrorContainer = styled.div`
+    position: fixed;
+    top: 70px;
+    left: 75%;
+    right: 1%;
+    overflow: inherit;
+`;
+
+export const ErrorFlag: FunctionComponent<AuthenticationErrorProps> = ({
+    showError,
+    dismissErrorFunc,
+    title,
+    description,
+    id,
+}): ReactElement => {
+    if (showError) {
+        return (
+            <ErrorContainer>
+                <Flag
+                    actions={[
+                        {
+                            content: 'Dismiss',
+                            onClick: dismissErrorFunc,
+                        },
+                    ]}
+                    icon={<ErrorIcon primaryColor={colors.R400} label="Info" />}
+                    description={description}
+                    id={id}
+                    key={id}
+                    title={title}
+                />
+            </ErrorContainer>
+        );
+    }
+    return null;
+};


### PR DESCRIPTION
## Summary

* Call API to create migration when "start" is clicked
* Render error flag when creation fails

Note: Does not redirect to next page as that is being left to CHET-278 so that it can be done in a consistent manner.