### PR TITLE
CHET-412: Fix padding between navigation buttons

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
@@ -21,7 +21,7 @@ import { CancelModal } from './CancelModal';
 
 export const cancelButtonStyle = {
     paddingLeft: '5px',
-    marginLeft: '20px',
+    marginLeft: '5px',
 };
 
 export const CancelButton: FunctionComponent = () => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -73,7 +73,7 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
 
     const marginButtonStyle = {
         ...defaultButtonStyle,
-        marginRight: '20px',
+        marginRight: '5px',
     };
 
     const StartButton = (

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -64,7 +64,7 @@ const CheckboxContainer = styled.div`
 
 const nextButtonStyle = {
     padding: '5px',
-    marginRight: '20px',
+    marginRight: '5px',
 };
 
 const LearnMore: FunctionComponent = () => {


### PR DESCRIPTION
Fixed padding between navigation buttons including the navigation buttons on the following routes:

```
- auth (step 1 of 6)
- provision (step 2 of 6)
    - provision/status 
- fs (step 3 of 6)
- warning (step 4 of 6)
- db (step 5 of 6)
```

New padding between navigation buttons now rendered like so:

![image](https://user-images.githubusercontent.com/409063/82862323-ae69c480-9f62-11ea-9312-ec5654e2bf9b.png)
