### PR TITLE
no-issue: remove develop endpoint for reset migrations as the regular…

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
@@ -98,7 +98,6 @@ class MigrationEndpoint(private val migrationService: MigrationService) {
         return Response.ok().build()
     }
 
-
     private fun migrationContextResponseEntity(): Map<String, String> {
         val currentContext = migrationService.currentContext
 

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/develop/DevelopEndpoint.kt
@@ -58,18 +58,6 @@ class DevelopEndpoint(private val migrationService: MigrationService, private va
         }
     }
 
-    @DELETE
-    @Path("/migration/reset")
-    @Produces(MediaType.APPLICATION_JSON)
-    fun resetMigrations(): Response {
-        return if (!isProfileEnabled()) {
-            Response.status(Response.Status.NOT_FOUND).build()
-        } else {
-            migrationService.deleteMigrations()
-            return Response.ok("Reset migration status").build()
-        }
-    }
-
     private fun isProfileEnabled(): Boolean {
         return environment.activeProfiles.any { it.equals(ALLOW_ANY_TRANSITION_PROFILE, ignoreCase = true) }
     }

--- a/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/migration.ts
@@ -20,7 +20,6 @@ enum RestApiPathConstants {
     migrationRestPath = `migration`,
     migrationSummaryRestPath = `migration/summary`,
     migrationResetRestPath = `migration/reset`,
-    migrationForceResetPath = `develop/migration/reset`,
 }
 
 export enum MigrationStage {
@@ -100,14 +99,6 @@ export const migration = {
         return callAppRest('GET', RestApiPathConstants.migrationSummaryRestPath).then(res =>
             res.json()
         );
-    },
-    forceResetMigration: (): Promise<void> => {
-        return callAppRest('DELETE', RestApiPathConstants.migrationForceResetPath).then(res => {
-            if (res.ok) {
-                return Promise.resolve();
-            }
-            return res.json().then(json => Promise.reject(json.error));
-        });
     },
 };
 

--- a/jira-e2e-tests/support/index.js
+++ b/jira-e2e-tests/support/index.js
@@ -43,6 +43,6 @@ Cypress.Commands.add('reset_migration', () => {
     cy.visit(migrationHome);
     cy.get('#dc-migration-assistant-root').should('exist');
     cy.window().then((window: Window) => {
-        window.AtlassianMigration.forceResetMigration();
+        window.AtlassianMigration.resetMigration();
     });
 });


### PR DESCRIPTION
… endpoint will work just as well

The /reset migration endpoint does the same thing - removing the duplicate and updating the usages