### PR TITLE
CHET-272: Add a error flag to highlight out of sequence migration step

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
@@ -2,6 +2,7 @@ import { callAppRest } from '../utils/api';
 
 enum RestApiPathConstants {
     migrationRestPath = `migration`,
+    migrationSummaryRestPath = `migration/summary`,
 }
 
 export enum MigrationStage {
@@ -51,5 +52,10 @@ export const migration = {
             }
             return res.json().then(json => Promise.reject(json.error));
         });
+    },
+    getMigrationSummary: (): Promise<Record<string, string>> => {
+        return callAppRest('GET', RestApiPathConstants.migrationSummaryRestPath).then(res =>
+            res.json()
+        );
     },
 };

--- a/frontend/src/main/dc-migration-assistant-fe/stage/Validation.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/stage/Validation.tsx
@@ -20,7 +20,7 @@ import SectionMessage from '@atlaskit/section-message';
 import TableTree, { Cell, Row } from '@atlaskit/table-tree';
 import { Button } from '@atlaskit/button/dist/esm/components/Button';
 import styled from 'styled-components';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { homePath } from '../utils/RoutePaths';
 import { migration, MigrationStage } from '../api/migration';
 
@@ -138,11 +138,7 @@ const MigrationSummary: FunctionComponent = () => {
     );
 };
 
