### PR TITLE
CHET_295: Fix early "complete" between application and migration provisioning

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
@@ -62,8 +62,11 @@ export const provisioning = {
                         case 'CREATE_IN_PROGRESS':
                             return phase === 'app_infra'
                                 ? ProvisioningStatus.ProvisioningApplicationStack
-                                : ProvisioningStatus.PreProvisionMigrationStack;
+                                : ProvisioningStatus.ProvisioningMigrationStack;
                         case 'CREATE_COMPLETE':
+                            if (phase === 'app_infra') {
+                                return ProvisioningStatus.PreProvisionMigrationStack;
+                            }
                             return ProvisioningStatus.Complete;
                         case 'CREATE_FAILED':
                             throw new Error(


### PR DESCRIPTION
When the application provisioning is complete but the migration infrastructure provisioning hasn't started, it will show "preparing migration infrastructure" as seen in below screenshot.

![image](https://user-images.githubusercontent.com/21027663/81254488-8b887680-906e-11ea-886d-2d7d206a86bf.png)
