### PR TITLE
CHET-406: Capture attachment thumbnails

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/JiraIssueAttachmentListener.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/JiraIssueAttachmentListener.java
@@ -21,6 +21,7 @@ import com.atlassian.event.api.EventListener;
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.event.type.EventType;
+import com.atlassian.jira.issue.attachment.Attachment;
 import com.atlassian.jira.issue.attachment.AttachmentStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 
 import java.io.File;
+import java.util.Collection;
 
 public class JiraIssueAttachmentListener implements InitializingBean, DisposableBean {
 
@@ -51,16 +53,23 @@ public class JiraIssueAttachmentListener implements InitializingBean, Disposable
 
     @EventListener
     public void onIssueEvent(IssueEvent issueEvent) {
-        logger.trace("received jira event with type {}", issueEvent.getEventTypeId());
         if (issueEvent.getEventTypeId().equals(EventType.ISSUE_CREATED_ID)) {
             logger.trace("got issue created event");
-            issueEvent
-                .getIssue()
-                .getAttachments()
-                .stream()
-                .map(this.attachmentStore::getAttachmentFile)
-                .map(File::toPath)
-                .forEach(this.attachmentPathCaptor::captureAttachmentPath);
+            Collection<Attachment> attachments = issueEvent
+                    .getIssue()
+                    .getAttachments();
+
+            attachments
+                    .stream()
+                    .map(this.attachmentStore::getAttachmentFile)
+                    .map(File::toPath)
+                    .forEach(this.attachmentPathCaptor::captureAttachmentPath);
+            attachments
+                    .stream()
+                    .map(attachment -> attachmentStore.getThumbnailFile(attachment))
+                    .map(File::toPath)
+                    .forEach(this.attachmentPathCaptor::captureAttachmentPath);
+
         }
     }
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/JiraIssueAttachmentListenerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/JiraIssueAttachmentListenerTest.java
@@ -30,6 +30,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -86,6 +87,22 @@ class JiraIssueAttachmentListenerTest {
         assertThat(capturedPaths, contains(
                 Paths.get(A_MOCK_ATTACHMENT_PATH),
                 Paths.get(ANOTHER_MOCK_ATTACHMENT_PATH)
+        ));
+    }
+
+    @Test
+    @Disabled("Until the attachment store dependency on the promise from atlassian.concurrent is sorted")
+    void shouldCaptureThumbnailsOfAttachment() {
+        when(mockIssue.getAttachments()).thenReturn(new ArrayList<Attachment>() {{
+            add(aMockAttachment);
+        }});
+        final Path thumbnailPath = Paths.get("fake-thumbnail");
+        when(attachmentStore.getThumbnailFile(aMockAttachment)).thenReturn(thumbnailPath.toFile());
+        IssueEvent mockEvent = new IssueEvent(mockIssue, null, null, null, null, null, EventType.ISSUE_CREATED_ID);
+        sut.onIssueEvent(mockEvent);
+
+        assertThat(capturedPaths, contains(
+                thumbnailPath
         ));
     }
 

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -63,7 +63,7 @@
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <jvmArgs>${amps.jvm.args} -Dspring.profiles.active=allowAnyTransition</jvmArgs>
+                    <jvmArgs>${amps.jvm.args} -Dspring.profiles.active=allowAnyTransition,gaFeature</jvmArgs>
                     <product>jira</product>
                     <enableQuickReload>true</enableQuickReload>
                     <instructions>


### PR DESCRIPTION
### Summary

* Use `AttachmentStore` to get attachment thumbnails
* Add `gaFeatures` spring profile to default amps run

#### Screenshot of attachment and thumbnail
![image](https://user-images.githubusercontent.com/21027663/81783118-3c46b800-953e-11ea-8ae8-924ec81b2c6c.png)
