### PR TITLE
CHET-286: update migration helper to drop owner and be more resilient

### DIFF
--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -147,15 +147,29 @@ Resources:
                     mkdir -p $DATABASE_DOWNLOAD_DIR
                     DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
                     SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
+                    if [ $? != 0]; then
+                      echo "Error when fetching db password from secret manage"
+                      exit 1
+                    fi
                     aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
+                    if [ $? != 0]; then
+                      echo "Error when synchronising with the S3 bucket"
+                      exit 1
+                    fi
                     echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/$DBName" | tee $DB_DUMP_LOG_FILE
-                    PGPASSWORD=$SECRET_PASSWORD pg_restore -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
-                    PG_RESTORE_EXIT_CODE=$?
-                    ERRORS_EXIST=`grep -qiE 'error|warning' /var/atlassian/dc-migration-assistant/pg_dump-log.txt && echo 'true' || echo 'false'`
-                    RESTORE_COMPLETE=`grep -qiE 'pg_restore: finished main parallel loop' /var/atlassian/dc-migration-assistant/pg_dump-log.txt && echo 'true' || echo 'false'`
-                    echo -e "{\"is_restore_complete\":\""$RESTORE_COMPLETE"\",\"is_error_present\":\""$ERRORS_EXIST"\", "return_code":\""$PG_RESTORE_EXIT_CODE"\"}"
+                    PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
+                    ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
+
+                    if [ -z "$ERROR_OUTPUT" ]; then
+                            echo "SUCCESS: Database migration was successful"
+                            exit 0
+                    else
+                            echo "Errors:"
+                            echo "${ERROR_OUTPUT}"
+                            echo "ERROR: Database migration wasn't successful"
+                            exit 1
+                    fi
                   - {
-                    SecretIdentifier: !Sub "atl-${AWS::StackName}-app-rds-password",
                     MigrationBucket: !Ref MigrationBucket,
                     DBHost: !Ref RDSEndpoint,
                     DBPort: !Ref RDSPort,

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -143,17 +143,32 @@ Resources:
                 content: !Sub
                   - |
                     #!/bin/bash
-                    DATABASE_DOWNLOAD_DIR="/efs/downloads/db.dump"
-                    mkdir -p $DATABASE_DOWNLOAD_DIR
-                    DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
-                    SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
-                    aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
-                    echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/$DBName" | tee $DB_DUMP_LOG_FILE
-                    PGPASSWORD=$SECRET_PASSWORD pg_restore -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
-                    PG_RESTORE_EXIT_CODE=$?
-                    ERRORS_EXIST=`grep -qiE 'error|warning' /var/atlassian/dc-migration-assistant/pg_dump-log.txt && echo 'true' || echo 'false'`
-                    RESTORE_COMPLETE=`grep -qiE 'pg_restore: finished main parallel loop' /var/atlassian/dc-migration-assistant/pg_dump-log.txt && echo 'true' || echo 'false'`
-                    echo -e "{\"is_restore_complete\":\""$RESTORE_COMPLETE"\",\"is_error_present\":\""$ERRORS_EXIST"\", "return_code":\""$PG_RESTORE_EXIT_CODE"\"}"
+                     DATABASE_DOWNLOAD_DIR="/efs/downloads/db.dump"
+                     mkdir -p $DATABASE_DOWNLOAD_DIR
+                     DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
+                     SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
+                     if [ $? != 0]; then
+                       echo "Error when fetching db password from secret manage"
+                       exit 1
+                     fi
+                     aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
+                     if [ $? != 0]; then
+                       echo "Error when synchronising with the S3 bucket"
+                       exit 1
+                     fi
+                     echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/$DBName" | tee $DB_DUMP_LOG_FILE
+                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
+                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
+
+                     if [ -z "$ERROR_OUTPUT" ]; then
+                             echo "SUCCESS: Database migration was successful"
+                             exit 0
+                     else
+                             echo "Errors:"
+                             echo "${ERROR_OUTPUT}"
+                             echo "ERROR: Database migration wasn't successful"
+                             exit 1
+                     fi
                   - {
                     SecretIdentifier: !Sub "atl-${AWS::StackName}-app-rds-password",
                     MigrationBucket: !Ref MigrationBucket,


### PR DESCRIPTION
* When doing `pg_dump` with directory format the `--no-owner` and `--no-acl` flags are ignored. These flags need to be instead used when running `pg_restore`, if the original table owner was different that the target stack (`atljira` in our case), the restore failed
* The script was always returning exit code 0 so it was always reported successful and DC migration plugin was always 😀  even when it should be a bit 😞 . It now exits with `1` if unsuccessful (for all sort of different reasons)
* The RDS I was restoring data to had the relationships in it - I am not sure how it happened - but to be sure I've included `--clear --if-exists`. We can investigate later - right now, the whole cycle to get the stack up and running makes this nightmare.
* I've uploaded the `migration-stack.yaml` to `trebuchet-aws-resources` S3 bucket so it will be picked up by the application.

Warning
The migration still doesn't work for Postgres 10 and newer. I've created https://aws-partner.atlassian.net/browse/CHET-298