### PR TITLE
CHET-320: Create common CancelButton component and update the design

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -23,7 +23,7 @@ import { MigrationTransferProps, MigrationTransferPage } from '../shared/Migrati
 import { Progress, ProgressBuilder } from '../shared/Progress';
 import { fs, FileSystemMigrationStatusResponse } from '../../api/fs';
 import { migration, MigrationStage } from '../../api/migration';
-import { dbPath } from '../../utils/RoutePaths';
+import { warningPath } from '../../utils/RoutePaths';
 
 const dummyStarted = moment();
 
@@ -124,7 +124,7 @@ const fsMigrationTranferPageProps: MigrationTransferProps = {
     inProgressStages: [MigrationStage.FS_MIGRATION_COPY_WAIT],
     startMigrationPhase: fs.startFsMigration,
     getProgress: getFsMigrationProgress,
-    nextRoute: dbPath,
+    nextRoute: warningPath,
 };
 
 export const FileSystemTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
@@ -4,17 +4,14 @@ import Button from '@atlaskit/button';
 import { overviewPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 
-export const defaultButtonStyle = {
-    padding: '5px',
-};
-export const marginButtonStyle = {
-    ...defaultButtonStyle,
-    marginRight: '20px',
+export const cancelButtonStyle = {
+    paddingLeft: '5px',
+    marginLeft: '20px',
 };
 
 export const CancelButton: FunctionComponent = () => (
     <Link to={overviewPath}>
-        <Button style={marginButtonStyle}>
+        <Button style={cancelButtonStyle}>
             {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
         </Button>
     </Link>

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
@@ -1,0 +1,21 @@
+import React, { FunctionComponent } from 'react';
+import { Link } from 'react-router-dom';
+import Button from '@atlaskit/button';
+import { overviewPath } from '../../utils/RoutePaths';
+import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+
+export const defaultButtonStyle = {
+    padding: '5px',
+};
+export const marginButtonStyle = {
+    ...defaultButtonStyle,
+    marginRight: '20px',
+};
+
+export const CancelButton: FunctionComponent = () => (
+    <Link to={overviewPath}>
+        <Button style={marginButtonStyle}>
+            {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
+        </Button>
+    </Link>
+);

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import Button from '@atlaskit/button';
 import { Link } from 'react-router-dom';
-import { CancelButton, marginButtonStyle, defaultButtonStyle } from './CancelButton';
+import { CancelButton } from './CancelButton';
 
 export type MigrationTransferActionsProps = {
     /**
@@ -51,6 +51,14 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
     started,
     loading,
 }) => {
+    const defaultButtonStyle = {
+        padding: '5px',
+    };
+
+    const marginButtonStyle = {
+        ...defaultButtonStyle,
+        marginRight: '20px',
+    };
     const StartButton = (
         <Button
             style={marginButtonStyle}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -1,8 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import Button from '@atlaskit/button';
 import { Link } from 'react-router-dom';
-import { I18n } from '@atlassian/wrm-react-i18n';
-import { overviewPath } from '../../utils/RoutePaths';
+import { CancelButton, marginButtonStyle, defaultButtonStyle } from './CancelButton';
 
 export type MigrationTransferActionsProps = {
     /**
@@ -52,22 +51,6 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
     started,
     loading,
 }) => {
-    const defaultButtonStyle = {
-        padding: '5px',
-    };
-    const marginButtonStyle = {
-        ...defaultButtonStyle,
-        marginRight: '20px',
-    };
-
-    const CancelButton = (
-        <Link to={overviewPath}>
-            <Button style={{ marginLeft: '20px', paddingLeft: '5px' }}>
-                {I18n.getText('atlassian.migration.datacenter.generic.cancel')}
-            </Button>
-        </Link>
-    );
-
     const StartButton = (
         <Button
             style={marginButtonStyle}
@@ -102,7 +85,7 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
     return (
         <>
             {ActionButton}
-            {CancelButton}
+            <CancelButton />
         </>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -5,15 +5,13 @@ import Button from '@atlaskit/button';
 import { Redirect } from 'react-router-dom';
 import { dbPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { CancelButton, marginButtonStyle } from '../shared/CancelButton';
 
 export const WarningStagePage: FunctionComponent = () => {
     const [agreed, setAgreed] = useState<boolean>(false);
     const [shouldRedirect, setShouldRedirect] = useState<boolean>(false);
 
-    const heading = I18n.getText('atlassian.migration.datacenter.db.title');
-    const description = I18n.getText('atlassian.migration.datacenter.db.description');
-
-    const handleClick = (): void => {
+    const handleConfirmation = (): void => {
         if (agreed) {
             setShouldRedirect(true);
         }
@@ -27,25 +25,52 @@ export const WarningStagePage: FunctionComponent = () => {
         return <Redirect to={dbPath} push />;
     }
 
+    const NextButton = (
+        <Button
+            isDisabled={!agreed}
+            onClick={handleConfirmation}
+            appearance="primary"
+            css={marginButtonStyle}
+        >
+            {I18n.getText('atlassian.migration.datacenter.generic.next')}
+        </Button>
+    );
+
+    const checkboxSectionStyle = {
+        margin: '20px',
+    };
+
     return (
         <div>
-            <h1>{heading}</h1>
-            <p>{description}</p>
-            <SectionMessage appearance="info" title="To take your Jira instance offline:">
+            <h1>{I18n.getText('atlassian.migration.datacenter.warning.title')}</h1>
+            <p>{I18n.getText('atlassian.migration.datacenter.warning.description')}</p>
+            <SectionMessage
+                appearance="info"
+                title={I18n.getText('atlassian.migration.datacenter.warning.section.header')}
+            >
                 <ol>
-                    <li>Make sure that users are logged out</li>
-                    <li>Redirect the DNS to a maintenance page</li>
+                    <li>
+                        {I18n.getText(
+                            'atlassian.migration.datacenter.warning.section.list.loggedOutUsers'
+                        )}
+                    </li>
+                    <li>
+                        {I18n.getText(
+                            'atlassian.migration.datacenter.warning.section.list.dnsRedirection'
+                        )}
+                    </li>
                 </ol>
             </SectionMessage>
-            <Checkbox
-                value="agree"
-                label="I'm ready for the next step"
-                onChange={agreeOnClick}
-                name="agree"
-            />
-            <Button isDisabled={!agreed} onClick={handleClick}>
-                Continue
-            </Button>
+            <div style={checkboxSectionStyle}>
+                <Checkbox
+                    value="agree"
+                    label="I'm ready for the next step"
+                    onChange={agreeOnClick}
+                    name="agree"
+                />
+            </div>
+            {NextButton}
+            <CancelButton css={marginButtonStyle} />
         </div>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -3,9 +3,27 @@ import SectionMessage from '@atlaskit/section-message';
 import { Checkbox } from '@atlaskit/checkbox';
 import Button from '@atlaskit/button';
 import { Redirect } from 'react-router-dom';
+import styled from 'styled-components';
 import { dbPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
-import { CancelButton, marginButtonStyle } from '../shared/CancelButton';
+import { CancelButton } from '../shared/CancelButton';
+
+const Container = styled.div`
+    max-width: 920px;
+`;
+
+const Paragraph = styled.p`
+    margin-bottom: '10px';
+`;
+
+const nextButtonStyle = {
+    padding: '5px',
+    marginRight: '20px',
+};
+
+const checkboxSectionStyle = {
+    margin: '20px',
+};
 
 export const WarningStagePage: FunctionComponent = () => {
     const [agreed, setAgreed] = useState<boolean>(false);
@@ -30,20 +48,18 @@ export const WarningStagePage: FunctionComponent = () => {
             isDisabled={!agreed}
             onClick={handleConfirmation}
             appearance="primary"
-            css={marginButtonStyle}
+            style={nextButtonStyle}
         >
             {I18n.getText('atlassian.migration.datacenter.generic.next')}
         </Button>
     );
 
-    const checkboxSectionStyle = {
-        margin: '20px',
-    };
-
     return (
-        <div>
+        <Container>
             <h1>{I18n.getText('atlassian.migration.datacenter.warning.title')}</h1>
-            <p>{I18n.getText('atlassian.migration.datacenter.warning.description')}</p>
+            <Paragraph>
+                {I18n.getText('atlassian.migration.datacenter.warning.description')}
+            </Paragraph>
             <SectionMessage
                 appearance="info"
                 title={I18n.getText('atlassian.migration.datacenter.warning.section.header')}
@@ -70,7 +86,7 @@ export const WarningStagePage: FunctionComponent = () => {
                 />
             </div>
             {NextButton}
-            <CancelButton css={marginButtonStyle} />
-        </div>
+            <CancelButton />
+        </Container>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -16,13 +16,13 @@ const Paragraph = styled.p`
     margin-bottom: '10px';
 `;
 
+const CheckboxContainer = styled.div`
+    margin: '20px';
+`;
+
 const nextButtonStyle = {
     padding: '5px',
     marginRight: '20px',
-};
-
-const checkboxSectionStyle = {
-    margin: '20px',
 };
 
 export const WarningStagePage: FunctionComponent = () => {
@@ -77,14 +77,14 @@ export const WarningStagePage: FunctionComponent = () => {
                     </li>
                 </ol>
             </SectionMessage>
-            <div style={checkboxSectionStyle}>
+            <CheckboxContainer>
                 <Checkbox
                     value="agree"
                     label="I'm ready for the next step"
                     onChange={agreeOnClick}
                     name="agree"
                 />
-            </div>
+            </CheckboxContainer>
             {NextButton}
             <CancelButton />
         </Container>

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -84,6 +84,9 @@ atlassian.migration.datacenter.fs.completeMessage.message=were successfully migr
 # Warning page
 atlassian.migration.datacenter.warning.title=Step 4 of 6: Redirect users
 atlassian.migration.datacenter.warning.description=Take your Jira instance offline to prevent users from accessing it. This will allow us to sync your database properly. User access during this phase could prevent some data from being copied.
+atlassian.migration.datacenter.warning.section.header=To take your Jira instance offline:
+atlassian.migration.datacenter.warning.section.list.loggedOutUsers=Make sure that users are logged out
+atlassian.migration.datacenter.warning.section.list.dnsRedirection=Redirect the DNS to a maintenance page
 
 # Database sync page
 atlassian.migration.datacenter.db.title=Step 5 of 6: Sync database


### PR DESCRIPTION
* Internationalization for Warning page
* Extract common `CancelButton`
* The next page after FS migration is the Warning page now
* Add cancel button on the warning page
* Rename the submit button from `Continue` to `Next`

<img width="1352" alt="image" src="https://user-images.githubusercontent.com/416238/80782562-1292a600-8bba-11ea-9822-3a1535388ec5.png">

<img width="485" alt="image" src="https://user-images.githubusercontent.com/416238/80782585-2211ef00-8bba-11ea-8f01-daa1b5872e2d.png">
