### PR TITLE
CHET-385: Additional FS migration failure content

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -37,8 +37,11 @@ const getErrorFromResult = (result: FileSystemMigrationStatusResponse): ReactNod
 
         return (
             <>
-                <strong>{failedFilesCount} files</strong> failed to upload.
+                <strong>{failedFilesCount} files</strong> failed to upload.{' '}
+                {failedFilesCount === 100 &&
+                    I18n.getText('atlassian.migration.datacenter.fs.error.maxFailedFiles')}
                 <Panel header={I18n.getText('atlassian.migration.datacenter.fs.error.failedFiles')}>
+                    {I18n.getText('atlassian.migration.datacenter.fs.error.resolutionAction')}
                     <ul>
                         {result.failedFiles.map(({ filePath, reason }) => (
                             <li key={filePath}>

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -169,7 +169,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     const transferError = progress?.errorMessage;
 
     const LearnMoreLink =
-        'https://confluence.atlassian.com/jirakb/how-to-use-the-data-center-migration-app-to-migrate-jira-to-an-aws-cluster-1005781495.html#HowtousetheDataCenterMigrationapptomigrateJiratoanAWScluster-Knownissue';
+        'https://confluence.atlassian.com/jirakb/how-to-use-the-data-center-migration-app-to-migrate-jira-to-an-aws-cluster-1005781495.html#HowtousetheDataCenterMigrationapptomigrateJiratoanAWScluster-errors';
     return (
         <TransferPageContainer>
             <TransferContentContainer>

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -81,6 +81,8 @@ atlassian.migration.datacenter.fs.phase.complete=Files are copied
 atlassian.migration.datacenter.fs.completeMessage.boldPrefix={0} of {1} files
 atlassian.migration.datacenter.fs.completeMessage.message=were successfully migrated
 atlassian.migration.datacenter.fs.error.failedFiles=These files failed to upload
+atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 100 file failures, more may have occured.
+atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and restart the migration.
 
 # Warning page
 atlassian.migration.datacenter.warning.title=Step 4 of 6: Redirect users


### PR DESCRIPTION
## Summary

* If 100 errors are seen we tell the user that it's the minimum number of errors
* Instructions on how to resolve fs failures
    * Manual copy _OR_ restart migration
* Correct learn more link for errors on MigrationTransferPage