### PR TITLE
CHET-428: Helper for uploading all captured paths to S3

### DIFF
--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/S3FinalFileSync.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/S3FinalFileSync.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs
+
+import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager
+import com.atlassian.migration.datacenter.core.util.UploadQueue
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class S3FinalFileSync(private val attachmentSyncManager: AttachmentSyncManager, private val uploader: Uploader) {
+
+    fun uploadCapturedFiles() {
+        val capturedAttachments = attachmentSyncManager.capturedAttachments
+        val uploadQueue = UploadQueue<Path>(capturedAttachments.size + 1)
+
+        capturedAttachments.forEach { uploadQueue.put(Paths.get(it.filePath)) }
+        uploadQueue.finish()
+
+        uploader.upload(uploadQueue)
+    }
+
+}

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/S3FinalFileSyncTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/S3FinalFileSyncTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs
+
+import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager
+import com.atlassian.migration.datacenter.core.util.UploadQueue
+import com.atlassian.migration.datacenter.dto.FileSyncRecord
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Optional
+import kotlin.test.assertTrue
+
+@ExtendWith(MockKExtension::class)
+internal class S3FinalFileSyncTest {
+
+    @MockK
+    lateinit var mockSyncManager: AttachmentSyncManager
+
+    @MockK
+    lateinit var mockUploader: Uploader
+
+    @MockK
+    lateinit var mockFile: FileSyncRecord
+
+    @MockK
+    lateinit var anotherMockFile: FileSyncRecord
+
+    lateinit var sut: S3FinalFileSync
+
+    private val uploadedPaths: MutableList<String> = ArrayList()
+
+    @BeforeEach
+    internal fun setUp() {
+        sut = S3FinalFileSync(mockSyncManager, mockUploader)
+
+        val slot = slot<UploadQueue<Path>>()
+        every { mockUploader.upload(capture(slot)) } answers {
+            val uploadQueue = slot.captured
+            var path = uploadQueue.take()
+            while (path != Optional.empty<Path>()) {
+                uploadedPaths.add(path.get().toString())
+                path = uploadQueue.take()
+            }
+        }
+    }
+
+    @Test
+    fun shouldUploadAllFilesReturnedByCaptor() {
+        val filePath = "hello/there"
+        every { mockFile.filePath } returns filePath
+        val anotherFilePath = "general/kenobi"
+        every { anotherMockFile.filePath } returns anotherFilePath
+
+        every { mockSyncManager.capturedAttachments } returns setOf(mockFile, anotherMockFile)
+
+        sut.uploadCapturedFiles()
+
+        assertThat(uploadedPaths, containsInAnyOrder(filePath, anotherFilePath))
+    }
+
+}


### PR DESCRIPTION
# Summary

* New class which uses attachment sync manager to get listened files
* Use S3Uploader to upload them all to S3

## Follow up

* Create instance during Final sync phase (DB migration)
* Run upload

## Notes

* I wanted to make this a service and export it as a bean injecting the Uploader is difficult as it depends on the report and `S3Config`. I tried picking apart the uploader but it's a bit of a rabbit hole so I'm just going to construct it at migration time.
* A good future refactor would be to decouple the S3 config, S3 uploading, and S3 reporting from the `S3Uploader` implementation