### PR TITLE
Chet 311 parameterise cfn template url

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
-QUICKSTART_PARAMETERS_URL=https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/mothra/quickstart-jira-dc-with-vpc.template.parameters.yaml
-QUICKSTART_TEMPLATE_URL=https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml
+REACT_APP_QUICKSTART_PARAMETERS_URL=https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/trebuchet/tests/existing-vpc/quickstart-jira-dc.template.parameters.yaml

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_QUICKSTART_PARAMETERS_URL=https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/trebuchet/tests/existing-vpc/quickstart-jira-dc.template.parameters.yaml
+REACT_APP_QUICKSTART_PARAMETERS_URL=https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc-with-vpc.template.parameters.yaml

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,0 @@
-QUICKSTART_PARAMETERS_URL=https://dcd-slinghost-templates.s3.amazonaws.com/mothra/test-create-s3-bucket.parameters.yaml
-QUICKSTART_TEMPLATE_URL=https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/mothra/test-create-s3-bucket.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ package-lock.json
 # Emacs
 *~
 \#*\#
+
+# Env overrides file
+.env.*

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -48,6 +48,8 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
     private static final Logger logger = LoggerFactory.getLogger(AWSMigrationHelperDeploymentService.class);
     private static final String MIGRATION_HELPER_TEMPLATE_URL = "https://trebuchet-aws-resources.s3.amazonaws.com/migration-helper.yml";
 
+    private static final String templateUrl = System.getProperty("migration_helper.template.url", MIGRATION_HELPER_TEMPLATE_URL);
+
     private final Supplier<AutoScalingClient> autoscalingClientFactory;
     private final MigrationService migrationService;
     private final CfnApi cfnApi;
@@ -81,7 +83,7 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
 
         String applicationDeploymentId = migrationService.getCurrentContext().getApplicationDeploymentId();
         String migrationStackDeploymentId = applicationDeploymentId + "-migration";
-        super.deployCloudformationStack(MIGRATION_HELPER_TEMPLATE_URL, migrationStackDeploymentId, params);
+        super.deployCloudformationStack(templateUrl, migrationStackDeploymentId, params);
         migrationService.transition(MigrationStage.PROVISION_MIGRATION_STACK_WAIT);
 
         final MigrationContext context = migrationService.getCurrentContext();

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -44,6 +44,8 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     private final Logger logger = LoggerFactory.getLogger(QuickstartDeploymentService.class);
     private static final String QUICKSTART_TEMPLATE_URL = "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml";
 
+    private static final String templateUrl = System.getProperty("quickstart.template.url", QUICKSTART_TEMPLATE_URL);
+
     private final MigrationService migrationService;
     private final TargetDbCredentialsStorageService dbCredentialsStorageService;
     private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
@@ -74,7 +76,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         migrationService.transition(MigrationStage.PROVISION_APPLICATION_WAIT);
 
         logger.info("deploying application stack");
-        super.deployCloudformationStack(QUICKSTART_TEMPLATE_URL, deploymentId, params);
+        super.deployCloudformationStack(templateUrl, deploymentId, params);
 
         addDeploymentIdToMigrationContext(deploymentId);
 

--- a/frontend/config/webpack.config.js
+++ b/frontend/config/webpack.config.js
@@ -19,6 +19,7 @@ const merge = require('webpack-merge');
 const webpack = require('webpack');
 const path = require('path');
 const dotenv = require('dotenv');
