### PR TITLE
CHET-396: persist listened files

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/AttachmentSyncManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/AttachmentSyncManager.java
@@ -16,6 +16,8 @@
 
 package com.atlassian.migration.datacenter.core.fs.captor;
 
+import com.atlassian.migration.datacenter.dto.FileSyncRecord;
+
 import java.util.Set;
 
 public interface AttachmentSyncManager extends AttachmentPathCaptor {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/AttachmentSyncManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/AttachmentSyncManager.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.captor;
+
+import java.util.Set;
+
+public interface AttachmentSyncManager extends AttachmentPathCaptor {
+    Set<FileSyncRecord> getCapturedAttachments();
+}

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
@@ -16,6 +16,7 @@
 
 package com.atlassian.migration.datacenter.core.fs.captor;
 
+import com.atlassian.activeobjects.external.ActiveObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,9 +25,20 @@ import java.nio.file.Path;
 public class DefaultAttachmentPathCaptor implements AttachmentPathCaptor {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultAttachmentPathCaptor.class);
+    private final ActiveObjects ao;
+
+    public DefaultAttachmentPathCaptor(ActiveObjects ao) {
+        this.ao = ao;
+    }
 
     @Override
     public void captureAttachmentPath(Path attachmentPath) {
         logger.debug("captured attachment for final sync: {}", attachmentPath.toString());
+
+        FileSyncRecord record = ao.create(FileSyncRecord.class);
+
+        record.setFilePath(attachmentPath.toString());
+
+        record.save();
     }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
@@ -17,6 +17,7 @@
 package com.atlassian.migration.datacenter.core.fs.captor;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.migration.datacenter.spi.MigrationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,9 +27,11 @@ public class DefaultAttachmentPathCaptor implements AttachmentPathCaptor {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultAttachmentPathCaptor.class);
     private final ActiveObjects ao;
+    private final MigrationService migrationService;
 
-    public DefaultAttachmentPathCaptor(ActiveObjects ao) {
+    public DefaultAttachmentPathCaptor(ActiveObjects ao, MigrationService migrationService) {
         this.ao = ao;
+        this.migrationService = migrationService;
     }
 
     @Override
@@ -38,6 +41,8 @@ public class DefaultAttachmentPathCaptor implements AttachmentPathCaptor {
         FileSyncRecord record = ao.create(FileSyncRecord.class);
 
         record.setFilePath(attachmentPath.toString());
+        // FIXME: Should we cache the migration identifier so we don't hit the DB twice every time we capture a path?
+        record.setMigration(migrationService.getCurrentMigration());
 
         record.save();
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
@@ -22,8 +22,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
-public class DefaultAttachmentPathCaptor implements AttachmentPathCaptor {
+public class DefaultAttachmentPathCaptor implements AttachmentSyncManager {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultAttachmentPathCaptor.class);
     private final ActiveObjects ao;
@@ -45,5 +48,13 @@ public class DefaultAttachmentPathCaptor implements AttachmentPathCaptor {
         record.setMigration(migrationService.getCurrentMigration());
 
         record.save();
+    }
+
+    @Override
+    public Set<FileSyncRecord> getCapturedAttachments() {
+        Set<FileSyncRecord> records = new HashSet<>();
+        Collections.addAll(records, ao.find(FileSyncRecord.class));
+
+        return records;
     }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptor.java
@@ -17,7 +17,10 @@
 package com.atlassian.migration.datacenter.core.fs.captor;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.migration.datacenter.dto.FileSyncRecord;
+import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationService;
+import net.java.ao.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +56,17 @@ public class DefaultAttachmentPathCaptor implements AttachmentSyncManager {
     @Override
     public Set<FileSyncRecord> getCapturedAttachments() {
         Set<FileSyncRecord> records = new HashSet<>();
-        Collections.addAll(records, ao.find(FileSyncRecord.class));
+        Migration migration = migrationService.getCurrentMigration();
+
+        if (migration == null) {
+            return Collections.emptySet();
+        }
+
+        final FileSyncRecord[] recordsForCurrentMigration = ao.find(
+                FileSyncRecord.class,
+                Query.select().where("migration_id = ?", migration.getID()));
+
+        Collections.addAll(records, recordsForCurrentMigration);
 
         return records;
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/FileSyncRecord.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/FileSyncRecord.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.captor;
+
+import com.atlassian.migration.datacenter.dto.Migration;
+import net.java.ao.Entity;
+
+public interface FileSyncRecord extends Entity {
+    /**
+     * @return the migration that this file was captured in
+     */
+    Migration getMigration();
+    void setMigration(Migration migration);
+
+    String getFilePath();
+    void setFilePath(String path);
+}

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptorTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptorTest.java
@@ -31,7 +31,10 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.nio.file.Paths;
+import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -86,4 +89,23 @@ public class DefaultAttachmentPathCaptorTest {
         assertEquals(migration, record.getMigration());
     }
 
+    @Test
+    public void shouldRetrieveAllCapturedFilePaths() {
+        FileSyncRecord record = ao.create(FileSyncRecord.class);
+        final String pathOne = "pathOne";
+        record.setFilePath(pathOne);
+        record.save();
+
+        FileSyncRecord anotherRecord = ao.create(FileSyncRecord.class);
+        final String pathTwo = "pathTwo";
+        anotherRecord.setFilePath(pathTwo);
+        anotherRecord.save();
+
+        Set<FileSyncRecord> records = sut.getCapturedAttachments();
+
+        assertThat(records, contains(
+                record,
+                anotherRecord
+        ));
+    }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptorTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptorTest.java
@@ -18,16 +18,23 @@ package com.atlassian.migration.datacenter.core.fs.captor;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.activeobjects.test.TestActiveObjects;
+import com.atlassian.migration.datacenter.dto.Migration;
+import com.atlassian.migration.datacenter.spi.MigrationService;
 import net.java.ao.EntityManager;
 import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 
 @RunWith(ActiveObjectsJUnitRunner.class)
 public class DefaultAttachmentPathCaptorTest {
@@ -37,11 +44,17 @@ public class DefaultAttachmentPathCaptorTest {
 
     private DefaultAttachmentPathCaptor sut;
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    MigrationService migrationService;
+
     @Before
     public void setup() {
         assertNotNull(entityManager);
         ao = new TestActiveObjects(entityManager);
-        sut = new DefaultAttachmentPathCaptor(ao);
+        sut = new DefaultAttachmentPathCaptor(ao, migrationService);
         setupEntities();
     }
 
@@ -57,6 +70,20 @@ public class DefaultAttachmentPathCaptorTest {
         FileSyncRecord record = ao.find(FileSyncRecord.class)[0];
 
         assertEquals(testPath, record.getFilePath());
+    }
+
+    @Test
+    public void shouldStoreRecordAgainstCurrentMigration() {
+        Migration migration = ao.create(Migration.class);
+        migration.save();
+
+        when(migrationService.getCurrentMigration()).thenReturn(migration);
+
+        sut.captureAttachmentPath(Paths.get("test"));
+
+        FileSyncRecord record = ao.find(FileSyncRecord.class)[0];
+
+        assertEquals(migration, record.getMigration());
     }
 
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptorTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentPathCaptorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.captor;
+
+import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.activeobjects.test.TestActiveObjects;
+import net.java.ao.EntityManager;
+import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@RunWith(ActiveObjectsJUnitRunner.class)
+public class DefaultAttachmentPathCaptorTest {
+
+    private ActiveObjects ao;
+    private EntityManager entityManager;
+
+    private DefaultAttachmentPathCaptor sut;
+
+    @Before
+    public void setup() {
+        assertNotNull(entityManager);
+        ao = new TestActiveObjects(entityManager);
+        sut = new DefaultAttachmentPathCaptor(ao);
+        setupEntities();
+    }
+
+    private void setupEntities() {
+        ao.migrate(FileSyncRecord.class);
+    }
+
+    @Test
+    public void shouldStorePathInActiveObjects() {
+        final String testPath = "hello-path";
+        sut.captureAttachmentPath(Paths.get(testPath));
+
+        FileSyncRecord record = ao.find(FileSyncRecord.class)[0];
+
+        assertEquals(testPath, record.getFilePath());
+    }
+
+}

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -53,6 +53,7 @@ import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSyst
 import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSystemDownloader;
 import com.atlassian.migration.datacenter.core.util.EncryptionManager;
 import com.atlassian.migration.datacenter.core.util.MigrationRunner;
+import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
@@ -260,7 +261,7 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public AttachmentPathCaptor attachmentCaptor() {
-        return new DefaultAttachmentPathCaptor();
+    public AttachmentPathCaptor attachmentCaptor(ActiveObjects activeObjects, MigrationService migrationService) {
+        return new DefaultAttachmentPathCaptor(activeObjects, migrationService);
     }
 }

--- a/jira-plugin/src/main/resources/atlassian-plugin.xml
+++ b/jira-plugin/src/main/resources/atlassian-plugin.xml
@@ -25,6 +25,7 @@
         <description>The module configuring the Active Objects service used by this plugin</description>
         <entity>com.atlassian.migration.datacenter.dto.Migration</entity>
         <entity>com.atlassian.migration.datacenter.dto.MigrationContext</entity>
+        <entity>com.atlassian.migration.datacenter.dto.FileSyncRecord</entity>
     </ao>
 
     <!-- add our i18n resource -->

--- a/spi/src/main/java/com/atlassian/migration/datacenter/dto/FileSyncRecord.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/dto/FileSyncRecord.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.atlassian.migration.datacenter.core.fs.captor;
+package com.atlassian.migration.datacenter.dto;
 
-import com.atlassian.migration.datacenter.dto.Migration;
 import net.java.ao.Entity;
 
 public interface FileSyncRecord extends Entity {

--- a/spi/src/main/java/com/atlassian/migration/datacenter/dto/Migration.java
+++ b/spi/src/main/java/com/atlassian/migration/datacenter/dto/Migration.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.dto;
 
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import net.java.ao.Entity;
+import net.java.ao.OneToMany;
 import net.java.ao.OneToOne;
 
 public interface Migration extends Entity {
@@ -28,5 +29,8 @@ public interface Migration extends Entity {
 
     @OneToOne(reverse = "getMigration")
     MigrationContext getContext();
+
+    @OneToMany(reverse = "getMigration")
+    FileSyncRecord[] getRecords();
 
 }


### PR DESCRIPTION
### Summary

* Implement DTO class for capturing paths "listened to" during the FS copy
* Associate these paths with the current migration
* Implement and test, storing and fetching these paths