### PR TITLE
CHET-285: hide "start migration" when migration is started

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
@@ -32,12 +32,17 @@ type GetMigrationResult = {
 
 export const migration = {
     getMigrationStage: (): Promise<MigrationStage> => {
-        return callAppRest('GET', RestApiPathConstants.migrationRestPath)
-            .then(res => res.json())
-            .then(res => {
-                const response = res as GetMigrationResult;
-                return response.stage;
-            });
+        return callAppRest('GET', RestApiPathConstants.migrationRestPath).then(res => {
+            if (res.ok) {
+                return res.json().then(json => {
+                    const response = json as GetMigrationResult;
+                    return response.stage;
+                });
+            }
+            if (res.status === 404) {
+                return MigrationStage.NOT_STARTED;
+            }
+        });
     },
     createMigration: (): Promise<void> => {
         return callAppRest('POST', RestApiPathConstants.migrationRestPath).then(res => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.test.tsx
@@ -20,6 +20,15 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { Home } from './Home';
 
+const mockFetch = jest.fn();
+mockFetch.mockReturnValue(
+    Promise.resolve({
+        status: 200,
+    })
+);
+
+window.fetch = mockFetch;
+
 describe('Home', () => {
     it('Should render', () => {
         const { queryByText } = render(
@@ -30,6 +39,6 @@ describe('Home', () => {
 
         expect(queryByText('Test Title')).toBeTruthy();
         expect(queryByText('Test synopsis')).toBeTruthy();
-        expect(queryByText('Test button')).toBeTruthy();
+        expect(queryByText('Test button')).toBeFalsy();
     });
 });

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -82,8 +82,7 @@ const MigrationActionSection: FunctionComponent<ActionSectionProps> = ({
                 <ErrorFlag
                     showError={error && error !== ''}
                     dismissErrorFunc={(): void => setError('')}
-                    // FIXME: Internationalisation
-                    title="Unable to create migration"
+                    title={I18n.getText('atlassian.migration.datacenter.home.start.error')}
                     description={error}
                     id="migration-creation-error"
                 />
@@ -96,7 +95,11 @@ const MigrationActionSection: FunctionComponent<ActionSectionProps> = ({
             </>
         );
     }
-    return <SectionMessage appearance="warning">You are already in a migration.</SectionMessage>;
+    return (
+        <SectionMessage appearance="warning">
+            {I18n.getText('atlassian.migration.datacenter.home.start.alreadyStarted')}
+        </SectionMessage>
+    );
 };
 
 export const Home = ({ title, synopsis, startButtonText }: HomeProps): ReactElement => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useState, useEffect, FunctionComponent } from 'react';
 import Button from '@atlaskit/button';
 import InlineMessage from '@atlaskit/inline-message';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { I18n } from '@atlassian/wrm-react-i18n';
+import SectionMessage from '@atlaskit/section-message';
+import Spinner from '@atlaskit/spinner';
 
 import { startPath } from '../utils/RoutePaths';
 import { migration } from '../api/migration';
@@ -47,7 +49,15 @@ const InfoProps = {
     secondaryText: I18n.getText('atlassian.migration.datacenter.home.info.content'),
 };
 
-export const Home = ({ title, synopsis, startButtonText }: HomeProps): ReactElement => {
+type ActionSectionProps = {
+    canStart: boolean;
+    startButtonText: string;
+};
+
+const MigrationActionSection: FunctionComponent<ActionSectionProps> = ({
+    startButtonText,
+    canStart,
+}) => {
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<boolean>(false);
 
@@ -66,24 +76,58 @@ export const Home = ({ title, synopsis, startButtonText }: HomeProps): ReactElem
             });
     };
 
+    if (canStart) {
+        return (
+            <>
+                <ErrorFlag
+                    showError={error && error !== ''}
+                    dismissErrorFunc={(): void => setError('')}
+                    // FIXME: Internationalisation
+                    title="Unable to create migration"
+                    description={error}
+                    id="migration-creation-error"
+                />
+                <InlineMessage {...InfoProps} />
+                <ButtonContainer>
+                    <Button isLoading={loading} appearance="primary" onClick={createMigration}>
+                        {startButtonText}
+                    </Button>
+                </ButtonContainer>
+            </>
+        );
+    }
+    return <SectionMessage appearance="warning">You are already in a migration.</SectionMessage>;
+};
+
+export const Home = ({ title, synopsis, startButtonText }: HomeProps): ReactElement => {
+    const [canStart, setCanStart] = useState<boolean>(false);
+    const [loadingCanStart, setLoadingCanStart] = useState<boolean>(true);
+
+    useEffect(() => {
+        setLoadingCanStart(true);
+        migration
+            .getMigrationStage()
+            .then(stage => {
+                if (stage === 'not_started') {
+                    setCanStart(true);
+                } else {
+                    setCanStart(false);
+                }
+            })
+            .finally(() => {
+                setLoadingCanStart(false);
+            });
+    }, []);
+
     return (
         <HomeContainer>
             <h2>{title}</h2>
             <p>{synopsis}</p>
-            <ErrorFlag
-                showError={error && error !== ''}
-                dismissErrorFunc={(): void => setError('')}
-                // FIXME: Internationalisation
-                title="Unable to create migration"
-                description={error}
-                id="migration-creation-error"
-            />
-            <InlineMessage {...InfoProps} />
-            <ButtonContainer>
-                <Button isLoading={loading} appearance="primary" onClick={createMigration}>
-                    {startButtonText}
-                </Button>
-            </ButtonContainer>
+            {loadingCanStart ? (
+                <Spinner />
+            ) : (
+                <MigrationActionSection startButtonText={startButtonText} canStart={canStart} />
+            )}
         </HomeContainer>
     );
 };

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -34,6 +34,9 @@ atlassian.migration.datacenter.home.synopsis=Use this assistant to securely migr
 atlassian.migration.datacenter.home.migration.start=Start new migration
 atlassian.migration.datacenter.home.info.title=You can only proceed with the migration if your Jira instance:
 atlassian.migration.datacenter.home.info.content=Uses a PostgreSQL database, is running on Linux server, and has a home directory under 400GB.
+atlassian.migration.datacenter.home.start.alreadyStarted=You are already in a migration.
+atlassian.migration.datacenter.home.start.error=Unable to create migration
+
 
 atlassian.migration.datacenter.overview.title=Migration Overview
 atlassian.migration.datacenter.step.authenticate.phrase=Step 1 of 6: Connect to AWS


### PR DESCRIPTION
## Summary

* Implement check for if migration is started
* Render warning message if migration is already started

### Follow up

* Render button or redirect when migration is started and take user to their current step.