### PR TITLE
CHET-323: Scroll to top of page on page transitions

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/AwsRoutes.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/AwsRoutes.tsx
@@ -22,23 +22,6 @@ import { QuickStartDeploy } from './quickstart/QuickStartDeploy';
 import { AuthenticateAWS, CredSubmitFun, QueryRegionFun } from './auth/AuthenticateAWS';
 import { callAppRest, RestApiPathConstants } from '../../utils/api';
 import { ProvisioningStatusPage } from './quickstart/ProvisioningStatusPage';
-import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
-
-/*
- * Pages that are navigated to from long content pages 
- * stay scrolled down. This is a component that will 
- * scroll the window up.
- */
-const ScrollToTop = (): null => {
-    const { pathname } = useLocation();
-
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [pathname]);
-
-    return null;
-};
 
 const getRegions: QueryRegionFun = () => {
     return callAppRest('GET', RestApiPathConstants.awsRegionListPath).then(response =>
@@ -70,7 +53,6 @@ export const AWSRoutes: FunctionComponent = () => (
             <QuickStartDeploy />
         </Route>
         <Route exact path={quickstartStatusPath}>
-            <ScrollToTop />
             <ProvisioningStatusPage />
         </Route>
         <Route exact path={awsAuthPath}>

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/AwsRoutes.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/AwsRoutes.tsx
@@ -22,6 +22,23 @@ import { QuickStartDeploy } from './quickstart/QuickStartDeploy';
 import { AuthenticateAWS, CredSubmitFun, QueryRegionFun } from './auth/AuthenticateAWS';
 import { callAppRest, RestApiPathConstants } from '../../utils/api';
 import { ProvisioningStatusPage } from './quickstart/ProvisioningStatusPage';
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+/*
+ * Pages that are navigated to from long content pages 
+ * stay scrolled down. This is a component that will 
+ * scroll the window up.
+ */
+const ScrollToTop = (): null => {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+};
 
 const getRegions: QueryRegionFun = () => {
     return callAppRest('GET', RestApiPathConstants.awsRegionListPath).then(response =>
@@ -53,6 +70,7 @@ export const AWSRoutes: FunctionComponent = () => (
             <QuickStartDeploy />
         </Route>
         <Route exact path={quickstartStatusPath}>
+            <ScrollToTop />
             <ProvisioningStatusPage />
         </Route>
         <Route exact path={awsAuthPath}>

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -22,6 +22,8 @@ import { ProgressBuilder, ProgressCallback } from '../../shared/Progress';
 import { provisioning, ProvisioningStatus } from '../../../api/provisioning';
 import { MigrationStage } from '../../../api/migration';
 import { fsPath } from '../../../utils/RoutePaths';
+import { useLocation } from "react-router-dom";
+import { useEffect } from "react";
 
 const getDeploymentProgress: ProgressCallback = () => {
     return provisioning
@@ -73,6 +75,17 @@ const inProgressStages = [
 ];
 
 export const ProvisioningStatusPage: FunctionComponent = () => {
+    
+  /*
+   * Pages that are navigated to from long content pages 
+   * stay scrolled down. This is a component that will 
+   * scroll the window up.
+   */
+    const { pathname } = useLocation();
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
     return (
         <MigrationTransferPage
             description={I18n.getText(

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -78,8 +78,9 @@ export const ProvisioningStatusPage: FunctionComponent = () => {
     
   /*
    * Pages that are navigated to from long content pages 
-   * stay scrolled down. This is a component that will 
-   * scroll the window up.
+   * stay scrolled down. 
+   * 
+   * Scroll the window up after render.
    */
     const { pathname } = useLocation();
     useEffect(() => {

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { I18n } from '@atlassian/wrm-react-i18n';
 
 import { MigrationTransferPage } from '../../shared/MigrationTransferPage';
@@ -22,8 +22,6 @@ import { ProgressBuilder, ProgressCallback } from '../../shared/Progress';
 import { provisioning, ProvisioningStatus } from '../../../api/provisioning';
 import { MigrationStage } from '../../../api/migration';
 import { fsPath } from '../../../utils/RoutePaths';
-import { useLocation } from "react-router-dom";
-import { useEffect } from "react";
 
 const getDeploymentProgress: ProgressCallback = () => {
     return provisioning
@@ -75,17 +73,13 @@ const inProgressStages = [
 ];
 
 export const ProvisioningStatusPage: FunctionComponent = () => {
-    
-  /*
-   * Pages that are navigated to from long content pages 
-   * stay scrolled down. 
-   * 
-   * Scroll the window up after render.
-   */
-    const { pathname } = useLocation();
+    /*
+     * Pages that are navigated to from long content pages
+     * stay scrolled down. Scroll the window up after render.
+     */
     useEffect(() => {
         window.scrollTo(0, 0);
-    }, [pathname]);
+    });
 
     return (
         <MigrationTransferPage


### PR DESCRIPTION
When transitioning from step `Step 2 of 6: Deploy on AWS` by selecting the `Deploy` button the subsequent page is scrolled to the bottom. This fix ensures the subsequent scrolls to the top on load.