### PR TITLE
CHET-278: automated next step transitions

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
@@ -19,8 +19,9 @@ import Form, { ErrorMessage, Field, FormFooter, HelperMessage } from '@atlaskit/
 import Button, { ButtonGroup } from '@atlaskit/button';
 import TextField from '@atlaskit/textfield';
 import { I18n } from '@atlassian/wrm-react-i18n';
+import { Redirect } from 'react-router-dom';
 import { AsyncSelect, OptionType } from '@atlaskit/select';
-import { useHistory } from 'react-router-dom';
+
 import { quickstartPath } from '../../../utils/RoutePaths';
 import { ErrorFlag } from '../../shared/ErrorFlag';
 
@@ -73,9 +74,10 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
     onSubmitCreds,
     getRegions,
 }): ReactElement => {
-    const [credentialPersistError, setCredentialPersistError] = useState(false);
-    const [awaitResponseFromApi, setAwaitResponseFromApi] = useState(false);
-    const history = useHistory();
+    const [credentialPersistError, setCredentialPersistError] = useState<boolean>(false);
+    const [awaitResponseFromApi, setAwaitResponseFromApi] = useState<boolean>(false);
+    const [readyForNextStep, setReadyForNextStep] = useState<boolean>(false);
+
     const submitCreds = (formCreds: {
         accessKeyId: string;
         secretAccessKey: string;
@@ -93,10 +95,9 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
             resolve();
         })
             .then(() => onSubmitCreds(creds))
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            .then(_value => {
+            .then(() => {
                 setAwaitResponseFromApi(false);
-                history.push(quickstartPath);
+                setReadyForNextStep(true);
             })
             .catch(() => {
                 setAwaitResponseFromApi(false);
@@ -106,6 +107,7 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
 
     return (
         <>
+            {readyForNextStep && <Redirect to={quickstartPath} />}
             <h1>{I18n.getText('atlassian.migration.datacenter.step.authenticate.phrase')}</h1>
             <h1>{I18n.getText('atlassian.migration.datacenter.authenticate.aws.title')}</h1>
             <ErrorFlag

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
@@ -107,7 +107,7 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
 
     return (
         <>
-            {readyForNextStep && <Redirect to={quickstartPath} />}
+            {readyForNextStep && <Redirect to={quickstartPath} push />}
             <h1>{I18n.getText('atlassian.migration.datacenter.step.authenticate.phrase')}</h1>
             <h1>{I18n.getText('atlassian.migration.datacenter.authenticate.aws.title')}</h1>
             <ErrorFlag

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -24,7 +24,7 @@ import { OptionType } from '@atlaskit/select';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import styled from 'styled-components';
 import Panel from '@atlaskit/panel';
-import { useHistory } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 
 import { createQuickstartFormField } from './quickstartToAtlaskit';
 import {
@@ -203,8 +203,7 @@ const QuickStartDeployContainer = styled.div`
 export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
     const [params, setParams] = useState<Array<QuickstartParameterGroup>>([]);
     const [loading, setLoading] = useState<boolean>(false);
-
-    const history = useHistory();
+    const [readyForNextStep, setReadyForNextStep] = useState<boolean>(false);
 
     useEffect(() => {
         setLoading(true);
@@ -245,7 +244,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
                 if (response.status !== 202) {
                     throw Error('Stack provisioning failed');
                 }
-                history.push(quickstartStatusPath);
+                setReadyForNextStep(true);
             })
             .catch(err => {
                 console.error(err);
@@ -254,6 +253,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
 
     return (
         <QuickStartDeployContainer>
+            {readyForNextStep && <Redirect to={quickstartStatusPath} />}
             {loading ? (
                 <Spinner />
             ) : (

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -253,7 +253,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
 
     return (
         <QuickStartDeployContainer>
-            {readyForNextStep && <Redirect to={quickstartStatusPath} />}
+            {readyForNextStep && <Redirect to={quickstartStatusPath} push />}
             {loading ? (
                 <Spinner />
             ) : (

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -24,7 +24,7 @@ import { OptionType } from '@atlaskit/select';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import styled from 'styled-components';
 import Panel from '@atlaskit/panel';
-import { Redirect } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import { createQuickstartFormField } from './quickstartToAtlaskit';
 import {
@@ -190,7 +190,8 @@ const QuickStartDeployContainer = styled.div`
 export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
     const [params, setParams] = useState<Array<QuickstartParameterGroup>>([]);
     const [loading, setLoading] = useState<boolean>(false);
-    const [readyForNextStep, setReadyForNextStep] = useState<boolean>(false);
+
+    const history = useHistory();
 
     useEffect(() => {
         setLoading(true);
@@ -231,7 +232,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
                 if (response.status !== 202) {
                     throw Error('Stack provisioning failed');
                 }
-                setReadyForNextStep(true);
+                history.push(quickstartStatusPath);
             })
             .catch(err => {
                 console.error(err);
@@ -240,7 +241,6 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
 
     return (
         <QuickStartDeployContainer>
-            {readyForNextStep && <Redirect to={quickstartStatusPath} />}
             {loading ? (
                 <Spinner />
             ) : (

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -34,6 +34,8 @@ import {
 } from './QuickStartTypes';
 
 import { callAppRest, RestApiPathConstants } from '../../../utils/api';
+import { Redirect } from 'react-router-dom';
+import { quickstartStatusPath } from '../../../utils/RoutePaths';
 
 const QUICKSTART_PARAMETERS_URL =
     'https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/mothra/quickstart-jira-dc-with-vpc.template.parameters.yaml';
@@ -217,8 +219,9 @@ const QuickStartDeployContainer = styled.div`
 `;
 
 export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
-    const [params, setParams]: [Array<QuickstartParameterGroup>, Function] = useState([]);
-    const [loading, setLoading] = useState(false);
+    const [params, setParams] = useState<Array<QuickstartParameterGroup>>([]);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [readyForNextStep, setReadyForNextStep] = useState<boolean>(false);
 
     useEffect(() => {
         setLoading(true);
@@ -238,6 +241,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
 
     return (
         <QuickStartDeployContainer>
+            {readyForNextStep && <Redirect to={quickstartStatusPath} />}
             {loading ? <Spinner /> : <QuickstartForm quickstartParamGroups={params} />}
         </QuickStartDeployContainer>
     );

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -219,7 +219,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
             if (isOptionType(value)) {
                 transformedCfnParams[key] = value.value;
             } else if (isArrayOfOptionType(value)) {
-                transformedCfnParams[key] = JSON.stringify(value.map(option => option.value));
+                transformedCfnParams[key] = value.map(option => option.value).join(',');
             }
         });
 
@@ -228,7 +228,6 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
             params: transformedCfnParams,
         })
             .then(response => {
-                console.log(response);
                 if (response.status !== 202) {
                     throw Error('Stack provisioning failed');
                 }

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/quickstartToAtlaskit.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/quickstartToAtlaskit.tsx
@@ -198,17 +198,13 @@ const createStringInputFromQuickstartParam: FormElementGenerator = (defaultField
 
 const createInputFromQuickstartParam: FormElementGenerator = (defaultFieldProps, param) => {
     const {
-        paramKey,
         paramProperties: { Type },
     } = param;
     if (Type === 'Number') {
         return createNumberInputFromQuickstartParam(defaultFieldProps, param);
     }
-    if (Type === 'String') {
-        return createStringInputFromQuickstartParam(defaultFieldProps, param);
-    }
 
-    return <div key={paramKey}>UNRECOGNISED PARAM TYPE</div>;
+    return createStringInputFromQuickstartParam(defaultFieldProps, param);
 };
 
 const createSelectFromQuickstartParam: FormElementGenerator = (defaultFieldProps, param) => {


### PR DESCRIPTION
## Summary

* Implements "Automatic" navigation transitions to the next step after submission of
    * Migration creation
    * Quickstart form submission
    * Authentication

### Side Fixes

* Updates the s3 bucket to the production bucket with the latest version of the template parameters.
* Fixes a bug where the availability zones were being serialised as JSON instead of a comma-separated list
* Bit of a cleanup on the quickstart form
* Default to string input if the quickstart form parameter type isn't recognised