### PR TITLE
CHET-355: Add SSM url to the output logs

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
@@ -34,9 +34,8 @@ class MigrationEndpoint(private val migrationService: MigrationService) {
     /**
      * @return A response with the status of the current migration
      */
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
     @GET
+    @Produces(MediaType.APPLICATION_JSON)
     fun getMigrationStatus(): Response {
         return if (migrationService.currentStage == MigrationStage.NOT_STARTED) {
             Response
@@ -75,10 +74,9 @@ class MigrationEndpoint(private val migrationService: MigrationService) {
         }
     }
 
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
     @GET
     @Path("/summary")
+    @Produces(MediaType.APPLICATION_JSON)
     fun getMigrationSummary(): Response {
         return if (migrationService.currentStage == MigrationStage.NOT_STARTED) {
             Response

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.kt
@@ -115,7 +115,7 @@ class DatabaseMigrationEndpoint(
     @Path("/logs")
     fun getCommandOutputs(): Response {
         return try {
-            Response.ok(ssmPsqlDatabaseRestoreService.fetchCommandLogs()).build()
+            Response.ok(ssmPsqlDatabaseRestoreService.fetchCommandResult()).build()
         } catch (e: SsmPsqlDatabaseRestoreService.SsmCommandNotInitialisedException) {
             return Response.status(Response.Status.CONFLICT).entity(mapOf("error" to "SSM command wasn't executed"))
                 .build()

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/db/DatabaseMigrationEndpoint.kt
@@ -16,6 +16,7 @@
 package com.atlassian.migration.datacenter.api.db
 
 import com.atlassian.migration.datacenter.core.aws.db.DatabaseMigrationService
+import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService
 import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.fasterxml.jackson.annotation.JsonAutoDetect
@@ -36,7 +37,8 @@ import javax.ws.rs.core.Response
 @Path("/migration/db")
 class DatabaseMigrationEndpoint(
     private val databaseMigrationService: DatabaseMigrationService,
-    private val migrationService: MigrationService
+    private val migrationService: MigrationService,
+    private val ssmPsqlDatabaseRestoreService: SsmPsqlDatabaseRestoreService
 ) {
     private val mapper: ObjectMapper = ObjectMapper()
 
@@ -73,16 +75,16 @@ class DatabaseMigrationEndpoint(
     @GET
     fun getMigrationStatus(): Response {
         val elapsed = databaseMigrationService.elapsedTime
-                .orElse(Duration.ZERO)
+            .orElse(Duration.ZERO)
         val dto = DatabaseMigrationStatus(
-                stageToStatus(migrationService.currentStage),
-                elapsed)
+            stageToStatus(migrationService.currentStage),
+            elapsed
+        )
 
         return try {
             Response
                 .ok(mapper.writeValueAsString(dto))
                 .build()
-
         } catch (e: JsonProcessingException) {
             Response
                 .serverError()
@@ -104,6 +106,18 @@ class DatabaseMigrationEndpoint(
             Response
                 .status(Response.Status.CONFLICT)
                 .entity(mapOf("error" to "db migration is not in progress"))
+                .build()
+        }
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/logs")
+    fun getCommandOutputs(): Response {
+        return try {
+            Response.ok(ssmPsqlDatabaseRestoreService.fetchCommandLogs()).build()
+        } catch (e: SsmPsqlDatabaseRestoreService.SsmCommandNotInitialisedException) {
+            return Response.status(Response.Status.CONFLICT).entity(mapOf("error" to "SSM command wasn't executed"))
                 .build()
         }
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
@@ -22,6 +22,7 @@ import com.atlassian.migration.datacenter.core.aws.ssm.SuccessfulSSMCommandConsu
 import com.atlassian.migration.datacenter.core.fs.download.s3sync.EnsureSuccessfulSSMCommandConsumer;
 import com.atlassian.migration.datacenter.spi.exceptions.DatabaseMigrationFailure;
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError;
+import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 
 import java.util.Collections;
 
@@ -32,15 +33,17 @@ public class SsmPsqlDatabaseRestoreService {
     private final SSMApi ssm;
     private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
 
+    private String commandId;
+
     SsmPsqlDatabaseRestoreService(SSMApi ssm, int maxCommandRetries,
-            AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
+                                  AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this.ssm = ssm;
         this.maxCommandRetries = maxCommandRetries;
         this.migrationHelperDeploymentService = migrationHelperDeploymentService;
     }
 
     public SsmPsqlDatabaseRestoreService(SSMApi ssm,
-            AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
+                                         AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this(ssm, 10, migrationHelperDeploymentService);
     }
 
@@ -51,7 +54,7 @@ public class SsmPsqlDatabaseRestoreService {
 
         restoreStageTransitionCallback.assertInStartingStage();
 
-        String commandId = ssm.runSSMDocument(dbRestorePlaybook, migrationInstanceId, Collections.emptyMap());
+        this.commandId = ssm.runSSMDocument(dbRestorePlaybook, migrationInstanceId, Collections.emptyMap());
 
         SuccessfulSSMCommandConsumer consumer = new EnsureSuccessfulSSMCommandConsumer(ssm, commandId,
                 migrationInstanceId);
@@ -67,6 +70,36 @@ public class SsmPsqlDatabaseRestoreService {
             restoreStageTransitionCallback
                     .transitionToServiceErrorStage(String.format("%s. %s", errorMessage, e.getMessage()));
             throw new DatabaseMigrationFailure(errorMessage, e);
+        }
+    }
+
+    public SsmCommandLogs fetchCommandLogs() throws SsmCommandNotInitialisedException {
+        if (getCommandId() == null) {
+            throw new SsmCommandNotInitialisedException("SSM command was not executed");
+        }
+        String migrationInstanceId = migrationHelperDeploymentService.getMigrationHostInstanceId();
+
+        final GetCommandInvocationResponse response = ssm.getSSMCommand(getCommandId(), migrationInstanceId);
+
+        final SsmCommandLogs ssmCommandOutputs = new SsmCommandLogs();
+        ssmCommandOutputs.outputUrl = response.standardOutputUrl();
+        ssmCommandOutputs.errorUrl = response.standardErrorUrl();
+
+        return ssmCommandOutputs;
+    }
+
+    public String getCommandId() {
+        return commandId;
+    }
+
+    public class SsmCommandLogs {
+        public String errorUrl;
+        public String outputUrl;
+    }
+
+    public class SsmCommandNotInitialisedException extends Exception {
+        public SsmCommandNotInitialisedException(String message) {
+            super(message);
         }
     }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
@@ -84,6 +84,11 @@ public class SsmPsqlDatabaseRestoreService {
         final SsmCommandLogs ssmCommandOutputs = new SsmCommandLogs();
         ssmCommandOutputs.outputUrl = response.standardOutputUrl();
         ssmCommandOutputs.errorUrl = response.standardErrorUrl();
+        ssmCommandOutputs.commandUrl = String.format(
+                "https://console.aws.amazon.com/s3/buckets/%s/trebuchet-ssm-document-logs/%s/%s/awsrunShellScript/restoreDatabaseBackupToRDS/",
+                migrationHelperDeploymentService.getMigrationS3BucketName(),
+                response.commandId(),
+                response.instanceId());
 
         return ssmCommandOutputs;
     }
@@ -95,6 +100,7 @@ public class SsmPsqlDatabaseRestoreService {
     public class SsmCommandLogs {
         public String errorUrl;
         public String outputUrl;
+        public String commandUrl;
     }
 
     public class SsmCommandNotInitialisedException extends Exception {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SSMApi.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SSMApi.java
@@ -36,6 +36,8 @@ public class SSMApi {
     private Supplier<SsmClient> clientFactory;
     private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
 
+    private final String ssmS3KeyPrefix = "trebuchet-ssm-document-logs";
+
     public SSMApi(Supplier<SsmClient> clientFactory, AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this.clientFactory = clientFactory;
         this.migrationHelperDeploymentService = migrationHelperDeploymentService;
@@ -62,7 +64,7 @@ public class SSMApi {
                 .timeoutSeconds(600)
                 .comment("command run by Jira DC Migration Assistant")
                 .outputS3BucketName(migrationHelperDeploymentService.getMigrationS3BucketName())
-                .outputS3KeyPrefix("trebuchet-ssm-document-logs")
+                .outputS3KeyPrefix(ssmS3KeyPrefix)
                 .build();
 
         SendCommandResponse response = client.sendCommand(request);
@@ -94,5 +96,9 @@ public class SSMApi {
         GetCommandInvocationResponse response = client.getCommandInvocation(request);
 
         return response;
+    }
+
+    public String getSsmS3KeyPrefix() {
+        return ssmS3KeyPrefix;
     }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreServiceTest.java
@@ -31,7 +31,9 @@ import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,8 +56,7 @@ class SsmPsqlDatabaseRestoreServiceTest {
     }
 
     @Test
-    void shouldBeSuccessfulWhenCommandStatusIsSuccessful() throws InvalidMigrationStageError
-    {
+    void shouldBeSuccessfulWhenCommandStatusIsSuccessful() throws InvalidMigrationStageError {
         givenCommandCompletesWithStatus(CommandInvocationStatus.SUCCESS);
 
         sut.restoreDatabase(callback);
@@ -68,10 +69,37 @@ class SsmPsqlDatabaseRestoreServiceTest {
         assertThrows(DatabaseMigrationFailure.class, () -> sut.restoreDatabase(callback));
     }
 
+    @Test
+    void shouldReturnOutputAndErrorUrls() throws SsmPsqlDatabaseRestoreService.SsmCommandNotInitialisedException, InvalidMigrationStageError {
+        final String mockCommandId = "fake-command";
+        final String mockInstance = "i-0353cc9a8ad7dafc2";
+        final String outputUrl = "output-url";
+        final String errorUrl = "error-url";
+
+        final SsmPsqlDatabaseRestoreService spy = spy(sut);
+        when(spy.getCommandId()).thenReturn(mockCommandId);
+
+        when(migrationHelperDeploymentService.getMigrationHostInstanceId()).thenReturn(mockInstance);
+        when(ssmApi.getSSMCommand(mockCommandId, mockInstance)).thenReturn(
+                GetCommandInvocationResponse.builder()
+                        .standardOutputUrl(outputUrl)
+                        .standardErrorUrl(errorUrl)
+                        .build()
+        );
+
+        final SsmPsqlDatabaseRestoreService.SsmCommandLogs commandOutputs = spy.fetchCommandLogs();
+
+        assertEquals("output-url", commandOutputs.outputUrl);
+        assertEquals("error-url", commandOutputs.errorUrl);
+    }
+
     private void givenCommandCompletesWithStatus(CommandInvocationStatus status) {
         final String mockCommandId = "fake-command";
         final String mockInstance = "i-0353cc9a8ad7dafc2";
         final String mocument = "ssm-document";
+        final String outputUrl = "output-url";
+        final String errorUrl = "error-url";
+
         when(migrationHelperDeploymentService.getDbRestoreDocument()).thenReturn(mocument);
         when(migrationHelperDeploymentService.getMigrationHostInstanceId()).thenReturn(mockInstance);
 
@@ -80,6 +108,8 @@ class SsmPsqlDatabaseRestoreServiceTest {
         when(ssmApi.getSSMCommand(mockCommandId, mockInstance)).thenReturn(
                 (GetCommandInvocationResponse) GetCommandInvocationResponse.builder()
                         .status(status)
+                        .standardOutputUrl(outputUrl)
+                        .standardErrorUrl(errorUrl)
                         .sdkHttpResponse(SdkHttpResponse.builder().statusText("it failed").build())
                         .build()
         );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
         "@atlaskit/textfield": "^3.1.4",
         "@atlaskit/theme": "^9.5.2",
         "@atlaskit/toggle": "^8.1.3",
+        "@atlaskit/tooltip": "^15.2.6",
         "@atlassian/wrm-react-i18n": "^0.4.3",
         "@babel/core": "^7.5.5",
         "@babel/plugin-proposal-class-properties": "^7.5.5",

--- a/frontend/src/main/dc-migration-assistant-fe/api/db.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/db.ts
@@ -20,6 +20,7 @@ import { MigrationDuration } from './common';
 const dbAPIBase = 'migration/db';
 export const dbStatusReportEndpoint = `${dbAPIBase}/report`;
 export const dbStartEndpoint = `${dbAPIBase}/start`;
+export const dbLogsEndpoint = `${dbAPIBase}/logs`;
 
 export enum DBMigrationStatus {
     NOT_STARTED = 'NOT_STARTED',
@@ -50,4 +51,9 @@ export const statusToI18nString = (status: DBMigrationStatus): string => {
 export type DatabaseMigrationStatus = {
     status: DBMigrationStatus;
     elapsedTime: MigrationDuration;
+};
+
+export type CommandLogs = {
+    errorUrl: string;
+    outputUrl: string;
 };

--- a/frontend/src/main/dc-migration-assistant-fe/api/db.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/db.ts
@@ -53,7 +53,7 @@ export type DatabaseMigrationStatus = {
     elapsedTime: MigrationDuration;
 };
 
-export type CommandLogs = {
-    errorUrl: string;
-    outputUrl: string;
+export type CommandDetails = {
+    errorUrl?: string;
+    outputUrl?: string;
 };

--- a/frontend/src/main/dc-migration-assistant-fe/api/db.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/db.ts
@@ -54,7 +54,6 @@ export type DatabaseMigrationStatus = {
 };
 
 export type CommandDetails = {
-    errorUrl?: string;
-    outputUrl?: string;
-    commandUrl?: string;
+    errorMessage?: string;
+    consoleUrl?: string;
 };

--- a/frontend/src/main/dc-migration-assistant-fe/api/db.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/db.ts
@@ -56,4 +56,5 @@ export type DatabaseMigrationStatus = {
 export type CommandDetails = {
     errorUrl?: string;
     outputUrl?: string;
+    commandUrl?: string;
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -25,10 +25,11 @@ import {
     dbStartEndpoint,
     DatabaseMigrationStatus,
     statusToI18nString,
-    DBMigrationStatus,
+    dbLogsEndpoint, DBMigrationStatus,
 } from '../../api/db';
 import { MigrationStage } from '../../api/migration';
 import { validationPath } from '../../utils/RoutePaths';
+import { CommandLogs } from '../../api/db';
 
 const dbMigrationInProgressStages = [
     MigrationStage.DATA_MIGRATION_IMPORT,
@@ -69,6 +70,10 @@ const getProgressFromStatus = (): Promise<Progress> => {
     return fetchDBMigrationStatus().then(toProgress);
 };
 
+const fetchDBMigrationLogs = (): Promise<CommandLogs> => {
+    return callAppRest('GET', dbLogsEndpoint).then(result => result.json());
+};
+
 const props: MigrationTransferProps = {
     heading: I18n.getText('atlassian.migration.datacenter.db.title'),
     description: I18n.getText('atlassian.migration.datacenter.db.description'),
@@ -77,6 +82,7 @@ const props: MigrationTransferProps = {
     inProgressStages: dbMigrationInProgressStages,
     getProgress: getProgressFromStatus,
     nextRoute: validationPath,
+    getLogs: fetchDBMigrationLogs,
 };
 
 export const DatabaseTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -25,11 +25,12 @@ import {
     dbStartEndpoint,
     DatabaseMigrationStatus,
     statusToI18nString,
-    dbLogsEndpoint, DBMigrationStatus,
+    dbLogsEndpoint,
+    DBMigrationStatus,
+    CommandDetails,
 } from '../../api/db';
 import { MigrationStage } from '../../api/migration';
 import { validationPath } from '../../utils/RoutePaths';
-import { CommandDetails } from '../../api/db';
 
 const dbMigrationInProgressStages = [
     MigrationStage.DATA_MIGRATION_IMPORT,

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../api/db';
 import { MigrationStage } from '../../api/migration';
 import { validationPath } from '../../utils/RoutePaths';
-import { CommandLogs } from '../../api/db';
+import { CommandDetails } from '../../api/db';
 
 const dbMigrationInProgressStages = [
     MigrationStage.DATA_MIGRATION_IMPORT,
@@ -70,7 +70,7 @@ const getProgressFromStatus = (): Promise<Progress> => {
     return fetchDBMigrationStatus().then(toProgress);
 };
 
-const fetchDBMigrationLogs = (): Promise<CommandLogs> => {
+const fetchDBMigrationLogs = (): Promise<CommandDetails> => {
     return callAppRest('GET', dbLogsEndpoint).then(result => result.json());
 };
 
@@ -82,7 +82,7 @@ const props: MigrationTransferProps = {
     inProgressStages: dbMigrationInProgressStages,
     getProgress: getProgressFromStatus,
     nextRoute: validationPath,
-    getLogs: fetchDBMigrationLogs,
+    getDetails: fetchDBMigrationLogs,
 };
 
 export const DatabaseTransferPage: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationDetailsProps.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationDetailsProps.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FunctionComponent } from 'react';
+import SectionMessage from '@atlaskit/section-message';
+import Tooltip from '@atlaskit/tooltip';
+import { Button } from '@atlaskit/button/dist/cjs/components/Button';
+import { CommandDetails as CommandResult } from '../../api/db';
+
+type CommandResultProps = {
+    result: CommandResult;
+};
+export const MigrationErrorSection: FunctionComponent<CommandResultProps> = ({
+    result: commandResult,
+}) => {
+    return (
+        <SectionMessage appearance="warning" title="Database migration error">
+            <p>
+                When running the database migration we have encountered error(s). Some of the errors
+                are not necessary fatal and you can continue with migration. We recommend reviewing
+                the errors and continue at your discretion. The error message is truncated to 8000
+                characters
+            </p>
+            <pre>{commandResult.errorMessage.replace(/\n/g, '\n')}</pre>
+
+            <Tooltip content="You need to be logged into AWS console">
+                <Button href={commandResult.consoleUrl} target="_blank">
+                    View logs in S3
+                </Button>
+            </Tooltip>
+        </SectionMessage>
+    );
+};

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
@@ -19,9 +19,10 @@ import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 
 import { CommandDetails as CommandResult } from '../../api/db';
+import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 
 const ErrorFragment = styled.div`
-    margin-top: 20px;
+    margin-top: 0px;
 `;
 
 type CommandResultProps = {
@@ -34,15 +35,11 @@ export const MigrationErrorSection: FunctionComponent<CommandResultProps> = ({
     return (
         <ErrorFragment>
             <SectionMessage appearance="warning" title="Database sync warning">
-                <p>
-                    We encountered some errors during the database sync. Some of these errors
-                    aren&apos;t necessarily fatal, and you can continue with the migration if you
-                    want. Before doing so, we recommend you review the errors first.
-                </p>
+                <p>{I18n.getText('atlassian.migration.datacenter.db.error.warning')}</p>
 
                 <p>
                     <a href={commandResult.consoleUrl} target="_blank" rel="noopener noreferrer">
-                        View the errors in S3
+                        {I18n.getText('atlassian.migration.datacenter.db.error.s3link')}
                     </a>
                 </p>
             </SectionMessage>

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
@@ -16,31 +16,36 @@
 
 import React, { FunctionComponent } from 'react';
 import SectionMessage from '@atlaskit/section-message';
-import Tooltip from '@atlaskit/tooltip';
-import { Button } from '@atlaskit/button/dist/cjs/components/Button';
+import styled from 'styled-components';
+
 import { CommandDetails as CommandResult } from '../../api/db';
+
+const ErrorFragment = styled.div`
+    margin-top: 20px;
+`;
 
 type CommandResultProps = {
     result: CommandResult;
 };
+
 export const MigrationErrorSection: FunctionComponent<CommandResultProps> = ({
     result: commandResult,
 }) => {
     return (
-        <SectionMessage appearance="warning" title="Database migration error">
-            <p>
-                When running the database migration we have encountered error(s). Some of the errors
-                are not necessary fatal and you can continue with migration. We recommend reviewing
-                the errors and continue at your discretion. The error message is truncated to 8000
-                characters
-            </p>
-            <pre>{commandResult.errorMessage.replace(/\n/g, '\n')}</pre>
+        <ErrorFragment>
+            <SectionMessage appearance="warning" title="Database sync warning">
+                <p>
+                    We encountered some errors during the database sync. Some of these errors
+                    aren&apos;t necessarily fatal, and you can continue with the migration if you
+                    want. Before doing so, we recommend you review the errors first.
+                </p>
 
-            <Tooltip content="You need to be logged into AWS console">
-                <Button href={commandResult.consoleUrl} target="_blank">
-                    View logs in S3
-                </Button>
-            </Tooltip>
-        </SectionMessage>
+                <p>
+                    <a href={commandResult.consoleUrl} target="_blank" rel="noopener noreferrer">
+                        View the errors in S3
+                    </a>
+                </p>
+            </SectionMessage>
+        </ErrorFragment>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -20,7 +20,6 @@ import styled from 'styled-components';
 import moment from 'moment';
 import Spinner from '@atlaskit/spinner';
 import { Redirect } from 'react-router-dom';
-import TableTree, { Cell, Row } from '@atlaskit/table-tree';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import Tooltip from '@atlaskit/tooltip';
 import { Button } from '@atlaskit/button/dist/cjs/components/Button';
@@ -98,36 +97,18 @@ const TransferActionsContainer = styled.div`
 `;
 type MigrationDetailsProps = { details: CommandDetails };
 export const MigrationDetails: FunctionComponent<MigrationDetailsProps> = ({ details }) => {
-    const MigrationDetailsSection = styled.div`
-        display: flex;
-        flex-direction: column;
-        padding-right: 30px;
-
-        padding-bottom: 5px;
-    `;
     return (
-        <MigrationDetailsSection>
-            <div>
-                <h4>Migration details</h4>
-            </div>
-            <TableTree>
-                <Row key="migration-details-logs" hasChildren={false}>
-                    <Cell width={400} singleLine>
-                        Migration logs
-                        {/* {I18n.getText(
-                            'atlassian.migration.datacenter.validation.summary.phrase.instanceUrl'
-                        )} */}
-                    </Cell>
-                    <Cell width={400}>
-                        <Tooltip content="You need to be logged into AWS console">
-                            <Button target="_blank" href={details.commandUrl}>
-                                Log files in S3
-                            </Button>
-                        </Tooltip>
-                    </Cell>
-                </Row>
-            </TableTree>
-        </MigrationDetailsSection>
+        <SectionMessage appearance="warning" title="Migration details">
+            <p>
+                While running the database migration we&apos;ve encountered some errors. Please take
+                a look on the log files.
+            </p>
+            <Tooltip content="You need to be logged into AWS console">
+                <a href={details.commandUrl} target="_blank">
+                    <Button>Log files in S3</Button>
+                </a>
+            </Tooltip>
+        </SectionMessage>
     );
 };
 
@@ -263,7 +244,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                                 startedMoment={startMoment}
                             />
                         )}
-                        {details && <MigrationDetails details={details} />}
+                        {details?.errorUrl && <MigrationDetails details={details} />}
                     </TransferContentContainer>
                     <TransferActionsContainer>
                         <MigrationTransferActions

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -27,6 +27,7 @@ import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
 import { migrationErrorPath } from '../../utils/RoutePaths';
+import { CommandLogs } from '../../api/db';
 
 const POLL_INTERVAL_MILLIS = 3000;
 
@@ -64,6 +65,8 @@ export type MigrationTransferProps = {
      * A function which will be called to get the progress of the current transfer
      */
     getProgress: ProgressCallback;
+
+    getLogs: Promise<CommandLogs>;
 };
 
 const TransferPageContainer = styled.div`

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, useState, useEffect, DOMAttributes } from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 import moment from 'moment';
@@ -28,7 +28,7 @@ import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
 import { migrationErrorPath } from '../../utils/RoutePaths';
 import { CommandDetails as CommandResult } from '../../api/db';
-import { MigrationErrorSection } from './MigrationDetailsProps';
+import { MigrationErrorSection } from './MigrationErrorSection';
 
 const POLL_INTERVAL_MILLIS = 3000;
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -23,14 +23,14 @@ import { Redirect } from 'react-router-dom';
 import TableTree, { Cell, Row } from '@atlaskit/table-tree';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import Tooltip from '@atlaskit/tooltip';
+import { Button } from '@atlaskit/button/dist/cjs/components/Button';
 
 import { MigrationTransferActions } from './MigrationTransferPageActions';
-import { ProgressCallback, Progress, ProgressBuilder } from './Progress';
+import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
 import { migrationErrorPath } from '../../utils/RoutePaths';
-import { CommandDetails, DBMigrationStatus } from '../../api/db';
-import { Button } from '@atlaskit/button/dist/cjs/components/Button';
+import { CommandDetails } from '../../api/db';
 
 const POLL_INTERVAL_MILLIS = 3000;
 
@@ -120,15 +120,8 @@ export const MigrationDetails: FunctionComponent<MigrationDetailsProps> = ({ det
                     </Cell>
                     <Cell width={400}>
                         <Tooltip content="You need to be logged into AWS console">
-                            <Button target="_blank" href={details.outputUrl}>
-                                Standard output
-                            </Button>
-                        </Tooltip>
-                    </Cell>
-                    <Cell width={400}>
-                        <Tooltip content="You need to be logged into AWS console">
-                            <Button target="_blank" href={details.errorUrl}>
-                                Error output
+                            <Button target="_blank" href={details.commandUrl}>
+                                Log files in S3
                             </Button>
                         </Tooltip>
                     </Cell>

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent, useState } from 'react';
 import SectionMessage from '@atlaskit/section-message';
 import { Checkbox } from '@atlaskit/checkbox';

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -102,6 +102,9 @@ atlassian.migration.datacenter.db.status.uploading=Uploading
 atlassian.migration.datacenter.db.status.done=Complete
 atlassian.migration.datacenter.db.status.unknown=Unknown Status
 atlassian.migration.datacenter.db.completeMessage=Database has been successfully migrated
+atlassian.migration.datacenter.db.error.warning=We encountered some errors during the database sync. Some of these errors aren't necessarily fatal, and you can continue with the migration if you want. Before doing so, we recommend you review the errors first.
+atlassian.migration.datacenter.db.error.s3link=View the errors in S3
+
 
 # Validation page
 atlassian.migration.datacenter.step.validation.phrase=Step 6 of 6: Validation

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -321,6 +321,20 @@
     react-uid "^2.2.0"
     tslib "^1.9.3"
 
+"@atlaskit/tooltip@^15.2.6":
+  version "15.2.6"
+  resolved "https://registry.yarnpkg.com/@atlaskit/tooltip/-/tooltip-15.2.6.tgz#e5bdd0b75b355b628da08449ec23f8af4307e4e1"
+  integrity sha512-tMwXw2WfI5GYjNo5JI67pfYElA9Kor/T90h9iC/Z1vM9velC+eSvnGdML2A5WS6zyeS9dkJVTNd6D7qLOvlEBw==
+  dependencies:
+    "@atlaskit/analytics-next" "^6.3.5"
+    "@atlaskit/popper" "^3.1.12"
+    "@atlaskit/portal" "^3.1.6"
+    "@atlaskit/theme" "^9.5.1"
+    flushable "^1.0.0"
+    react-node-resolver "^1.0.1"
+    react-transition-group "^2.2.1"
+    tslib "^1.9.3"
+
 "@atlaskit/type-helpers@^4.2.3":
   version "4.2.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/type-helpers/-/type-helpers-4.2.3.tgz#64a183f3d5e499303e6bf494c7012f4fa54d8a7b"
@@ -6118,6 +6132,11 @@ focus-lock@^0.6.3:
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.8.tgz#61985fadfa92f02f2ee1d90bc738efaf7f3c9f46"
   integrity sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==
+
+flushable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/flushable/-/flushable-1.0.0.tgz#2fc16837ec85f8d7ec1bd777087b8448e1ca8216"
+  integrity sha512-WQr7DsBZfdmXwqWk7yyk9H2R60iHiUpLMvkov6KivafC9d1SzDTjSBsKMa8skT4laaSxus+F4v7WLO6J0zxPkw==
 
 focus-trap@^2.4.5:
   version "2.4.6"


### PR DESCRIPTION
* Create `/migration/db/logs `GET` REST endpoint to fetch the end result when we have finished the DB restore. Example responses:
```
{
    "consoleUrl": "https://console.aws.amazon.com/s3/buckets/atl-migrationbucket-abrokes-migration-helper/trebuchet-ssm-document-logs/6cc3f383-a916-4fdd-b23b-6b614e642944/i-08f9fa6be33226139/awsrunShellScript/restoreDatabaseBackupToRDS/",
    "errorMessage": ""
}
```
* Display `SectionMessage` when there was an error in the DB migration and provide link to reach the AWS S3 Console with the `stdout` and `stderr` files.
* We also get first 8000 characters of the error but to keep the designs simple we've decided to not show it in the interface.

<img width="1663" alt="image" src="https://user-images.githubusercontent.com/416238/81636430-2f9b6480-9457-11ea-8833-5796ff548e4c.png">