-const ValidationSummary = ({
-    onClick,
-}: {
-    onClick: () => void;
-}): ReactElement => {
+const ValidationSummary = (): ReactElement => {
     return (
         <>
             <h3>{I18n.getText('atlassian.migration.datacenter.step.validation.phrase')}</h3>
@@ -160,7 +156,7 @@ const ValidationSummary = ({
                 style={{
                     marginTop: '15px',
                 }}
-                onClick={onClick}
+                href={homePath}
             >
                 {I18n.getText('atlassian.migration.datacenter.validation.next.button')}
             </Button>
@@ -169,7 +165,16 @@ const ValidationSummary = ({
 };
 
 const InvalidMigrationStageErrorMessage = (): ReactElement => (
-    <SectionMessage appearance="error">
+    <SectionMessage
+        appearance="error"
+        actions={[
+            {
+                key: 'invalid-stage-error-section-link',
+                href: homePath,
+                text: I18n.getText('atlassian.migration.datacenter.step.validation.redirect.home'),
+            },
+        ]}
+    >
         <p>
             {I18n.getText(
                 'atlassian.migration.datacenter.step.validation.incorrect.stage.error.title'
@@ -180,18 +185,12 @@ const InvalidMigrationStageErrorMessage = (): ReactElement => (
                 'atlassian.migration.datacenter.step.validation.incorrect.stage.error.description'
             )}
         </p>
-        <p>
-            <Link to={homePath}>{I18n.getText('atlassian.migration.datacenter.step.validation.redirect.home')}</Link>
-        </p>
     </SectionMessage>
 );
 
 export const ValidateStagePage: FunctionComponent = () => {
-    const history = useHistory();
     const [isStageValid, setIsStageValid]: [boolean, Function] = useState<boolean>(true);
-    const redirectUserToMigrationHome = (): void => {
-        history.push(homePath);
-    };
+
     useEffect(() => {
         migration
             .getMigrationStage()
@@ -205,9 +204,5 @@ export const ValidateStagePage: FunctionComponent = () => {
             });
     }, []);
 
-    return isStageValid ? (
-        <ValidationSummary onClick={redirectUserToMigrationHome} />
-    ) : (
-        <InvalidMigrationStageErrorMessage />
-    );
+    return isStageValid ? <ValidationSummary /> : <InvalidMigrationStageErrorMessage />;
 };

--- a/frontend/src/main/dc-migration-assistant-fe/stage/Validation.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/stage/Validation.tsx
@@ -23,7 +23,6 @@ import styled from 'styled-components';
 import { Link, useHistory } from 'react-router-dom';
 import { homePath } from '../utils/RoutePaths';
 import { migration, MigrationStage } from '../api/migration';
-import { ErrorFlag } from '../components/shared/ErrorFlag';
 
 const MigrationSummaryContainer = styled.div`
     display: grid;
@@ -139,10 +138,58 @@ const MigrationSummary: FunctionComponent = () => {
     );
 };
 
+const ValidationSummary = ({
+    onClick,
+}: {
+    onClick: () => void;
+}): ReactElement => {
+    return (
+        <>
+            <h3>{I18n.getText('atlassian.migration.datacenter.step.validation.phrase')}</h3>
+            <h3>{I18n.getText('atlassian.migration.datacenter.validation.message')}</h3>
+            <SectionMessageContainer>
+                <SectionMessage appearance="info">
+                    {I18n.getText('atlassian.migration.datacenter.validation.section.message')}
+                </SectionMessage>
+            </SectionMessageContainer>
+            <MigrationSummary />
+            <MigrationSummaryActionCallout />
+            <Button
+                isLoading={false}
+                appearance="primary"
+                style={{
+                    marginTop: '15px',
+                }}
+                onClick={onClick}
+            >
+                {I18n.getText('atlassian.migration.datacenter.validation.next.button')}
+            </Button>
+        </>
+    );
+};
+
+const InvalidMigrationStageErrorMessage = (): ReactElement => (
+    <SectionMessage appearance="error">
+        <p>
+            {I18n.getText(
+                'atlassian.migration.datacenter.step.validation.incorrect.stage.error.title'
+            )}
+        </p>
+        <p>
+            {I18n.getText(
+                'atlassian.migration.datacenter.step.validation.incorrect.stage.error.description'
+            )}
+        </p>
+        <p>
+            <Link to={homePath}>{I18n.getText('atlassian.migration.datacenter.step.validation.redirect.home')}</Link>
+        </p>
+    </SectionMessage>
+);
+
 export const ValidateStagePage: FunctionComponent = () => {
     const history = useHistory();
     const [isStageValid, setIsStageValid]: [boolean, Function] = useState<boolean>(true);
-    const redirectUserToHome = (): void => {
+    const redirectUserToMigrationHome = (): void => {
         history.push(homePath);
     };
     useEffect(() => {
@@ -158,38 +205,9 @@ export const ValidateStagePage: FunctionComponent = () => {
             });
     }, []);
 
-    return (
-        <>
-            <h3>{I18n.getText('atlassian.migration.datacenter.step.validation.phrase')}</h3>
-            <h3>{I18n.getText('atlassian.migration.datacenter.validation.message')}</h3>
-            <ErrorFlag
-                showError={!isStageValid}
-                dismissErrorFunc={(): void => setIsStageValid(true)}
-                title={I18n.getText(
-                    'atlassian.migration.datacenter.step.validation.incorrect.stage.error.title'
-                )}
-                description={I18n.getText(
-                    'atlassian.migration.datacenter.step.validation.incorrect.stage.error.description'
-                )}
-                id="invalid-validation-step-error"
-            />
-            <SectionMessageContainer>
-                <SectionMessage appearance="info">
-                    {I18n.getText('atlassian.migration.datacenter.validation.section.message')}
-                </SectionMessage>
-            </SectionMessageContainer>
-            <MigrationSummary />
-            <MigrationSummaryActionCallout />
-            <Button
-                isLoading={false}
-                appearance="primary"
-                style={{
-                    marginTop: '15px',
-                }}
-                onClick={redirectUserToHome}
-            >
-                {I18n.getText('atlassian.migration.datacenter.validation.next.button')}
-            </Button>
-        </>
+    return isStageValid ? (
+        <ValidationSummary onClick={redirectUserToMigrationHome} />
+    ) : (
+        <InvalidMigrationStageErrorMessage />
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/utils/api.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/utils/api.ts
@@ -66,5 +66,4 @@ export enum RestApiPathConstants {
     awsCredentialsStorePath = `aws/configure`,
     awsRegionListPath = `aws/global-infrastructure/regions`,
     awsAzListForRegion = `aws/availabilityZones`,
-    migrationSummaryRestPath = `migration/summary`,
 }

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -100,6 +100,9 @@ atlassian.migration.datacenter.db.storage.size=Database storage size (GB)
 atlassian.migration.datacenter.db.storage.type=Database storge type
 
 atlassian.migration.datacenter.step.validation.phrase=Step 7 of 7: Validation
+atlassian.migration.datacenter.step.validation.incorrect.stage.error.title=Out of sequence migration step
+atlassian.migration.datacenter.step.validation.incorrect.stage.error.description=You may have arrived at this page by clicking on a direct link. \
+  Please check the server logs and ensure that you complete the previous migration steps
 atlassian.migration.datacenter.validation.message=Review details of your migration and proceed to refine your new deployment
 atlassian.migration.datacenter.validation.section.message=Review details of your migration and proceed to refine your new deployment
 atlassian.migration.datacenter.validation.summary.phrase.instanceUrl=AWS Jira Instance

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -100,7 +100,8 @@ atlassian.migration.datacenter.db.storage.size=Database storage size (GB)
 atlassian.migration.datacenter.db.storage.type=Database storge type
 
 atlassian.migration.datacenter.step.validation.phrase=Step 7 of 7: Validation
-atlassian.migration.datacenter.step.validation.incorrect.stage.error.title=Out of sequence migration step
+atlassian.migration.datacenter.step.validation.redirect.home=Click here to visit the migration home page
+atlassian.migration.datacenter.step.validation.incorrect.stage.error.title=You have reached this page out of a pre-defined order of migration steps
 atlassian.migration.datacenter.step.validation.incorrect.stage.error.description=You may have arrived at this page by clicking on a direct link. \
   Please check the server logs and ensure that you complete the previous migration steps
 atlassian.migration.datacenter.validation.message=Review details of your migration and proceed to refine your new deployment


### PR DESCRIPTION
Add a validation error flag component.

Refactor to use the migration api

2 stages of the component -

* When stage is validation
 
<img width="1098" alt="Screenshot 2020-04-28 at 14 43 26" src="https://user-images.githubusercontent.com/1063972/80448355-5b9aee00-895f-11ea-814c-21a74a676b07.png">

* When stage is not validation

<img width="1677" alt="Screenshot 2020-04-28 at 14 43 47" src="https://user-images.githubusercontent.com/1063972/80448359-5d64b180-895f-11ea-89b8-dac6cf5115e9.png">

