### PR TITLE
CHET-185: Lock down migration bucket

### DIFF
--- a/templates/migration-stack/Makefile
+++ b/templates/migration-stack/Makefile
@@ -35,4 +35,6 @@ deletestack:
 	aws cloudformation delete-stack --stack-name $(STACK_NAME)
 updatestack:
 	aws cloudformation update-stack --stack-name $(STACK_NAME) --template-body file://migration-helper.yml --parameters $(PARAMS) --capabilities CAPABILITY_IAM
+uploadtemplate: rendertemplate
+	aws s3 cp --acl=public-read migration-helper.yml s3://trebuchet-public-resources/migration-helper.yml
 

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -66,13 +66,13 @@ Resources:
         QueueConfigurations:
           - Queue: !GetAtt MigrationQueue.Arn
             Event: s3:ObjectCreated:*
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
-    PublicAccessBlockConfiguration:
-      BlockPublicAcls: true
-      BlockPublicPolicy: true
-      IgnorePublicAcls: true
-      RestrictPublicBuckets: true
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy

--- a/templates/migration-stack/migration-helper.yml
+++ b/templates/migration-stack/migration-helper.yml
@@ -68,6 +68,11 @@ Resources:
             Event: s3:ObjectCreated:*
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+    PublicAccessBlockConfiguration:
+      BlockPublicAcls: true
+      BlockPublicPolicy: true
+      IgnorePublicAcls: true
+      RestrictPublicBuckets: true
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -66,13 +66,13 @@ Resources:
         QueueConfigurations:
           - Queue: !GetAtt MigrationQueue.Arn
             Event: s3:ObjectCreated:*
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
-    PublicAccessBlockConfiguration:
-      BlockPublicAcls: true
-      BlockPublicPolicy: true
-      IgnorePublicAcls: true
-      RestrictPublicBuckets: true
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -68,6 +68,11 @@ Resources:
             Event: s3:ObjectCreated:*
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+    PublicAccessBlockConfiguration:
+      BlockPublicAcls: true
+      BlockPublicPolicy: true
+      IgnorePublicAcls: true
+      RestrictPublicBuckets: true
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
Tests using a `make createstack` show that the migration buckets are now created with the correct public access settings:

![image](https://user-images.githubusercontent.com/409063/83218947-6e008580-a1b2-11ea-9a8d-b70b64a4ca8a.png)
