### PR TITLE
CHET-289: Navigate between migration steps using "next" button

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -21,6 +21,7 @@ import { MigrationTransferPage } from '../../shared/MigrationTransferPage';
 import { ProgressBuilder, ProgressCallback } from '../../shared/Progress';
 import { provisioning, ProvisioningStatus } from '../../../api/provisioning';
 import { MigrationStage } from '../../../api/migration';
+import { fsPath } from '../../../utils/RoutePaths';
 
 const getDeploymentProgress: ProgressCallback = () => {
     return provisioning
@@ -80,6 +81,7 @@ export const ProvisioningStatusPage: FunctionComponent = () => {
             nextText={I18n.getText('atlassian.migration.datacenter.generic.next')}
             // This page is only rendered when provisioning has already started. The deployment will be started by the QuickstartDeploy page
             startMigrationPhase={Promise.resolve}
+            nextRoute={fsPath}
         />
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -27,6 +27,7 @@ import {
     toI18nProp,
 } from '../../api/db';
 import { MigrationStage } from '../../api/migration';
+import { validationPath } from '../../utils/RoutePaths';
 
 const dbMigrationInProgressStages = [
     MigrationStage.DATA_MIGRATION_IMPORT,
@@ -63,6 +64,7 @@ const props: MigrationTransferProps = {
     startMigrationPhase: startDbMigration,
     inProgressStages: dbMigrationInProgressStages,
     getProgress: getProgressFromStatus,
+    nextRoute: validationPath,
 };
 
 export const DatabaseTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -23,6 +23,7 @@ import { MigrationTransferProps, MigrationTransferPage } from '../shared/Migrati
 import { Progress, ProgressBuilder } from '../shared/Progress';
 import { fs, FileSystemMigrationStatusResponse } from '../../api/fs';
 import { migration, MigrationStage } from '../../api/migration';
+import { dbPath } from '../../utils/RoutePaths';
 
 const dummyStarted = moment();
 
@@ -123,6 +124,7 @@ const fsMigrationTranferPageProps: MigrationTransferProps = {
     inProgressStages: [MigrationStage.FS_MIGRATION_COPY_WAIT],
     startMigrationPhase: fs.startFsMigration,
     getProgress: getFsMigrationProgress,
+    nextRoute: dbPath,
 };
 
 export const FileSystemTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
@@ -43,6 +43,7 @@ const props: MigrationTransferProps = {
             }, 500);
         });
     },
+    nextRoute: '',
 };
 
 describe('Migration Page Component', () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -163,18 +163,13 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                     </TransferContentContainer>
                     <TransferActionsContainer>
                         <MigrationTransferActions
-                            completeness={progress?.completeness}
+                            finished={progress?.completeness === 1}
                             nextText={nextText}
                             startMigrationPhase={startMigration}
                             updateTransferProgress={updateProgress}
                             started={started}
                             loading={loading}
                         />
-                        <Link to={overviewPath}>
-                            <Button style={{ marginLeft: '20px', paddingLeft: '5px' }}>
-                                {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
-                            </Button>
-                        </Link>
                     </TransferActionsContainer>
                 </>
             )}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -17,14 +17,10 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
-import { Button } from '@atlaskit/button/dist/cjs/components/Button';
-import { Link } from 'react-router-dom';
-import moment, { Moment } from 'moment';
+import moment from 'moment';
 import Spinner from '@atlaskit/spinner';
-import { I18n } from '@atlassian/wrm-react-i18n';
 
 import { MigrationTransferActions } from './MigrationTransferPageActions';
-import { overviewPath } from '../../utils/RoutePaths';
 import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
@@ -32,12 +28,38 @@ import { MigrationProgress } from './MigrationTransferProgress';
 const POLL_INTERVAL_MILLIS = 3000;
 
 export type MigrationTransferProps = {
+    /**
+     * The heading for the current migration transfer. Should follow pattern "Step X of Y: Z"
+     */
     heading: string;
+    /**
+     * A description for what the current transfer does. Will be rendered below the title
+     */
     description: string;
+    /**
+     * @see MigrationTransferActionsProps
+     */
     nextText: string;
+    /**
+     * @see MigrationTransferActionsProps
+     */
+    nextRoute: string;
+    /**
+     * @see MigrationProgressProps
+     */
     startMoment?: moment.Moment;
+    /**
+     * The MigrationStages where this transfer is "in progress"
+     * @see MigrationStage
+     */
     inProgressStages: Array<MigrationStage>;
+    /**
+     * A function which starts this migration transfer
+     */
     startMigrationPhase: () => Promise<void>;
+    /**
+     * A function which will be called to get the progress of the current transfer
+     */
     getProgress: ProgressCallback;
 };
 
