### PR TITLE
CHET-209: Make reset API delete migrations irrespective of stage

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
@@ -94,14 +94,8 @@ class MigrationEndpoint(private val migrationService: MigrationService) {
     @Path("/reset")
     @Produces(MediaType.APPLICATION_JSON)
     fun resetMigration(): Response {
-        val currentStage = migrationService.currentStage
-        if (currentStage == MigrationStage.ERROR) {
-            migrationService.deleteMigrations()
-            return Response.ok().build()
-        }
-        return Response.status(Response.Status.CONFLICT)
-                .entity(mapOf("reason" to "Cannot reset migration when current stage is $currentStage"))
-                .build()
+        migrationService.deleteMigrations()
+        return Response.ok().build()
     }
 
 

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
@@ -119,26 +119,13 @@ class MigrationEndpointTest {
     }
 
     @Test
-    fun shouldResetMigrationWhenCurrentMigrationStageIsError() {
+    fun shouldResetMigration() {
         every { migrationService.deleteMigrations() } just Runs
-        every { migrationService.currentStage } returns MigrationStage.ERROR
 
         val response = sut.resetMigration()
 
         assertThat(response.status, equalTo(Response.Status.OK.statusCode))
         verify { migrationService.deleteMigrations() }
-    }
-
-    @Test
-    fun shouldNotResetMigrationWhenCurrentMigrationStageIsNotError() {
-        every { migrationService.currentStage } returns MigrationStage.AUTHENTICATION
-
-        val response = sut.resetMigration()
-
-        assertThat(response.status, equalTo(Response.Status.CONFLICT.statusCode))
-        assertThat((response.entity as Map<String, String>)["reason"], equalTo("Cannot reset migration when current stage is authentication"))
-
-        verify(exactly = 0) { migrationService.deleteMigrations() }
     }
 
     @Test

--- a/spi/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/spi/MigrationService.java
@@ -61,7 +61,7 @@ public interface MigrationService {
     MigrationContext getCurrentContext();
 
     /**
-     * Deletes all migrations and associated contexts. It should be used only in developer testing.
+     * Deletes all migrations and associated contexts.
      */
     void deleteMigrations();
 


### PR DESCRIPTION
Remove all migrations w/o considering the current stage of the migration