+const fs = require('fs');
 
 const {
     DEV_SERVER_HOST,
@@ -90,22 +91,41 @@ const prodConfig = {
 };
 
 module.exports = (env, argv = {}) => {
-    function isProductionEnv(mode = argv.mode) {
-        return mode !== 'development';
-    }
+    const isProductionEnv = (mode = argv.mode) => mode !== 'development';
 
-    function loadDotEnvVariables(mode) {
-        let dotEnvFilePath = path.join(__dirname, '../..', '.env');
-        if (!isProductionEnv(mode)) {
-            dotEnvFilePath = dotEnvFilePath + '.' + mode;
-        }
-        const dotEnvOverrides = dotenv.config({ path: dotEnvFilePath }).parsed;
+    const parseEnvVariablesFrom = filePath => {
+        const dotEnvOverrides = dotenv.config({ path: filePath }).parsed;
 
-        return Object.keys(dotEnvOverrides).reduce((acc, current) => {
+        const acc = Object.keys(dotEnvOverrides).reduce((acc, current) => {
             acc[`process.env.${current}`] = JSON.stringify(dotEnvOverrides[current]);
             return acc;
         }, {});
-    }
+        console.log(acc)
+        return acc;
+    };
+
+    const loadDotEnvVariables = mode => {
+        const dotEnvFilePath = path.join(__dirname, '../..', '.env');
+        const acc = {};
+
+        if (fs.existsSync(dotEnvFilePath)) {
+            const envVars = parseEnvVariablesFrom(dotEnvFilePath);
+            Object.keys(envVars).forEach(key => {
+                acc[key] = envVars[key];
+            });
+        }
+        if (!isProductionEnv(mode)) {
+            const envScopedOverridesFile = `${dotEnvFilePath}.${mode}`;
+            if (fs.existsSync(envScopedOverridesFile)) {
+                const envVars = parseEnvVariablesFrom(envScopedOverridesFile);
+                Object.keys(envVars).forEach(key => {
+                    acc[key] = envVars[key];
+                });
+            }
+            console.log(acc);
+            return acc;
+        }
+    };
 
     const isProduction = isProductionEnv();
     const modeConfig = isProduction ? prodConfig : devConfig(env);

--- a/frontend/config/webpack.config.js
+++ b/frontend/config/webpack.config.js
@@ -95,36 +95,35 @@ module.exports = (env, argv = {}) => {
 
     const parseEnvVariablesFrom = filePath => {
         const dotEnvOverrides = dotenv.config({ path: filePath }).parsed;
-
-        const acc = Object.keys(dotEnvOverrides).reduce((acc, current) => {
+        return Object.keys(dotEnvOverrides).reduce((acc, current) => {
             acc[`process.env.${current}`] = JSON.stringify(dotEnvOverrides[current]);
             return acc;
         }, {});
-        console.log(acc)
-        return acc;
     };
 
-    const loadDotEnvVariables = mode => {
-        const dotEnvFilePath = path.join(__dirname, '../..', '.env');
-        const acc = {};
-
+    const loadEnvVarsFrom = (dotEnvFilePath, acc) => {
         if (fs.existsSync(dotEnvFilePath)) {
             const envVars = parseEnvVariablesFrom(dotEnvFilePath);
             Object.keys(envVars).forEach(key => {
                 acc[key] = envVars[key];
             });
         }
+        return acc;
+    };
+
+    const loadDotEnvVariables = mode => {
+        const dotEnvFilePath = path.join(__dirname, '../..', '.env');
+        const varsFromEnvFile = loadEnvVarsFrom(dotEnvFilePath, {});
         if (!isProductionEnv(mode)) {
             const envScopedOverridesFile = `${dotEnvFilePath}.${mode}`;
-            if (fs.existsSync(envScopedOverridesFile)) {
-                const envVars = parseEnvVariablesFrom(envScopedOverridesFile);
-                Object.keys(envVars).forEach(key => {
-                    acc[key] = envVars[key];
-                });
-            }
-            console.log(acc);
-            return acc;
+            const envVarOverrides = loadEnvVarsFrom(envScopedOverridesFile, varsFromEnvFile);
+            console.log(`Loaded env vars with overrides`);
+            console.log(envVarOverrides);
+            return envVarOverrides;
         }
+        console.log(`Loaded env vars`);
+        console.log(varsFromEnvFile);
+        return varsFromEnvFile;
     };
 
     const isProduction = isProductionEnv();

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -16,7 +16,7 @@
 
 import React, { FunctionComponent, ReactElement, ReactFragment, useEffect, useState } from 'react';
 import yaml from 'yaml';
-import Form, { ErrorMessage, Field, HelperMessage, FormHeader, FormSection } from '@atlaskit/form';
+import Form, { ErrorMessage, Field, FormHeader, FormSection, HelperMessage } from '@atlaskit/form';
 import TextField from '@atlaskit/textfield';
 import Button, { ButtonGroup } from '@atlaskit/button';
 import Spinner from '@atlaskit/spinner';
@@ -36,9 +36,6 @@ import {
 
 import { callAppRest, RestApiPathConstants } from '../../../utils/api';
 import { quickstartStatusPath } from '../../../utils/RoutePaths';
-
-const QUICKSTART_PARAMETERS_URL =
-    'https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc-with-vpc.template.parameters.yaml';
 
 const STACK_NAME_FIELD_NAME = 'stackName';
 
@@ -206,6 +203,16 @@ const QuickStartDeployContainer = styled.div`
     justify-items: center;
 `;
 
+const DEFAULT_QUICKSTART_PARAMETER_URL =
+    'https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc-with-vpc.template.parameters.yaml';
+
+const quickstartParametersTemplateLocation = () => {
+    const parametersUrlFromEnv = process.env.REACT_APP_QUICKSTART_PARAMETERS_URL;
+    return parametersUrlFromEnv === undefined
+        ? DEFAULT_QUICKSTART_PARAMETER_URL
+        : parametersUrlFromEnv;
+};
+
 export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
     const [params, setParams] = useState<Array<QuickstartParameterGroup>>([]);
     const [loading, setLoading] = useState<boolean>(false);
@@ -213,7 +220,7 @@ export const QuickStartDeploy: FunctionComponent = (): ReactElement => {
 
     useEffect(() => {
         setLoading(true);
-        fetch(QUICKSTART_PARAMETERS_URL, {
+        fetch(quickstartParametersTemplateLocation(), {
             method: 'GET',
         })
             .then(resp => resp.text())


### PR DESCRIPTION
OK, so this PR adds the ability to parameterise template URLs both in the FE and backend code flows

On the server side, if we want to specify a template URL for deploy, we should specify a system property like so - `-Dquickstart.template.url=https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/trebuchet/tests/existing-vpc/quickstart-jira-dc.template.yaml ` to specify the DC template without VPC.

On the front end, things get a bit more interesting. Obviously, the FE app can't read environment variables at runtime. We can inject the template URLs at build time. To do this, we create a webpack plugin that reads from a `.env` file (located in the project root) and creates a dictionary with keys having a prefix (`process.env.`) and suffixed by the key value defined in the `.env` file. 

In this case, the dictionary would be `{process.env.REACT_APP_QUICKSTART_PARAMETERS_URL=https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc-with-vpc.template.parameters.yaml}`

After this, when we use `process.env.REACT_APP_QUICKSTART_PARAMETERS_URL` in any `.tsx` file, it will be replaced with the value above.

When we run this using `yarn:dev-server`, we can additionally specify overrides in a file called `.env.development` (this has been `.gitignored`) and further override the value in the `.env` file, which is checked in to source control.

When we compile the FE project using `mvn install`, the .env file is read and the default, production value of the URL is used during the compilation flow. Subsequently, this is packaged and installed as a plugin, we can see the form rendered with the values from the template file present in `.env`

If we need to override this with the, say, existing VPC template, we should create an `.env.development` file (or modify the .env file for local testing only) and update the URL to the without VPC parameters file (`https://dcd-slinghost-templates.s3-ap-southeast-2.amazonaws.com/trebuchet/tests/existing-vpc/quickstart-jira-dc.template.yaml`)

We can then build the FE project by running `mvn clean install -DskipTests -Dyarn.cmd.build=build:dev
` in development mode to pick these changes in the `.env.development` file and when we package & install the plugin, we should be able to see the parameters being based on the URL in the `.env.development` file

It's imperative that the .env file remains checked-in and has the prroduction parameters file URL in it at all times. This perhaps requires a build time test that I can write.

Do try this out and let me know if anything needs to be changed/modified.

All template and the parameters file (publicly accessible) can be found under - 
`https://s3.console.aws.amazon.com/s3/buckets/dcd-slinghost-templates/trebuchet/tests/existing-vpc/?region=ap-southeast-2&tab=overview`