### PR TITLE
Add some helper scripts for blitz testing.

### DIFF
--- a/jira-e2e-tests/helpers/README.md
+++ b/jira-e2e-tests/helpers/README.md
@@ -4,7 +4,7 @@ To use:
 
 From the project root:
 
-    docker-compose -f jira-e2e-tests/helpers/jira-psql-compose.yml up
+    docker-compose -f jira-e2e-tests/helpers/jira-psql-compose.yml up --no-recreate
 
 Then visit `http://localhost:2990/jira/` and perform setup. (Todo: Automate setup.)
 

--- a/jira-e2e-tests/helpers/README.md
+++ b/jira-e2e-tests/helpers/README.md
@@ -1,0 +1,18 @@
+### Test helpers for Jira plugin
+
+To use:
+
+From the project root:
+
+    docker-compose -f jira-e2e-tests/helpers/jira-psql-compose.yml up
+
+Then visit `http://localhost:2990/jira/` and perform setup. (Todo: Automate setup.)
+
+The latest version of the plugin can be built and installed using:
+
+    mvn package -DskipTests && ./jira-e2e-tests/helpers/upload-plugin
+     
+This builds, uploads, and installs the plugin, and restarts the Jira container.
+
+Optionally; `cd` to `jira-e2e-tests` and run `yarn cypress` to run automated
+UI tests. See README for more details.

--- a/jira-e2e-tests/helpers/jira-psql-compose.yml
+++ b/jira-e2e-tests/helpers/jira-psql-compose.yml
@@ -15,6 +15,7 @@ services:
       - 'ATL_DB_DRIVER=org.postgresql.Driver'
       - 'ATL_DB_TYPE=postgres72'
       - 'ATL_TOMCAT_CONTEXTPATH=/jira'
+      - 'JVM_SUPPORT_RECOMMENDED_ARGS=-Dspring.profiles.active=allowAnyTransition'
 
   postgresql:
     image: postgres:9.6-alpine

--- a/jira-e2e-tests/helpers/jira-psql-compose.yml
+++ b/jira-e2e-tests/helpers/jira-psql-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+
+  jira:
+    image: atlassian/jira-software
+    depends_on:
+      - postgresql
+    ports:
+      - '2990:8080'
+    environment:
+      - 'ATL_JDBC_URL=jdbc:postgresql://postgresql/jiradb'
+      - 'ATL_JDBC_USER=jiradb'
+      - 'ATL_JDBC_PASSWORD=password'
+      - 'ATL_DB_DRIVER=org.postgresql.Driver'
+      - 'ATL_DB_TYPE=postgres72'
+      - 'ATL_TOMCAT_CONTEXTPATH=/jira'
+
+  postgresql:
+    image: postgres:9.6-alpine
+    environment:
+      - 'POSTGRES_DB=jiradb'
+      - 'POSTGRES_USER=jiradb'
+      - 'POSTGRES_PASSWORD=password'
+      - 'POSTGRES_ENCODING=UNICODE'
+      - 'POSTGRES_COLLATE=C'
+      - 'POSTGRES_COLLATE_TYPE=C'

--- a/jira-e2e-tests/helpers/upload-plugin
+++ b/jira-e2e-tests/helpers/upload-plugin
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+
+cat <<EOF > /tmp/setup.sh
+    if [[ ! -e /usr/bin/unzip ]]; then
+       apt-get update && apt-get install -y unzip
+    fi
+    cd /var/atlassian/application-data/jira/plugins/installed-plugins
+    unzip -o /tmp/jira-plugin-1.0.0.obr jira-plugin-1.0.0.jar
+EOF
+
+docker cp /tmp/setup.sh helpers_jira_1:/tmp/
+
+docker cp jira-plugin/target/jira-plugin-1.0.0.obr \
+       helpers_jira_1:/tmp/
+
+docker exec -t helpers_jira_1 /bin/bash -x /tmp/setup.sh
+
+docker restart helpers_jira_1

--- a/jira-e2e-tests/support/index.js
+++ b/jira-e2e-tests/support/index.js
@@ -4,6 +4,7 @@
 export const baseURL = 'http://localhost:2990/jira';
 export const welcomeURL = baseURL+'/secure/WelcomeToJIRA.jspa'
 export const loginURL = baseURL+'/login.jsp';
+export const sudoURL = baseURL+'/secure/admin/WebSudoAuthenticate!default.jspa';
 export const migrationBase = baseURL+'/plugins/servlet/dc-migration-assistant';
 export const migrationHome = migrationBase;
 
@@ -15,6 +16,11 @@ Cypress.Commands.add('jira_login', (uname, passwd) => {
     cy.get('#login-form-submit').click();
     // Force wait for dashboard to avoid flakiness.
     cy.get('[class=g-intro]').should('exist');
+
+    // Ensure we have full admin access before doing anything
+    cy.visit(sudoURL);
+    cy.get('#login-form-authenticatePassword').type('admin');
+    cy.get('#login-form-submit').click();
 })
 
 


### PR DESCRIPTION
This adds a docker-compose config and helper scripts to install the current plugin. See readme for details.