@@ -70,6 +92,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     description,
     heading,
     nextText,
+    nextRoute,
     startMoment,
     getProgress,
     inProgressStages,
@@ -165,8 +188,9 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                         <MigrationTransferActions
                             finished={progress?.completeness === 1}
                             nextText={nextText}
+                            nextRoute={nextRoute}
                             startMigrationPhase={startMigration}
-                            updateTransferProgress={updateProgress}
+                            onRefresh={updateProgress}
                             started={started}
                             loading={loading}
                         />

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -1,9 +1,12 @@
 import React, { FunctionComponent } from 'react';
 import Button from '@atlaskit/button';
+import { Link } from 'react-router-dom';
+import { I18n } from '@atlassian/wrm-react-i18n';
+import { overviewPath } from '../../utils/RoutePaths';
 
 type MigrationTransferActionsProps = {
     updateTransferProgress: () => Promise<void>;
-    completeness: number;
+    finished: boolean;
     nextText: string;
     startMigrationPhase: () => Promise<void>;
     started: boolean;
@@ -11,7 +14,7 @@ type MigrationTransferActionsProps = {
 };
 
 export const MigrationTransferActions: FunctionComponent<MigrationTransferActionsProps> = ({
-    completeness,
+    finished,
     nextText,
     startMigrationPhase,
     updateTransferProgress,
@@ -26,21 +29,15 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
         marginRight: '20px',
     };
 
-    if (completeness === 1) {
-        return (
-            <Button style={defaultButtonStyle} appearance="primary">
-                {nextText}
+    const CancelButton = (
+        <Link to={overviewPath}>
+            <Button style={{ marginLeft: '20px', paddingLeft: '5px' }}>
+                {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
             </Button>
-        );
-    }
-    if (started) {
-        return (
-            <Button style={marginButtonStyle} isLoading={loading} onClick={updateTransferProgress}>
-                Refresh
-            </Button>
-        );
-    }
-    return (
+        </Link>
+    );
+
+    const StartButton = (
         <Button
             style={marginButtonStyle}
             isLoading={loading}
@@ -49,5 +46,31 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
         >
             Start
         </Button>
+    );
+
+    let ActionButton = StartButton;
+
+    if (finished) {
+        const NextButton = (
+            <Button style={defaultButtonStyle} appearance="primary">
+                {nextText}
+            </Button>
+        );
+        ActionButton = NextButton;
+    }
+    if (started) {
+        const RefreshButton = (
+            <Button style={marginButtonStyle} isLoading={loading} onClick={updateTransferProgress}>
+                Refresh
+            </Button>
+        );
+        ActionButton = RefreshButton;
+    }
+
+    return (
+        <>
+            {ActionButton}
+            {CancelButton}
+        </>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -1,0 +1,53 @@
+import React, { FunctionComponent } from 'react';
+import Button from '@atlaskit/button';
+
+type MigrationTransferActionsProps = {
+    updateTransferProgress: () => Promise<void>;
+    completeness: number;
+    nextText: string;
+    startMigrationPhase: () => Promise<void>;
+    started: boolean;
+    loading: boolean;
+};
+
+export const MigrationTransferActions: FunctionComponent<MigrationTransferActionsProps> = ({
+    completeness,
+    nextText,
+    startMigrationPhase,
+    updateTransferProgress,
+    started,
+    loading,
+}) => {
+    const defaultButtonStyle = {
+        padding: '5px',
+    };
+    const marginButtonStyle = {
+        ...defaultButtonStyle,
+        marginRight: '20px',
+    };
+
+    if (completeness === 1) {
+        return (
+            <Button style={defaultButtonStyle} appearance="primary">
+                {nextText}
+            </Button>
+        );
+    }
+    if (started) {
+        return (
+            <Button style={marginButtonStyle} isLoading={loading} onClick={updateTransferProgress}>
+                Refresh
+            </Button>
+        );
+    }
+    return (
+        <Button
+            style={marginButtonStyle}
+            isLoading={loading}
+            appearance="primary"
+            onClick={startMigrationPhase}
+        >
+            Start
+        </Button>
+    );
+};

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -4,20 +4,51 @@ import { Link } from 'react-router-dom';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { overviewPath } from '../../utils/RoutePaths';
 
+/**
+ * A component which renders the actions that can be taken at a given step of the migration.
+ * The "Cancel" action is always available and cancels the current step. There are three other
+ * possible actions which can be availabl depending on the props:
+ *   **Start**: Will be available when the current transfer hasn't started
+ *   **Refresh**: Will be available when the current transfer is in progress
+ *   **Next**: Will be available when the current transfer is completed. It's text can be overriden
+ */
 type MigrationTransferActionsProps = {
-    updateTransferProgress: () => Promise<void>;
+    /**
+     * A function which will be called when the Refresh button is clicked
+     */
+    onRefresh: () => Promise<void>;
+    /**
+     * Whether the current migration transfer has completed or not
+     */
     finished: boolean;
+    /**
+     * The text to display on the button that takes the user to the next step of the migration
+     */
     nextText: string;
+    /**
+     * The path to take the user to whent hey click the "next" action button
+     */
+    nextRoute: string;
+    /**
+     * A function which will be called when the "start" action button is called.
+     */
     startMigrationPhase: () => Promise<void>;
+    /**
+     * Whether the current migration transfer has already started or not
+     */
     started: boolean;
+    /**
+     * Should be true if any of the above properties are being fetched
+     */
     loading: boolean;
 };
 
 export const MigrationTransferActions: FunctionComponent<MigrationTransferActionsProps> = ({
     finished,
     nextText,
+    nextRoute,
     startMigrationPhase,
-    updateTransferProgress,
+    onRefresh: updateTransferProgress,
     started,
     loading,
 }) => {
@@ -52,9 +83,11 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
 
     if (finished) {
         const NextButton = (
-            <Button style={defaultButtonStyle} appearance="primary">
-                {nextText}
-            </Button>
+            <Link to={nextRoute}>
+                <Button style={defaultButtonStyle} appearance="primary">
+                    {nextText}
+                </Button>
+            </Link>
         );
         ActionButton = NextButton;
     }

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -90,8 +90,7 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
             </Link>
         );
         ActionButton = NextButton;
-    }
-    if (started) {
+    } else if (started) {
         const RefreshButton = (
             <Button style={marginButtonStyle} isLoading={loading} onClick={updateTransferProgress}>
                 Refresh

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -4,15 +4,7 @@ import { Link } from 'react-router-dom';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { overviewPath } from '../../utils/RoutePaths';
 
-/**
- * A component which renders the actions that can be taken at a given step of the migration.
- * The "Cancel" action is always available and cancels the current step. There are three other
- * possible actions which can be availabl depending on the props:
- *   **Start**: Will be available when the current transfer hasn't started
- *   **Refresh**: Will be available when the current transfer is in progress
- *   **Next**: Will be available when the current transfer is completed. It's text can be overriden
- */
-type MigrationTransferActionsProps = {
+export type MigrationTransferActionsProps = {
     /**
      * A function which will be called when the Refresh button is clicked
      */
@@ -43,6 +35,14 @@ type MigrationTransferActionsProps = {
     loading: boolean;
 };
 
+/**
+ * A component which renders the actions that can be taken at a given step of the migration.
+ * The "Cancel" action is always available and cancels the current step. There are three other
+ * possible actions which can be availabl depending on the props:
+ *   **Start**: Will be available when the current transfer hasn't started
+ *   **Refresh**: Will be available when the current transfer is in progress
+ *   **Next**: Will be available when the current transfer is completed. It's text can be overriden
+ */
 export const MigrationTransferActions: FunctionComponent<MigrationTransferActionsProps> = ({
     finished,
     nextText,

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, ReactElement, FunctionComponent } from 'react';
+import React, { ReactElement, FunctionComponent } from 'react';
 import { Moment } from 'moment';
 import SectionMessage from '@atlaskit/section-message';
 import Spinner from '@atlaskit/spinner';

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -12,57 +12,6 @@ import {
     calculateStartedFromElapsedSeconds,
 } from './migration-timing';
 
-const renderContentIfLoading = (
-    loading: boolean,
-    progress: Progress,
-    started: Moment
-): ReactElement => {
-    if (loading) {
-        return (
-            <>
-                <Spinner />
-                <ProgressBar isIndeterminate />
-                <Spinner />
-            </>
-        );
-    }
-
-    const duration =
-        calculateDurationFromBeginning(started) ||
-        calcualateDurationFromElapsedSeconds(progress.elapsedTimeSeconds);
-
-    return (
-        <>
-            <h4>
-                {progress.phase}
-                {progress.completeness === undefined &&
-                    ` (${I18n.getText('atlassian.migration.datacenter.common.estimating')}...)`}
-            </h4>
-            {progress.completeness ? (
-                <SuccessProgressBar value={progress.completeness} />
-            ) : (
-                <ProgressBar isIndeterminate />
-            )}
-            <p>
-                {I18n.getText(
-                    'atlassian.migration.datacenter.common.progress.started',
-                    (
-                        started || calculateStartedFromElapsedSeconds(progress.elapsedTimeSeconds)
-                    ).format('D/MMM/YY h:mm A')
-                )}
-            </p>
-            <p>
-                {duration &&
-                    I18n.getText(
-                        'atlassian.migration.datacenter.common.progress.mins_elapsed',
-                        `${duration.days * 24 + duration.hours}`,
-                        `${duration.minutes}`
-                    )}
-            </p>
-        </>
-    );
-};
-
 type MigrationProgressProps = {
     progress: Progress;
     loading: boolean;
@@ -74,6 +23,20 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     loading,
     startedMoment,
 }) => {
+    if (loading) {
+        return (
+            <>
+                <Spinner />
+                <ProgressBar isIndeterminate />
+                <Spinner />
+            </>
+        );
+    }
+
+    const duration =
+        calculateDurationFromBeginning(startedMoment) ||
+        calcualateDurationFromElapsedSeconds(progress.elapsedTimeSeconds);
+
     return (
         <>
             {progress?.completeness === 1 && progress?.completeMessage && (
@@ -82,7 +45,36 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                     {progress.completeMessage.message}
                 </SectionMessage>
             )}
-            {renderContentIfLoading(loading, progress, startedMoment)}
+
+            <>
+                <h4>
+                    {progress.phase}
+                    {progress.completeness === undefined &&
+                        ` (${I18n.getText('atlassian.migration.datacenter.common.estimating')}...)`}
+                </h4>
+                {progress.completeness ? (
+                    <SuccessProgressBar value={progress.completeness} />
+                ) : (
+                    <ProgressBar isIndeterminate />
+                )}
+                <p>
+                    {I18n.getText(
+                        'atlassian.migration.datacenter.common.progress.started',
+                        (
+                            startedMoment ||
+                            calculateStartedFromElapsedSeconds(progress.elapsedTimeSeconds)
+                        ).format('D/MMM/YY h:mm A')
+                    )}
+                </p>
+                <p>
+                    {duration &&
+                        I18n.getText(
+                            'atlassian.migration.datacenter.common.progress.mins_elapsed',
+                            `${duration.days * 24 + duration.hours}`,
+                            `${duration.minutes}`
+                        )}
+                </p>
+            </>
         </>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -12,12 +12,22 @@ import {
     calculateStartedFromElapsedSeconds,
 } from './migration-timing';
 
-type MigrationProgressProps = {
+export type MigrationProgressProps = {
     progress: Progress;
+    /**
+     * Should be true when the progress is being fetched
+     */
     loading: boolean;
+    /**
+     * A moment representing the time that the transfer was started
+     */
     startedMoment: Moment;
 };
 
+/**
+ * A component which renders the progress of the current transfer. It renders
+ * a progress bar and elapsed time. It handles when the completeness is indeterminate.
+ */
 export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     progress,
     loading,

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -1,0 +1,88 @@
+import React, { ReactNode, ReactElement, FunctionComponent } from 'react';
+import { Moment } from 'moment';
+import SectionMessage from '@atlaskit/section-message';
+import Spinner from '@atlaskit/spinner';
+import ProgressBar, { SuccessProgressBar } from '@atlaskit/progress-bar';
+import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+
+import { Progress } from './Progress';
+import {
+    calculateDurationFromBeginning,
+    calcualateDurationFromElapsedSeconds,
+    calculateStartedFromElapsedSeconds,
+} from './migration-timing';
+
+const renderContentIfLoading = (
+    loading: boolean,
+    progress: Progress,
+    started: Moment
+): ReactElement => {
+    if (loading) {
+        return (
+            <>
+                <Spinner />
+                <ProgressBar isIndeterminate />
+                <Spinner />
+            </>
+        );
+    }
+
+    const duration =
+        calculateDurationFromBeginning(started) ||
+        calcualateDurationFromElapsedSeconds(progress.elapsedTimeSeconds);
+
+    return (
+        <>
+            <h4>
+                {progress.phase}
+                {progress.completeness === undefined &&
+                    ` (${I18n.getText('atlassian.migration.datacenter.common.estimating')}...)`}
+            </h4>
+            {progress.completeness ? (
+                <SuccessProgressBar value={progress.completeness} />
+            ) : (
+                <ProgressBar isIndeterminate />
+            )}
+            <p>
+                {I18n.getText(
+                    'atlassian.migration.datacenter.common.progress.started',
+                    (
+                        started || calculateStartedFromElapsedSeconds(progress.elapsedTimeSeconds)
+                    ).format('D/MMM/YY h:mm A')
+                )}
+            </p>
+            <p>
+                {duration &&
+                    I18n.getText(
+                        'atlassian.migration.datacenter.common.progress.mins_elapsed',
+                        `${duration.days * 24 + duration.hours}`,
+                        `${duration.minutes}`
+                    )}
+            </p>
+        </>
+    );
+};
+
+type MigrationProgressProps = {
+    progress: Progress;
+    loading: boolean;
+    startedMoment: Moment;
+};
+
+export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
+    progress,
+    loading,
+    startedMoment,
+}) => {
+    return (
+        <>
+            {progress?.completeness === 1 && progress?.completeMessage && (
+                <SectionMessage appearance="confirmation">
+                    <strong>{progress.completeMessage.boldPrefix}</strong>{' '}
+                    {progress.completeMessage.message}
+                </SectionMessage>
+            )}
+            {renderContentIfLoading(loading, progress, startedMoment)}
+        </>
+    );
+};

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/migration-timing.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/migration-timing.ts
@@ -1,0 +1,40 @@
+import moment, { Moment } from 'moment';
+
+type TransferDuration = {
+    days: number;
+    hours: number;
+    minutes: number;
+};
+
+export const calculateDurationFromBeginning = (start: Moment): TransferDuration => {
+    if (!start) {
+        return undefined;
+    }
+
+    const elapsedTime = moment.duration(moment.now() - start.valueOf());
+
+    return {
+        days: elapsedTime.days(),
+        hours: elapsedTime.hours(),
+        minutes: elapsedTime.minutes(),
+    };
+};
+
+export const calculateStartedFromElapsedSeconds = (elapsedSeconds: number): Moment => {
+    const now = moment();
+    return now.subtract(elapsedSeconds, 'seconds');
+};
+
+export const calcualateDurationFromElapsedSeconds = (seconds: number): TransferDuration => {
+    if (!seconds) {
+        return undefined;
+    }
+
+    const duration = moment.duration(seconds, 'seconds');
+
+    return {
+        days: duration.days(),
+        hours: duration.hours(),
+        minutes: duration.minutes(),
+    };
+};


### PR DESCRIPTION
## Summary

* Refactor MigrationTransferPage into smaller components, it was a bit of a behemoth
* Implement `nextRoute` as a prop of the MigrationTransfer shared component
* Wire up the next routes of all steps which require a "click" to proceed to the next step of each to go to their respective next step.