### PR TITLE
CHET-322: Exit with 0 with non-critical errors from pg_restore

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -101,7 +101,8 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
 
     @Override
     protected void handleSuccessfulDeployment() {
-        Optional<Stack> maybeStack = cfnApi.getStack(migrationService.getCurrentContext().getHelperStackDeploymentId());
+        String stackId = System.getProperty("com.atlassian.migration.migrationStack.id", migrationService.getCurrentContext().getHelperStackDeploymentId());
+        Optional<Stack> maybeStack = cfnApi.getStack(stackId);
         if (!maybeStack.isPresent()) {
             throw new InfrastructureDeploymentError("stack was not found by DescribeStack even though it succeeded");
         }

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -148,27 +148,37 @@ Resources:
                     DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
                     SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
                     if [ $? != 0 ]; then
-                      echo "Error when fetching DB password from secret manager"
+                      echo "ERROR: cannot fetch DB password from secret manager"
                       exit 1
                     fi
+
                     aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
                     if [ ${pipestatus} != 0 ]; then
-                      echo "Error when synchronising with the S3 bucket"
+                      echo "ERROR: cannot load DB dump from the S3 bucket"
                       exit 1
                     fi
+
                     echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/${DBName}" | tee $DB_DUMP_LOG_FILE
                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
+
+                    # pg_restore won't fail if there are SQL errors when restoring, it fails only if there is a fatal error (e.g. failed reading the file)
+                    PG_RESTORE_EXIT_CODE=${PIPESTATUS[0]}
+                    if [ $PG_RESTORE_EXIT_CODE != 0 ]; then
+                      echo "ERROR: Fatal error while running pg_restore, please review the logs"
+                      exit $PG_RESTORE_EXIT_CODE
+                    fi
+
                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
 
-                    if [ -z "$ERROR_OUTPUT" ]; then
-                            echo "SUCCESS: Database migration was successful"
-                            exit 0
+                    if [[ -z "$ERROR_OUTPUT" ]]; then
+                            echo "SUCCESS: Database migration was successful without errors"
                     else
-                            echo "Errors:"
+                            echo "SQL migration errors:"
                             echo "$ERROR_OUTPUT"
-                            echo "ERROR: Database migration wasn't successful"
-                            exit 1
+                            echo "WARNING: Database migration finished with some errors, please review the log"
                     fi
+
+                    exit 0
                   - SecretIdentifier: !Sub "atl-${AWS::StackName}-app-rds-password"
                     MigrationBucket: !Ref MigrationBucket
                     DBHost: !Ref RDSEndpoint

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -161,13 +161,6 @@ Resources:
                     echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/${DBName}" | tee $DB_DUMP_LOG_FILE
                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
 
-                    # pg_restore won't fail if there are SQL errors when restoring, it fails only if there is a fatal error (e.g. failed reading the file)
-                    PG_RESTORE_EXIT_CODE=${PIPESTATUS[0]}
-                    if [ $PG_RESTORE_EXIT_CODE != 0 ]; then
-                      echo "ERROR: Fatal error while running pg_restore, please review the logs"
-                      exit $PG_RESTORE_EXIT_CODE
-                    fi
-
                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
 
                     if [[ -z "$ERROR_OUTPUT" ]]; then

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -147,16 +147,16 @@ Resources:
                     mkdir -p $DATABASE_DOWNLOAD_DIR
                     DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
                     SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
-                    if [ $? != 0]; then
+                    if [ $? != 0 ]; then
                       echo "Error when fetching DB password from secret manager"
                       exit 1
                     fi
                     aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
-                    if [ ${pipestatus} != 0]; then
+                    if [ ${pipestatus} != 0 ]; then
                       echo "Error when synchronising with the S3 bucket"
                       exit 1
                     fi
-                    echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/$DBName" | tee $DB_DUMP_LOG_FILE
+                    echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/${DBName}" | tee $DB_DUMP_LOG_FILE
                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
 

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -148,27 +148,37 @@ Resources:
                     DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
                     SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
                     if [ $? != 0 ]; then
-                      echo "Error when fetching DB password from secret manager"
+                      echo "ERROR: cannot fetch DB password from secret manager"
                       exit 1
                     fi
+
                     aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
                     if [ ${pipestatus} != 0 ]; then
-                      echo "Error when synchronising with the S3 bucket"
+                      echo "ERROR: cannot load DB dump from the S3 bucket"
                       exit 1
                     fi
+
                     echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/${DBName}" | tee $DB_DUMP_LOG_FILE
                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
+
+                    # pg_restore won't fail if there are SQL errors when restoring, it fails only if there is a fatal error (e.g. failed reading the file)
+                    PG_RESTORE_EXIT_CODE=${PIPESTATUS[0]}
+                    if [ $PG_RESTORE_EXIT_CODE != 0 ]; then
+                      echo "ERROR: Fatal error while running pg_restore, please review the logs"
+                      exit $PG_RESTORE_EXIT_CODE
+                    fi
+
                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
 
-                    if [ -z "$ERROR_OUTPUT" ]; then
-                            echo "SUCCESS: Database migration was successful"
-                            exit 0
+                    if [[ -z "$ERROR_OUTPUT" ]]; then
+                            echo "SUCCESS: Database migration was successful without errors"
                     else
-                            echo "Errors:"
+                            echo "SQL migration errors:"
                             echo "$ERROR_OUTPUT"
-                            echo "ERROR: Database migration wasn't successful"
-                            exit 1
+                            echo "WARNING: Database migration finished with some errors, please review the log"
                     fi
+
+                    exit 0
                   - SecretIdentifier: !Sub "atl-${AWS::StackName}-app-rds-password"
                     MigrationBucket: !Ref MigrationBucket
                     DBHost: !Ref RDSEndpoint

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -161,13 +161,6 @@ Resources:
                     echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/${DBName}" | tee $DB_DUMP_LOG_FILE
                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
 
-                    # pg_restore won't fail if there are SQL errors when restoring, it fails only if there is a fatal error (e.g. failed reading the file)
-                    PG_RESTORE_EXIT_CODE=${PIPESTATUS[0]}
-                    if [ $PG_RESTORE_EXIT_CODE != 0 ]; then
-                      echo "ERROR: Fatal error while running pg_restore, please review the logs"
-                      exit $PG_RESTORE_EXIT_CODE
-                    fi
-
                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
 
                     if [[ -z "$ERROR_OUTPUT" ]]; then

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -147,16 +147,16 @@ Resources:
                     mkdir -p $DATABASE_DOWNLOAD_DIR
                     DB_DUMP_LOG_FILE="/var/atlassian/dc-migration-assistant/pg_dump-log.txt"
                     SECRET_PASSWORD=`aws secretsmanager  get-secret-value --secret-id ${SecretIdentifier} --region ${AWS::Region} --output text --query "SecretString"`
-                    if [ $? != 0]; then
+                    if [ $? != 0 ]; then
                       echo "Error when fetching DB password from secret manager"
                       exit 1
                     fi
                     aws s3 sync s3://${MigrationBucket}/db.dump/ $DATABASE_DOWNLOAD_DIR --region ${AWS::Region} | tee $DB_DUMP_LOG_FILE
-                    if [ ${pipestatus} != 0]; then
+                    if [ ${pipestatus} != 0 ]; then
                       echo "Error when synchronising with the S3 bucket"
                       exit 1
                     fi
-                    echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/$DBName" | tee $DB_DUMP_LOG_FILE
+                    echo "Restoring database from $DATABASE_DOWNLOAD_DIR to ${DBHost}:${DBPort}/${DBName}" | tee $DB_DUMP_LOG_FILE
                     PGPASSWORD=$SECRET_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists -h ${DBHost} -U ${DBUser} -d ${DBName} -p ${DBPort} -F d --verbose $DATABASE_DOWNLOAD_DIR 2>&1 | tee $DB_DUMP_LOG_FILE
                     ERROR_OUTPUT=$(grep -iE 'error|warning' $DB_DUMP_LOG_FILE)
 


### PR DESCRIPTION
* Return either exit code from `pg_restore` if it wasn't `0` or print information with the errors from migration and return `0` as exit code. `pg_dump` returns non-zero code only with fatal errors - e.g. the directory is missing.
* Formatting of the error messages (when we expect people to read the log)
* Added ability to provide migrationStackId via system property
* Uploaded `migration-helper.yml` to `trebuchet-public-resources` S3 bucket and made it public