### PR TITLE
CHET-384: render failed files and their reasons

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
@@ -23,7 +23,7 @@ enum RestApiPathConstants {
 }
 
 type FailedFile = {
-    path: string;
+    filePath: string;
     reason: string;
 };
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -103,7 +103,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
 }) => {
     const [progress, setProgress] = useState<Progress>();
     const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<string>();
+    const [progressFetchingError, setProgressFetchingError] = useState<string>();
     const [started, setStarted] = useState<boolean>(false);
 
     const updateProgress = (): Promise<void> => {
@@ -113,20 +113,20 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                 setLoading(false);
             })
             .catch(err => {
-                setError(err);
+                setProgressFetchingError(err);
                 setLoading(false);
             });
     };
 
     const startMigration = (): Promise<void> => {
         setLoading(true);
-        setError('');
+        setProgressFetchingError('');
         return startMigrationPhase()
             .then(() => {
                 setStarted(true);
             })
             .catch(err => {
-                setError(err.message);
+                setProgressFetchingError(err.message);
                 setLoading(false);
             });
     };
@@ -166,7 +166,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
         return <Redirect to={migrationErrorPath} push />;
     }
 
-    const transferError = progress?.error || error;
+    const transferError = progress?.errorMessage;
 
     const LearnMoreLink =
         'https://confluence.atlassian.com/jirakb/how-to-use-the-data-center-migration-app-to-migrate-jira-to-an-aws-cluster-1005781495.html#HowtousetheDataCenterMigrationapptomigrateJiratoanAWScluster-Knownissue';
@@ -181,10 +181,11 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
             ) : (
                 <>
                     <TransferContentContainer>
-                        {transferError && (
+                        {(transferError || progressFetchingError) && (
                             <SectionMessage appearance="error">
+                                {transferError}
                                 <p>
-                                    {transferError}{' '}
+                                    {progressFetchingError || ''}{' '}
                                     <a
                                         target="_blank"
                                         rel="noreferrer noopener"

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 /**
  * **boldPrefix** - text that will be at the beginning of the message in bold. This should be used
  * to communicate *how much* data has been migrated
@@ -13,7 +15,10 @@ export type CompleteMessage = {
  * **phase**: Text describing the current phase of the transfer e.g. uploading, downloading, importing..
  * **completeness**: A fraction representing the percentage complete the transfer is.
  * **elapsedTimeSeconds**: The number of seconds the transfer has been going on for.
- * **error**: Text describing a non-critical error that the user may want to verify.
+ * **error**: A React node displaying the error content to the user in the error section message.
+ *            Note that a raw string is a valid React node, ReactNode is the type simply so more complex
+ *            errors can be rendered.
+ *            Absence implies no errors occured and results in no error section message being rendered.
  * **completeMessage**: Message to display when the transfer has completed.
  * **failed**: a flag that should be true if a migration-stopping error has occcured, false otherwise.
  */
@@ -21,7 +26,7 @@ export type Progress = {
     phase: string;
     completeness?: number;
     elapsedTimeSeconds?: number;
-    error?: string;
+    errorMessage?: ReactNode;
     completeMessage?: CompleteMessage;
     failed?: boolean;
 };
@@ -34,7 +39,7 @@ export class ProgressBuilder {
 
     private completeness: number;
 
-    private error: string;
+    private errorMessage: ReactNode;
 
     private completeMessage: CompleteMessage;
 
@@ -57,8 +62,8 @@ export class ProgressBuilder {
         return this;
     }
 
-    setError(error: string): ProgressBuilder {
-        this.error = error;
+    setError(error: ReactNode): ProgressBuilder {
+        this.errorMessage = error;
         return this;
     }
 
@@ -70,7 +75,7 @@ export class ProgressBuilder {
         return this;
     }
 
-    setFailed(failed: boolean) {
+    setFailed(failed: boolean): ProgressBuilder {
         this.failed = failed;
 
         return this;
@@ -81,13 +86,13 @@ export class ProgressBuilder {
             throw new Error('must include phase in progress object');
         }
 
-        const { phase, completeMessage, completeness, error, elapsedSeconds, failed } = this;
+        const { phase, completeMessage, completeness, errorMessage, elapsedSeconds, failed } = this;
 
         return {
             phase,
             completeMessage,
             completeness,
-            error,
+            errorMessage,
             elapsedTimeSeconds: elapsedSeconds,
             failed: failed || false,
         };

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -80,6 +80,7 @@ atlassian.migration.datacenter.fs.phase.download=Loading files into target appli
 atlassian.migration.datacenter.fs.phase.complete=Files are copied
 atlassian.migration.datacenter.fs.completeMessage.boldPrefix={0} of {1} files
 atlassian.migration.datacenter.fs.completeMessage.message=were successfully migrated
+atlassian.migration.datacenter.fs.error.failedFiles=These files failed to upload
 
 # Warning page
 atlassian.migration.datacenter.warning.title=Step 4 of 6: Redirect users


### PR DESCRIPTION
## Summary
* Refactor migration summary screen error to accept arbitrary react
* Refactor failed file presentation to show all failed files and the corresponding failure reason in a list

### Collapsed
![image](https://user-images.githubusercontent.com/21027663/81371722-f18eff80-913b-11ea-97e9-2d2cd729fc6f.png)

### Uncollapsed
![image](https://user-images.githubusercontent.com/21027663/81371737-023f7580-913c-11ea-9eaa-048ca934fa05.png)

The design is a little bit offensive right now, we definitely want to iterate on this