### PR TITLE
Transfer page and fs listener bugfixes

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -106,7 +106,10 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
 
         for (String profile : environment.getActiveProfiles()) {
             if (profile.equals("gaFeature")) {
+                logger.info("detected GA feature flag. Enabling file listener");
                 attachmentListener.start();
+            } else {
+                logger.trace("not enabling file listener");
             }
         }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListener.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListener.java
@@ -67,7 +67,7 @@ public class JiraIssueAttachmentListener implements DisposableBean {
 
             attachments
                     .stream()
-                    // FIXME: I create NPE's...
+                    // FIXME: I lie about thumbnailable
                     //.filter(Attachment::isThumbnailable)
                     .map(attachmentStore::getThumbnailFile)
                     .filter(Objects::nonNull)

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListener.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListener.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class JiraIssueAttachmentListener implements DisposableBean {
 
@@ -69,6 +70,7 @@ public class JiraIssueAttachmentListener implements DisposableBean {
                     // FIXME: I create NPE's...
                     //.filter(Attachment::isThumbnailable)
                     .map(attachmentStore::getThumbnailFile)
+                    .filter(Objects::nonNull)
                     .map(File::toPath)
                     .forEach(this.attachmentPathCaptor::captureAttachmentPath);
         }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListener.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListener.java
@@ -66,7 +66,8 @@ public class JiraIssueAttachmentListener implements DisposableBean {
 
             attachments
                     .stream()
-                    .filter(Attachment::isThumbnailable)
+                    // FIXME: I create NPE's...
+                    //.filter(Attachment::isThumbnailable)
                     .map(attachmentStore::getThumbnailFile)
                     .map(File::toPath)
                     .forEach(this.attachmentPathCaptor::captureAttachmentPath);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListenerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/listener/JiraIssueAttachmentListenerTest.java
@@ -151,8 +151,8 @@ class JiraIssueAttachmentListenerTest {
         when(this.attachmentStore.getAttachmentFile(aMockAttachment)).thenReturn(new File(A_MOCK_ATTACHMENT_PATH));
         when(this.attachmentStore.getAttachmentFile(anotherMockAttachment)).thenReturn(new File(ANOTHER_MOCK_ATTACHMENT_PATH));
 
-        when(aMockAttachment.isThumbnailable()).thenReturn(includeThumbnails);
-        when(anotherMockAttachment.isThumbnailable()).thenReturn(includeThumbnails);
+//        when(aMockAttachment.isThumbnailable()).thenReturn(includeThumbnails);
+//        when(anotherMockAttachment.isThumbnailable()).thenReturn(includeThumbnails);
 
         if (includeThumbnails) {
             when(this.attachmentStore.getThumbnailFile(aMockAttachment)).thenReturn(new File(A_MOCK_ATTACHMENT_THUMBNAIL_PATH));

--- a/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
@@ -78,7 +78,7 @@ export const fs = {
     },
 
     getCapturedFiles: async (): Promise<Array<string>> => {
-        const result = await callAppRest('PUT', RestApiPathConstants.fsStartRestPath);
+        const result = await callAppRest('GET', RestApiPathConstants.fsFinalSyncPath);
         const capturedFiles = (await result.json()) as GetFinalSyncResponse;
         return capturedFiles.files || [];
     },

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -110,7 +110,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     const [loading, setLoading] = useState<boolean>(true);
     const [progressFetchingError, setProgressFetchingError] = useState<string>();
     const [started, setStarted] = useState<boolean>(false);
-    const [finished, setFinished] = useState<boolean>(true);
+    const [finished, setFinished] = useState<boolean>(false);
     const [commandResult, setCommandResult] = useState<CommandResult>();
 
     const updateProgress = (): Promise<void> => {
@@ -118,12 +118,12 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
             .then(result => {
                 setProgress(result);
                 setLoading(false);
-                if (progress.completeness === 1) {
+                if (progress?.completeness === 1) {
                     setFinished(true);
                 }
             })
             .catch(err => {
-                setProgressFetchingError(err);
+                setProgressFetchingError(err.message);
                 setLoading(false);
             });
     };
@@ -148,7 +148,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
             .then(stage => {
                 if (inProgressStages.includes(stage)) {
                     setStarted(true);
-                    return updateProgress();
+                    updateProgress();
                 }
                 setLoading(false);
             })
@@ -205,7 +205,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                     <TransferContentContainer>
                         {(transferError || progressFetchingError) && (
                             <SectionMessage appearance="error">
-                                {transferError}
+                                {transferError || ''}
                                 <p>
                                     {progressFetchingError || ''}{' '}
                                     <a


### PR DESCRIPTION
* Fix some null dereferences in transfer page
* Drop thumbnailable filter from issue listener - it was causing NPE's and missing the thumbnails