### PR TITLE
wip-no-issue: [WIP] add dependency on com.atlassian.util.concurrent a…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,18 @@
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-api</artifactId>
         </dependency>
+        <!-- TODO: Verify if scope is valid in 7.13 -->
+        <dependency>
+            <groupId>com.atlassian.util.concurrent</groupId>
+            <artifactId>atlassian-util-concurrent</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- TODO: Verify if scope is valid. Will this be provided? -->
+        <dependency>
+            <groupId>io.atlassian.util.concurrent</groupId>
+            <artifactId>atlassian-util-concurrent</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -64,7 +64,6 @@
                 <extensions>true</extensions>
                 <configuration>
                     <jvmArgs>${amps.jvm.args} -Dspring.profiles.active=allowAnyTransition</jvmArgs>
-                    <product>jira</product>
                     <enableQuickReload>true</enableQuickReload>
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
@@ -104,6 +103,13 @@
                             *
                         </Import-Package>
                     </instructions>
+                    <products>
+                        <product>
+                            <id>jira</id>
+                            <version>${jira.version}</version>
+                            <productDataVersion>${jira.version}</productDataVersion>
+                        </product>
+                    </products>
                 </configuration>
             </plugin>
 

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -72,7 +72,7 @@ import java.nio.file.Paths;
 
 @Configuration
 //ComponentScan is required only because IDEA seems to need it.
-@ComponentScan
+//@ComponentScan
 public class MigrationAssistantBeanConfiguration {
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,16 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>com.atlassian.util.concurrent</groupId>
+                <artifactId>atlassian-util-concurrent</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.atlassian.util.concurrent</groupId>
+                <artifactId>atlassian-util-concurrent</artifactId>
+                <version>4.0.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.atlassian.soy</groupId>
                 <artifactId>soy-template-renderer-api</artifactId>
                 <version>${soy.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,6 @@
 
     <dependencyManagement>
         <dependencies>
-
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
@@ -513,6 +512,7 @@
         <jackson.version>2.10.3</jackson.version>
         <mockk.version>1.9.3</mockk.version>
         <surefire.version>3.0.0-M4</surefire.version>
+        <jira.version>8.5.0</jira.version>
         <amps.jvm.args/>
 
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>


### PR DESCRIPTION
This is a draft PR that will not be merged. 

The issue that this shows is this - 

* we use the `AttachmentStore` class from `jira-api`
* Version 7.13.x of `jira-api` uses `com.atlassian.concurrent.util`
** Specifically, `AttachmentStore` uses the `Promise` class from the concurrent library

* Prior to this change, where we include a dependency (scope: provided) on `com.atlassian.concurrent.util`, the `Promise` class definition could not be found on the classpath as it was transitively resolved to an older version of `com.atlassian.concurrent.util`
* This change adds the required dependency. It has been verified that jira 8.8.x exports com.atlassian.concurrent.util and `io.atlassian.concurrent.util`


#### Testing

* To test, enable the test in `JiraIssueAttachmentListenerTest` and verify that it passes. Comment out the provided dependency, and it will complain that the `Promise` class can be loaded

Things to verify -

* Does jira 7.13.x export `com.atlassian.concurrent.util`
* ...