### PR TITLE
CHET-402: Update the Home design

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
         "@atlaskit/form": "^7.2.1",
         "@atlaskit/icon": "^20.0.1",
         "@atlaskit/inline-message": "^10.1.6",
+        "@atlaskit/lozenge": "^9.1.7",
         "@atlaskit/modal-dialog": "^10.5.8",
         "@atlaskit/panel": "^0.3.5",
         "@atlaskit/progress-bar": "^0.2.7",

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -16,10 +16,12 @@
 
 import React, { ReactElement, useEffect, useState, FunctionComponent } from 'react';
 import Button from '@atlaskit/button';
-import InlineMessage from '@atlaskit/inline-message';
 import styled from 'styled-components';
 import { Redirect } from 'react-router-dom';
 import { I18n } from '@atlassian/wrm-react-i18n';
+import Lozenge from '@atlaskit/lozenge';
+import SectionMessage from '@atlaskit/section-message';
+import Spinner from '@atlaskit/spinner';
 
 import { migration, MigrationReadyStatus } from '../api/migration';
 import { ErrorFlag } from './shared/ErrorFlag';
@@ -34,12 +36,15 @@ type HomeProps = {
 const HomeContainer = styled.div`
     display: flex;
     flex-direction: column;
-    align-items: center;
+    width: 100%;
+    margin-right: auto;
+    margin-bottom: auto;
+    padding-left: 15px;
+    max-width: 920px;
 `;
 
-const ButtonContainer = styled.div`
-    margin-top: 250px;
-    align-self: flex-end;
+const MigrationsContainer = styled.div`
+    margin-top: 20px;
 `;
 
 const InfoProps = {
@@ -84,7 +89,7 @@ const MigrationActionSection: FunctionComponent<ActionSectionProps> = ({ startBu
             <p>
                 <ReadyStatus />
             </p>
-            <ButtonContainer>
+            <MigrationsContainer>
                 <Button
                     isLoading={loading}
                     appearance="primary"
@@ -93,7 +98,7 @@ const MigrationActionSection: FunctionComponent<ActionSectionProps> = ({ startBu
                 >
                     {startButtonText}
                 </Button>
-            </ButtonContainer>
+            </MigrationsContainer>
         </>
     );
 };
@@ -101,7 +106,13 @@ const MigrationActionSection: FunctionComponent<ActionSectionProps> = ({ startBu
 export const ReadyStatus: FunctionComponent = () => {
     const [ready, setReady] = useState<MigrationReadyStatus>();
     const readyString = (state: boolean | undefined) => {
-        return state === undefined ? '...' : state ? 'OK' : 'Incompatible';
+        return state === undefined ? (
+            <Spinner size="small" />
+        ) : state ? (
+            <Lozenge appearance="success">OK</Lozenge>
+        ) : (
+            <Lozenge appearance="removed">Incompatible</Lozenge>
+        );
     };
 
     useEffect(() => {
@@ -111,23 +122,27 @@ export const ReadyStatus: FunctionComponent = () => {
     }, []);
 
     return (
-        <>
-            <InlineMessage {...InfoProps} />
+        <SectionMessage appearance="info" {...InfoProps}>
             <ul>
-                <li>... is using PostgreSQL: {readyString(ready?.dbCompatible)}</li>
-                <li>... is on Linux: {readyString(ready?.osCompatible)}</li>
                 <li>
-                    ... has a home directory under 400GB: {readyString(ready?.fsSizeCompatible)}
+                    uses <strong>PostgreSQL</strong> database &nbsp;{' '}
+                    {readyString(ready?.dbCompatible)}
+                </li>
+                <li>
+                    is running on <strong>Linux</strong> &nbsp; {readyString(ready?.osCompatible)}
+                </li>
+                <li>
+                    has a home directory under 400GB &nbsp; {readyString(ready?.fsSizeCompatible)}
                 </li>
             </ul>
-        </>
+        </SectionMessage>
     );
 };
 
 export const Home = ({ title, synopsis, startButtonText }: HomeProps): ReactElement => {
     return (
         <HomeContainer>
-            <h2>{title}</h2>
+            <h1>{title}</h1>
             <p>
                 {synopsis}{' '}
                 <a

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/auth/AuthenticateAWS.tsx
@@ -25,6 +25,7 @@ import { AsyncSelect, OptionType } from '@atlaskit/select';
 import { quickstartPath } from '../../../utils/RoutePaths';
 import { ErrorFlag } from '../../shared/ErrorFlag';
 import { CancelButton } from '../../shared/CancelButton';
+import styled from 'styled-components';
 
 export type AWSCreds = {
     accessKeyId: string;
@@ -48,6 +49,16 @@ export type AuthenticateAWSProps = {
     onSubmitCreds: CredSubmitFun;
     getRegions: QueryRegionFun;
 };
+
+const AuthenticationContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-right: auto;
+    margin-bottom: auto;
+    padding-left: 15px;
+    max-width: 920px;
+`;
 
 const RegionSelect: FunctionComponent<{ getRegions: QueryRegionFun }> = (props): ReactElement => {
     const { getRegions } = props;
@@ -107,7 +118,7 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
     };
 
     return (
-        <>
+        <AuthenticationContainer>
             {readyForNextStep && <Redirect to={quickstartPath} push />}
             <h1>{I18n.getText('atlassian.migration.datacenter.step.authenticate.title')}</h1>
             <p>
@@ -207,6 +218,6 @@ export const AuthenticateAWS: FunctionComponent<AuthenticateAWSProps> = ({
                     </form>
                 )}
             </Form>
-        </>
+        </AuthenticationContainer>
     );
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
@@ -34,7 +34,10 @@ export const MigrationErrorSection: FunctionComponent<CommandResultProps> = ({
 }) => {
     return (
         <ErrorFragment>
-            <SectionMessage appearance="warning" title="Database sync warning">
+            <SectionMessage
+                appearance="warning"
+                title={I18n.getText('atlassian.migration.datacenter.db.error.title')}
+            >
                 <p>{I18n.getText('atlassian.migration.datacenter.db.error.warning')}</p>
 
                 <p>

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -33,7 +33,7 @@ atlassian.migration.datacenter.common.learn_more=Learn more
 atlassian.migration.datacenter.common.estimating=Estimating
 
 # Migration Home page
-atlassian.migration.datacenter.home.title=Data Center Migration App
+atlassian.migration.datacenter.home.title=Jira Data Center Migration App
 atlassian.migration.datacenter.home.synopsis=This app deploys cluster-ready Data Center infrastructure on AWS, and then helps you migrate all your content to it. You'll need an AWS account to continue.
 # Learn more comes after this
 atlassian.migration.datacenter.home.migration.start=Start migration
@@ -102,6 +102,7 @@ atlassian.migration.datacenter.db.status.uploading=Uploading
 atlassian.migration.datacenter.db.status.done=Complete
 atlassian.migration.datacenter.db.status.unknown=Unknown Status
 atlassian.migration.datacenter.db.completeMessage=Database has been successfully migrated
+atlassian.migration.datacenter.db.error.title=Database sync warning
 atlassian.migration.datacenter.db.error.warning=We encountered some errors during the database sync. Some of these errors aren't necessarily fatal, and you can continue with the migration if you want. Before doing so, we recommend you review the errors first.
 atlassian.migration.datacenter.db.error.s3link=View the errors in S3
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -158,6 +158,15 @@
     "@atlaskit/theme" "^9.5.1"
     tslib "^1.9.3"
 
+"@atlaskit/lozenge@^9.1.7":
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/@atlaskit/lozenge/-/lozenge-9.1.7.tgz#2123278b52162c775c46c37fdeb427ed51e2e833"
+  integrity sha512-442QZXBvPxIT5OjmsYhN7RkZTQNoN6JmSBiu/AHKeZiqZsIIcmKoWai7KD4qiEPDDXXHZOTRxC/Mm2zeaI29Gw==
+  dependencies:
+    "@atlaskit/theme" "^9.5.1"
+    "@emotion/core" "^10.0.9"
+    tslib "^1.9.3"
+
 "@atlaskit/modal-dialog@^10.5.8":
   version "10.5.8"
   resolved "https://registry.yarnpkg.com/@atlaskit/modal-dialog/-/modal-dialog-10.5.8.tgz#2513daa4e9150f0ed2e56ecb770dd82329b93efe"


### PR DESCRIPTION
* Formatted the landing page closer to our design specification
* Added lozenges for the requirements
* Added spinner (instead of `...`) when we are fetching the status for each requirement
* Added same formatting for the Auth page
* Updated the title to `Jira Data Center Migration App`

The landing page
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/416238/81640666-79d61300-9462-11ea-82b5-5f60d8ef4b71.png">

Spinners while loading
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/416238/81640677-822e4e00-9462-11ea-81f0-6cb701f1cd43.png">

Auth page formatting
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/416238/81640685-865a6b80-9462-11ea-9bd7-140d489bf1ee.png">
