### PR TITLE
CHET-409: run file final sync during offline period

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/util/MigrationRunner.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/util/MigrationRunner.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-@Component
 public class MigrationRunner
 {
     private static final Logger logger = LoggerFactory.getLogger(MigrationRunner.class);

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalFileSync.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalFileSync.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.atlassian.migration.datacenter.core.fs
+package com.atlassian.migration.datacenter.core.fs.captor
 
-import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager
+import com.atlassian.migration.datacenter.core.fs.Uploader
 import com.atlassian.migration.datacenter.core.util.UploadQueue
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncRunner.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncRunner.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.captor
+
+import com.atlassian.jira.config.util.JiraHome
+import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService
+import com.atlassian.migration.datacenter.core.fs.S3UploadConfig
+import com.atlassian.migration.datacenter.core.fs.S3Uploader
+import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFileSystemMigrationReport
+import com.atlassian.migration.datacenter.core.util.MigrationJobRunner
+import com.atlassian.scheduler.JobRunnerRequest
+import com.atlassian.scheduler.JobRunnerResponse
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Supplier
+
+class S3FinalSyncRunner(
+        private val attachmentSyncManager: AttachmentSyncManager,
+        private val client: Supplier<S3AsyncClient>,
+        private val home: JiraHome,
+        private val migrationHelperDeploymentService: AWSMigrationHelperDeploymentService) : MigrationJobRunner {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(com.atlassian.migration.datacenter.core.db.DatabaseMigrationJobRunner::class.java)
+    }
+
+    private val isRunning = AtomicBoolean(false)
+
+    override fun getKey(): String {
+        return S3FinalSyncRunner::class.java.name
+    }
+
+    override fun runJob(request: JobRunnerRequest): JobRunnerResponse? {
+        if (!isRunning.compareAndSet(false, true)) {
+            return JobRunnerResponse.aborted("Database migration job is already running")
+        }
+
+        val config = S3UploadConfig(migrationHelperDeploymentService.migrationS3BucketName, client.get(), home.home.toPath())
+        val report = DefaultFileSystemMigrationReport()
+        val uploader = S3Uploader(config, report)
+
+        log.info("Starting final file sync migration job")
+        val finalSyncUploader = S3FinalFileSync(attachmentSyncManager, uploader)
+        finalSyncUploader.uploadCapturedFiles()
+
+        if (report.failedFiles.isNotEmpty()) {
+            log.error("Some files failed to upload during final sync")
+            report.failedFiles.forEach {
+                log.error("${it.filePath} - ${it.reason}")
+            }
+        }
+
+        log.info("Finished final file sync migration job")
+
+        return JobRunnerResponse.success("Final file sync migration complete")
+    }
+}

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.captor
+
+import com.atlassian.migration.datacenter.core.db.DatabaseMigrationJobRunner
+import com.atlassian.migration.datacenter.core.util.MigrationRunner
+import com.atlassian.migration.datacenter.spi.MigrationService
+import com.atlassian.scheduler.config.JobId
+import org.slf4j.LoggerFactory
+
+class S3FinalSyncService(private val migrationRunner: MigrationRunner, private val jobRunner: S3FinalSyncRunner, private val migrationService: MigrationService) {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(S3FinalSyncService::class.java)
+    }
+
+    fun scheduleSync(): Boolean {
+
+        val jobId = getScheduledJobId()
+
+        val result = migrationRunner.runMigration(jobId, jobRunner)
+
+        if (!result) {
+            logger.error("Unable to start database migration job.")
+        }
+        return result
+    }
+
+    fun abortMigration() {
+        // We always try to remove scheduled job if the system is in inconsistent state
+        migrationRunner.abortJobIfPresesnt(getScheduledJobId())
+
+        logger.warn("Aborting running filesystem migration")
+
+        migrationService.error("Aborted final file sync")
+    }
+
+    private fun getScheduledJobId(): JobId {
+        return JobId.of(DatabaseMigrationJobRunner.KEY + migrationService.currentMigration.id)
+    }
+}

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalFileSyncTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalFileSyncTest.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.atlassian.migration.datacenter.core.fs
+package com.atlassian.migration.datacenter.core.fs.captor
 
-import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager
+import com.atlassian.migration.datacenter.core.fs.Uploader
 import com.atlassian.migration.datacenter.core.util.UploadQueue
 import com.atlassian.migration.datacenter.dto.FileSyncRecord
 import io.mockk.every
@@ -24,15 +24,12 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.slot
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.util.Optional
-import kotlin.test.assertTrue
 
 @ExtendWith(MockKExtension::class)
 internal class S3FinalFileSyncTest {


### PR DESCRIPTION
## Summary

* Implement scheduled job for running final file sync
* Start scheduled job in DB API endpoint

## Note

* This is not very well integrated with the state machine, however I think that can come as a follow-up once the final sync is completed end-to-end
* I'm thinking of changing the name and path of the DB endpoint so it encompasses both the DB migration and the fs final sync. Maybe `FinalSyncEndpoint` or something like that. Any thoughts?
