### PR TITLE
fix the REST test running against dogfooding

### DIFF
--- a/func-tests/src/test/kotlin/com/atlassian/migration/api/MigrationEndpointRestTest.kt
+++ b/func-tests/src/test/kotlin/com/atlassian/migration/api/MigrationEndpointRestTest.kt
@@ -17,24 +17,29 @@
 package com.atlassian.migration.api
 
 import com.atlassian.migration.test.BaseRestTest
-import io.restassured.builder.RequestSpecBuilder
-import io.restassured.filter.log.LogDetail
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
+import org.hamcrest.CoreMatchers.anyOf
+import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.Test
 import javax.ws.rs.core.Response
 
 class MigrationEndpointRestTest : BaseRestTest() {
 
     @Test
-    fun `Migration endpoint should return 404 if not initialised`() {
+    fun `Migration endpoint should return 404 if not initialised or 200 when it was created`() {
         Given {
             spec(requestSpec)
         } When {
             get("/migration")
         } Then {
-            statusCode(Response.Status.NOT_FOUND.statusCode)
+            statusCode(
+                anyOf(
+                    equalTo(Response.Status.NOT_FOUND.statusCode),
+                    equalTo(Response.Status.OK.statusCode)
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
This is a fix for now but it is not ideal.

Testing against dogfooding instance that is used will be quite tricky. I think it would be good to introduce a testing beacon that we can ping to verify state of the plugin and verify basic diagnostics.

I've created:
https://aws-partner.atlassian.net/browse/CHET-307