### PR TITLE
CHET-433: wire up asi selector to api

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
@@ -16,6 +16,7 @@
 
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { callAppRest } from '../utils/api';
+import { ASIDescription } from '../components/aws/quickstart/asi/ExistingASIConfiguration';
 
 export enum ProvisioningStatus {
     ProvisioningApplicationStack,
@@ -26,6 +27,7 @@ export enum ProvisioningStatus {
 
 enum RestApiPathConstants {
     GetDeploymentStatusPath = 'aws/stack/status',
+    GetASIInfoPath = `/aws/global-infrastructure/asi`,
 }
 
 type InfrastructureDeploymentState =
@@ -46,10 +48,14 @@ type StackStatusErrorResponse = {
     error: string;
 };
 
-type GetProvisioningStatusResponse = StackStatusResponse | StackStatusErrorResponse;
+type ASIInfo = {
+    name: string;
+    id: string;
+    prefix: string;
+};
 
 export const provisioning = {
-    getProvisioningStatus: (): Promise<ProvisioningStatus> => {
+    getProvisioningStatus: async (): Promise<ProvisioningStatus> => {
         return callAppRest('GET', RestApiPathConstants.GetDeploymentStatusPath)
             .then(resp => resp.json())
             .then(resp => {
@@ -96,5 +102,15 @@ export const provisioning = {
                     )
                 );
             });
+    },
+    getASIs: async (): Promise<Array<ASIDescription>> => {
+        const json = await callAppRest('GET', RestApiPathConstants.GetASIInfoPath).then(resp => {
+            if (resp.ok) return resp.json();
+            return Promise.resolve([]);
+        });
+
+        const stackData = json as Array<ASIInfo>;
+
+        return stackData.map(data => ({ prefix: data.prefix, stackName: data.name }));
     },
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickstartRoutes.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickstartRoutes.tsx
@@ -26,7 +26,7 @@ export const QuickstartRoutes: FunctionComponent = () => {
     return (
         <Switch>
             <Route exact path={asiConfigurationPath}>
-                <ASIConfiguration ASIExists={true} updateASIPrefix={setPrefix} />
+                <ASIConfiguration updateASIPrefix={setPrefix} />
             </Route>
             <Route exact path={quickstartPath}>
                 <QuickStartDeploy ASIPrefix={prefix?.length === 0 ? 'ATL-' : prefix} />

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -90,7 +90,7 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
             </Description>
 
             {loadingPrefixes && <Spinner />}
-            {ASIExists && !loadingPrefixes ? (
+            {!loadingPrefixes && existingASIPrefixes.length !== 0 ? (
                 <ExistingASIConfiguration
                     handlePrefixUpdated={updatePRefix}
                     existingASIs={existingASIPrefixes}

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -26,7 +26,6 @@ import { quickstartPath } from '../../../../utils/RoutePaths';
 import { provisioning } from '../../../../api/provisioning';
 
 type ASIConfigurationProps = {
-    ASIExists: boolean;
     updateASIPrefix: (prefix: string) => void;
 };
 
@@ -49,10 +48,7 @@ const ButtonRow = styled.div`
     margin: 30px 0px 0px 0px;
 `;
 
-export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
-    ASIExists,
-    updateASIPrefix,
-}) => {
+export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({ updateASIPrefix }) => {
     const [prefix, setPrefix] = useState<string>('');
     const [readyToTransition, setReadyToTransition] = useState<boolean>(false);
     const [existingASIPrefixes, setExistingASIPrefixes] = useState<Array<ASIDescription>>([]);

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FunctionComponent, useState, useEffect } from 'react';
+import React, { FunctionComponent, useState, useEffect, ReactNode } from 'react';
 import styled from 'styled-components';
 import { ButtonGroup } from '@atlaskit/button';
 import { Button } from '@atlaskit/button/dist/cjs/components/Button';
@@ -75,6 +75,17 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({ upd
         return <Redirect to={quickstartPath} push />;
     }
 
+    const renderASISelector = (): ReactNode => {
+        return existingASIPrefixes.length !== 0 ? (
+            <ExistingASIConfiguration
+                handlePrefixUpdated={updatePRefix}
+                existingASIs={existingASIPrefixes}
+            />
+        ) : (
+            <ASISelector existingASIs={[]} useExisting={false} handlePrefixUpdated={updatePRefix} />
+        );
+    };
+
     return (
         <ContentContainer>
             <h1>{I18n.getText('atlassian.migration.datacenter.provision.aws.asi.title')}</h1>
@@ -85,19 +96,7 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({ upd
                 </a>
             </Description>
 
-            {loadingPrefixes && <Spinner />}
-            {!loadingPrefixes && existingASIPrefixes.length !== 0 ? (
-                <ExistingASIConfiguration
-                    handlePrefixUpdated={updatePRefix}
-                    existingASIs={existingASIPrefixes}
-                />
-            ) : (
-                <ASISelector
-                    existingASIs={[]}
-                    useExisting={false}
-                    handlePrefixUpdated={updatePRefix}
-                />
-            )}
+            {loadingPrefixes ? <Spinner /> : renderASISelector()}
             <ButtonRow>
                 <ButtonGroup>
                     <Button

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 import { ButtonGroup } from '@atlaskit/button';
 import { Button } from '@atlaskit/button/dist/cjs/components/Button';
 import { Redirect } from 'react-router-dom';
-import { ExistingASIConfiguration, ASISelector } from './ExistingASIConfiguration';
+import { ExistingASIConfiguration, ASISelector, ASIDescription } from './ExistingASIConfiguration';
 import { I18n } from '../../../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { CancelButton } from '../../../shared/CancelButton';
 import { quickstartPath } from '../../../../utils/RoutePaths';
@@ -53,7 +53,10 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
 }) => {
     const [prefix, setPrefix] = useState<string>('');
     const [readyToTransition, setReadyToTransition] = useState<boolean>(false);
-    const [existingASIPrefixes, setexistingASIPrefixes] = useState<Array<string>>([]);
+    const [existingASIPrefixes, setexistingASIPrefixes] = useState<Array<ASIDescription>>([
+        { prefix: 'ATL-', stackName: 'Atlassian Standard Infrastructure' },
+        { prefix: 'BP-', stackName: 'BenPartridge-ASI' },
+    ]);
     const [loadingPrefixes, setloadingPrefixes] = useState<boolean>(false);
 
     const handleSubmit = (): void => {
@@ -79,12 +82,12 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
 
             {ASIExists ? (
                 <ExistingASIConfiguration
-                    handleASIPrefixSet={updatePRefix}
-                    existingASIPrefixes={existingASIPrefixes}
+                    handlePrefixUpdated={updatePRefix}
+                    existingASIs={existingASIPrefixes}
                 />
             ) : (
                 <ASISelector
-                    existingASIPrefixes={[]}
+                    existingASIs={[]}
                     useExisting={false}
                     handlePrefixUpdated={updatePRefix}
                 />

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -53,6 +53,8 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
 }) => {
     const [prefix, setPrefix] = useState<string>('');
     const [readyToTransition, setReadyToTransition] = useState<boolean>(false);
+    const [existingASIPrefixes, setexistingASIPrefixes] = useState<Array<string>>([]);
+    const [loadingPrefixes, setloadingPrefixes] = useState<boolean>(false);
 
     const handleSubmit = (): void => {
         updateASIPrefix(prefix);
@@ -76,9 +78,16 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
             </Description>
 
             {ASIExists ? (
-                <ExistingASIConfiguration handleASIPrefixSet={updatePRefix} />
+                <ExistingASIConfiguration
+                    handleASIPrefixSet={updatePRefix}
+                    existingASIPrefixes={existingASIPrefixes}
+                />
             ) : (
-                <ASISelector useExisting={false} handlePrefixUpdated={updatePRefix} />
+                <ASISelector
+                    existingASIPrefixes={[]}
+                    useExisting={false}
+                    handlePrefixUpdated={updatePRefix}
+                />
             )}
             <ButtonRow>
                 <ButtonGroup>

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
@@ -50,26 +50,39 @@ const ASISelectorContainer = styled.div`
 `;
 
 type ExistingASIConfigurationProps = {
-    handleASIPrefixSet: (prefix: string) => void;
-    existingASIPrefixes: Array<string>;
-};
-
-type ASISelectorProps = {
-    useExisting: boolean;
     handlePrefixUpdated: (prefix: string) => void;
-    existingASIPrefixes: Array<string>;
+    existingASIs: Array<ASIDescription>;
 };
 
-const ASIPrefixOptionsFromList = (prefixes: Array<string>): Array<OptionType> => {
-    if (prefixes.length === 0) return [];
+export type ASIDescription = {
+    prefix: string;
+    stackName: string;
+};
 
-    return prefixes.map(prefix => ({ label: prefix, value: prefix, key: prefix }));
+type ASISelectorPropsBase = {
+    useExisting: boolean;
+};
+
+type ASISelectorProps = ASISelectorPropsBase & ExistingASIConfigurationProps;
+
+const ASIPrefixOptionsFromList = (ASIs: Array<ASIDescription>): Array<OptionType> => {
+    if (ASIs.length === 0) return [];
+
+    const asiToOptionValue = (asi: ASIDescription): string =>
+        `${asi.prefix}   (${I18n.getText(
+            'atlassian.migration.datacenter.provision.aws.asi.belongsTo'
+        )}: ${asi.stackName})`;
+    return ASIs.map(asi => ({
+        label: asiToOptionValue(asi),
+        value: asiToOptionValue(asi),
+        key: asi.prefix,
+    }));
 };
 
 export const ASISelector: FunctionComponent<ASISelectorProps> = ({
     useExisting,
     handlePrefixUpdated,
-    existingASIPrefixes,
+    existingASIs,
 }) => {
     return (
         <ASISelectorContainer>
@@ -82,7 +95,7 @@ export const ASISelector: FunctionComponent<ASISelectorProps> = ({
                     className="asi-select"
                     cacheOptions
                     defaultOptions
-                    options={ASIPrefixOptionsFromList(existingASIPrefixes)}
+                    options={ASIPrefixOptionsFromList(existingASIs)}
                     data-test="asi-select"
                     onChange={(event: OptionType): void =>
                         handlePrefixUpdated(event.value.toString())
@@ -103,8 +116,8 @@ export const ASISelector: FunctionComponent<ASISelectorProps> = ({
 };
 
 export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfigurationProps> = ({
-    handleASIPrefixSet,
-    existingASIPrefixes,
+    handlePrefixUpdated,
+    existingASIs,
 }) => {
     const [useExisting, setUseExisting] = useState<boolean>(true);
 
@@ -123,14 +136,14 @@ export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfiguratio
                 options={radioValues}
                 defaultValue={radioValues[0].value}
                 onChange={(event): void => {
-                    handleASIPrefixSet('');
+                    handlePrefixUpdated('');
                     setUseExisting(event.currentTarget.value === 'existing');
                 }}
             />
             <ASISelector
                 useExisting={useExisting}
-                handlePrefixUpdated={handleASIPrefixSet}
-                existingASIPrefixes={existingASIPrefixes}
+                handlePrefixUpdated={handlePrefixUpdated}
+                existingASIs={existingASIs}
             />
         </>
     );

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
@@ -16,7 +16,7 @@
 import { RadioGroup } from '@atlaskit/radio';
 import { HelperMessage } from '@atlaskit/form';
 import SectionMessage from '@atlaskit/section-message';
-import { AsyncSelect, OptionType } from '@atlaskit/select';
+import Select, { OptionType } from '@atlaskit/select';
 import TextField from '@atlaskit/textfield';
 import React, { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
@@ -49,25 +49,27 @@ const ASISelectorContainer = styled.div`
     margin-top: 15px;
 `;
 
-const asyncASIPrefixOptions = (): Promise<Array<OptionType>> =>
-    // FIXME: example options until there is API call to list ASI's
-    Promise.resolve([
-        { label: 'ATL-', value: 'ATL-', key: 'ATL-' },
-        { label: 'BP-', value: 'BP-', key: 'BP-' },
-    ]);
-
 type ExistingASIConfigurationProps = {
     handleASIPrefixSet: (prefix: string) => void;
+    existingASIPrefixes: Array<string>;
 };
 
 type ASISelectorProps = {
     useExisting: boolean;
     handlePrefixUpdated: (prefix: string) => void;
+    existingASIPrefixes: Array<string>;
+};
+
+const ASIPrefixOptionsFromList = (prefixes: Array<string>): Array<OptionType> => {
+    if (prefixes.length === 0) return [];
+
+    return prefixes.map(prefix => ({ label: prefix, value: prefix, key: prefix }));
 };
 
 export const ASISelector: FunctionComponent<ASISelectorProps> = ({
     useExisting,
     handlePrefixUpdated,
+    existingASIPrefixes,
 }) => {
     return (
         <ASISelectorContainer>
@@ -76,11 +78,11 @@ export const ASISelector: FunctionComponent<ASISelectorProps> = ({
                 <RequiredStar>*</RequiredStar>
             </h5>
             {useExisting ? (
-                <AsyncSelect
+                <Select
                     className="asi-select"
                     cacheOptions
                     defaultOptions
-                    loadOptions={asyncASIPrefixOptions}
+                    options={ASIPrefixOptionsFromList(existingASIPrefixes)}
                     data-test="asi-select"
                     onChange={(event: OptionType): void =>
                         handlePrefixUpdated(event.value.toString())
@@ -102,6 +104,7 @@ export const ASISelector: FunctionComponent<ASISelectorProps> = ({
 
 export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfigurationProps> = ({
     handleASIPrefixSet,
+    existingASIPrefixes,
 }) => {
     const [useExisting, setUseExisting] = useState<boolean>(true);
 
@@ -124,7 +127,11 @@ export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfiguratio
                     setUseExisting(event.currentTarget.value === 'existing');
                 }}
             />
-            <ASISelector useExisting={useExisting} handlePrefixUpdated={handleASIPrefixSet} />
+            <ASISelector
+                useExisting={useExisting}
+                handlePrefixUpdated={handleASIPrefixSet}
+                existingASIPrefixes={existingASIPrefixes}
+            />
         </>
     );
 };

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -63,6 +63,7 @@ atlassian.migration.datacenter.provision.aws.asi.details=Identifier used in all 
 atlassian.migration.datacenter.provision.aws.asi.option.existing=Existing ASI
 atlassian.migration.datacenter.provision.aws.asi.option.new=New ASI
 atlassian.migration.datacenter.provision.aws.asi.prefix=ASI identifier
+atlassian.migration.datacenter.provision.aws.asi.belongsTo=belongs to stack
 
 # Quickstart provisioning page
 atlassian.migration.datacenter.provision.aws.title=Step 3 of 7: Deploy on AWS


### PR DESCRIPTION
## Summary

* Hoist ASI loading into parent ASI Configuration page
* Render stack name along with stack prefix in prefix selection drop-down
* Optimise `CfnApi#listStacks` to only list active stacks
* Wire up ASI configuration page to ASI description API endpoint
