### PR TITLE
CHET-333: redirect to error path on failure

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/MigrationStageRenderer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/MigrationStageRenderer.tsx
@@ -14,7 +14,6 @@ export const MigrationStageRenderer: FunctionComponent = () => {
             .getMigrationStage()
             .then(stage => {
                 setStage(stage);
-                console.log(stage);
             })
             .catch(() => {
                 setStage(MigrationStage.ERROR);

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -60,6 +60,7 @@ const getDeploymentProgress: ProgressCallback = () => {
             );
             builder.setError(err.message);
             builder.setCompleteness(0);
+            builder.setFailed(true);
             return builder.build();
         });
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -25,6 +25,7 @@ import {
     dbStartEndpoint,
     DatabaseMigrationStatus,
     statusToI18nString,
+    DBMigrationStatus,
 } from '../../api/db';
 import { MigrationStage } from '../../api/migration';
 import { validationPath } from '../../utils/RoutePaths';
@@ -42,6 +43,7 @@ const toProgress = (status: DatabaseMigrationStatus): Progress => {
     return {
         phase: statusToI18nString(status.status),
         elapsedTimeSeconds: status.elapsedTime.seconds,
+        failed: status.status === DBMigrationStatus.FAILED,
     };
 };
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -88,6 +88,7 @@ const getFsMigrationProgress = (): Promise<Progress> => {
             builder.setCompleteness(getCompletenessFromResult(result));
             builder.setPhase(getPhaseFromStatus(result));
             builder.setElapsedSeconds(result.elapsedTime.seconds);
+            builder.setFailed(result.status === 'FAILED');
 
             if (result.status === 'DONE') {
                 builder.setCompleteMessage(

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -26,6 +26,7 @@ import { MigrationTransferActions } from './MigrationTransferPageActions';
 import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
+import { migrationErrorPath } from '../../utils/RoutePaths';
 
 const POLL_INTERVAL_MILLIS = 3000;
 
@@ -162,7 +163,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     }, [started]);
 
     if (progress?.failed) {
-        return <Redirect to="/migration-error" push />;
+        return <Redirect to={migrationErrorPath} push />;
     }
 
     const transferError = progress?.error || error;

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -22,7 +22,6 @@ import Spinner from '@atlaskit/spinner';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { Redirect } from 'react-router-dom';
 
-import { I18n } from '@atlassian/wrm-react-i18n';
 import { MigrationTransferActions } from './MigrationTransferPageActions';
 import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -19,12 +19,13 @@ import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 import moment from 'moment';
 import Spinner from '@atlaskit/spinner';
+import { I18n } from '@atlassian/wrm-react-i18n';
+import { Redirect } from 'react-router-dom';
 
 import { MigrationTransferActions } from './MigrationTransferPageActions';
 import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
-import { I18n } from '@atlassian/wrm-react-i18n';
 
 const POLL_INTERVAL_MILLIS = 3000;
 
@@ -124,7 +125,6 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                 setStarted(true);
             })
             .catch(err => {
-                console.log('setting error from start');
                 setError(err.message);
                 setLoading(false);
             });
@@ -160,6 +160,10 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
         }
         return (): void => undefined;
     }, [started]);
+
+    if (progress?.failed) {
+        return <Redirect to="/migration-error" push />;
+    }
 
     const transferError = progress?.error || error;
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -13,8 +13,9 @@ export type CompleteMessage = {
  * **phase**: Text describing the current phase of the transfer e.g. uploading, downloading, importing..
  * **completeness**: A fraction representing the percentage complete the transfer is.
  * **elapsedTimeSeconds**: The number of seconds the transfer has been going on for.
- * **error**: Text describing a non-critical error that the user may want to verify
- * **completeMessage**: Message to display when the transfer has completed
+ * **error**: Text describing a non-critical error that the user may want to verify.
+ * **completeMessage**: Message to display when the transfer has completed.
+ * **failed**: a flag that should be true if a migration-stopping error has occcured, false otherwise.
  */
 export type Progress = {
     phase: string;
@@ -22,6 +23,7 @@ export type Progress = {
     elapsedTimeSeconds?: number;
     error?: string;
     completeMessage?: CompleteMessage;
+    failed: boolean;
 };
 
 /**
@@ -37,6 +39,8 @@ export class ProgressBuilder {
     private completeMessage: CompleteMessage;
 
     private elapsedSeconds: number;
+
+    private failed: boolean;
 
     setElapsedSeconds(seconds: number): ProgressBuilder {
         this.elapsedSeconds = seconds;
@@ -66,12 +70,18 @@ export class ProgressBuilder {
         return this;
     }
 
+    setFailed(failed: boolean) {
+        this.failed = failed;
+
+        return this;
+    }
+
     build(): Progress {
         if (!this.phase) {
             throw new Error('must include phase in progress object');
         }
 
-        const { phase, completeMessage, completeness, error, elapsedSeconds } = this;
+        const { phase, completeMessage, completeness, error, elapsedSeconds, failed } = this;
 
         return {
             phase,
@@ -79,6 +89,7 @@ export class ProgressBuilder {
             completeness,
             error,
             elapsedTimeSeconds: elapsedSeconds,
+            failed: failed || false,
         };
     }
 }

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -23,7 +23,7 @@ export type Progress = {
     elapsedTimeSeconds?: number;
     error?: string;
     completeMessage?: CompleteMessage;
-    failed: boolean;
+    failed?: boolean;
 };
 
 /**

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -9,6 +9,13 @@ export type CompleteMessage = {
     message: string;
 };
 
+/**
+ * **phase**: Text describing the current phase of the transfer e.g. uploading, downloading, importing..
+ * **completeness**: A fraction representing the percentage complete the transfer is.
+ * **elapsedTimeSeconds**: The number of seconds the transfer has been going on for.
+ * **error**: Text describing a non-critical error that the user may want to verify
+ * **completeMessage**: Message to display when the transfer has completed
+ */
 export type Progress = {
     phase: string;
     completeness?: number;


### PR DESCRIPTION
## Summary

* Implement notion of _critical failure_ in `Progress` structure
* Handle setting of `failed` for each stage of migration
* Use common transfer page to redirect to error page in case of `failed`