### PR TITLE
CHET-329: Add learn more link

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -19,12 +19,12 @@ import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 import moment from 'moment';
 import Spinner from '@atlaskit/spinner';
+import { I18n } from '@atlassian/wrm-react-i18n';
 
 import { MigrationTransferActions } from './MigrationTransferPageActions';
 import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
-import { I18n } from '@atlassian/wrm-react-i18n';
 
 const POLL_INTERVAL_MILLIS = 3000;
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -7,17 +7,19 @@ import styled from 'styled-components';
 import { dbPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { CancelButton } from '../shared/CancelButton';
+import { migration } from '../../api/migration';
 
 const Container = styled.div`
     max-width: 920px;
 `;
 
 const Paragraph = styled.p`
-    margin-bottom: '10px';
+    margin-bottom: '20px';
 `;
 
 const CheckboxContainer = styled.div`
-    margin: '20px';
+    margin: '50px 0';
+    padding: '10px';
 `;
 
 const nextButtonStyle = {

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, useState } from 'react';
 import SectionMessage from '@atlaskit/section-message';
 import { Checkbox } from '@atlaskit/checkbox';
 import Button from '@atlaskit/button';
-import { Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 import { dbPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
@@ -66,29 +65,13 @@ const LearnMore: FunctionComponent = () => {
 
 export const WarningStagePage: FunctionComponent = () => {
     const [agreed, setAgreed] = useState<boolean>(false);
-    const [shouldRedirect, setShouldRedirect] = useState<boolean>(false);
-
-    const handleConfirmation = (): void => {
-        if (agreed) {
-            setShouldRedirect(true);
-        }
-    };
 
     const agreeOnClick = (event: any): void => {
         setAgreed(event.target.checked);
     };
 
-    if (shouldRedirect) {
-        return <Redirect to={dbPath} push />;
-    }
-
     const NextButton = (
-        <Button
-            isDisabled={!agreed}
-            onClick={handleConfirmation}
-            appearance="primary"
-            style={nextButtonStyle}
-        >
+        <Button href={dbPath} isDisabled={!agreed} appearance="primary" style={nextButtonStyle}>
             {I18n.getText('atlassian.migration.datacenter.generic.next')}
         </Button>
     );

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -7,19 +7,43 @@ import styled from 'styled-components';
 import { dbPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { CancelButton } from '../shared/CancelButton';
-import { migration } from '../../api/migration';
-
-const Container = styled.div`
-    max-width: 920px;
-`;
 
 const Paragraph = styled.p`
     margin-bottom: '20px';
 `;
 
+const WarningPageContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 920px;
+    margin-right: auto;
+    margin-bottom: auto;
+    padding-left: 15px;
+`;
+
+const WarningContentContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding-right: 30px;
+
+    padding-bottom: 5px;
+`;
+
+const WarningActionsContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+
+    margin-top: 20px;
+`;
+
 const CheckboxContainer = styled.div`
-    margin: '50px 0';
-    padding: '10px';
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    margin-top: 10px;
+    padding: 10px;
 `;
 
 const nextButtonStyle = {
@@ -70,12 +94,14 @@ export const WarningStagePage: FunctionComponent = () => {
     );
 
     return (
-        <Container>
-            <h1>{I18n.getText('atlassian.migration.datacenter.warning.title')}</h1>
-            <Paragraph>
-                {I18n.getText('atlassian.migration.datacenter.warning.description')}
-            </Paragraph>
-            <LearnMore />
+        <WarningPageContainer>
+            <WarningContentContainer>
+                <h1>{I18n.getText('atlassian.migration.datacenter.warning.title')}</h1>
+                <Paragraph>
+                    {I18n.getText('atlassian.migration.datacenter.warning.description')}
+                </Paragraph>
+                <LearnMore />
+            </WarningContentContainer>
             <SectionMessage
                 appearance="info"
                 title={I18n.getText('atlassian.migration.datacenter.warning.section.header')}
@@ -101,8 +127,10 @@ export const WarningStagePage: FunctionComponent = () => {
                     name="agree"
                 />
             </CheckboxContainer>
-            {NextButton}
-            <CancelButton />
-        </Container>
+            <WarningActionsContainer>
+                {NextButton}
+                <CancelButton />
+            </WarningActionsContainer>
+        </WarningPageContainer>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -25,6 +25,19 @@ const nextButtonStyle = {
     marginRight: '20px',
 };
 
+const LearnMore: FunctionComponent = () => {
+    const LearnMoreLink =
+        'https://confluence.atlassian.com/jirakb/how-to-use-the-data-center-migration-app-to-migrate-jira-to-an-aws-cluster-1005781495.html#HowtousetheDataCenterMigrationapptomigrateJiratoanAWScluster-downtimepage';
+
+    return (
+        <Paragraph>
+            <a target="_blank" rel="noreferrer noopener" href={LearnMoreLink}>
+                {I18n.getText('atlassian.migration.datacenter.common.learn_more')}
+            </a>
+        </Paragraph>
+    );
+};
+
 export const WarningStagePage: FunctionComponent = () => {
     const [agreed, setAgreed] = useState<boolean>(false);
     const [shouldRedirect, setShouldRedirect] = useState<boolean>(false);
@@ -60,6 +73,7 @@ export const WarningStagePage: FunctionComponent = () => {
             <Paragraph>
                 {I18n.getText('atlassian.migration.datacenter.warning.description')}
             </Paragraph>
+            <LearnMore />
             <SectionMessage
                 appearance="info"
                 title={I18n.getText('atlassian.migration.datacenter.warning.section.header')}


### PR DESCRIPTION
* added Learn More link that links to KB article with description for the downtime.
** The anchor doesn't work properly but I am not sure if this is expected and @ddomingorh does have a version prepared or we need to fix the link. I've left a comment on https://aws-partner.atlassian.net/browse/CHET-329?focusedCommentId=10144
* I've restyled the page so it is more spacious. I think it would be good to have some unified and consistent styles across the page but I would leave that post-MVP
* Lint fix

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/416238/80940334-d57d1c80-8e22-11ea-80f7-2cd56492f2c8.png">
