### PR TITLE
Allow deployment status reason to be null

### DIFF
--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureDeploymentStatus.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureDeploymentStatus.kt
@@ -21,4 +21,4 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonAutoDetect
 class InfrastructureDeploymentStatus(@get:JsonProperty("state") val state: InfrastructureDeploymentState, @get:JsonProperty("reason")
-@get:JsonInclude(JsonInclude.Include.NON_NULL) val reason: String) 
+@get:JsonInclude(JsonInclude.Include.NON_NULL) val reason: String?)


### PR DESCRIPTION
This was breaking the deployment status endpoint because sometimes the stack status reason is null and kotlin wasn't allowing the null. Since this is called from java code I decided it's better to allow null than to try change it to not be null as this structure is only really used by the API and it is not serialised by jackson when null