### PR TITLE
CHET-424: script parameters generation using python

### DIFF
--- a/templates/utils/cfn_parameters/README.md
+++ b/templates/utils/cfn_parameters/README.md
@@ -1,0 +1,20 @@
+### What
+
+Generate a parameters file that is used to render the quickstart form in the migration assistant plugin UI.
+
+### How
+
+Run the python file to print the parameters file.
+
+```bash
+python parameters_gen.py --template /path/to/quickstart-jira-dc.template.yaml > quickstart-jira-dc.template.parameters.yaml 
+
+```
+
+### What's next? 
+
+Upload the file to the S3 bucket. Don't forget to allow `cors` on the object
+
+### Improvements
+
+Script the S3 upload process using `make`

--- a/templates/utils/cfn_parameters/parameters_gen.py
+++ b/templates/utils/cfn_parameters/parameters_gen.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+import argparse
+from cfn_tools import load_yaml, dump_yaml
+
+
+class Parameters:
+    def __init__(self, groups, labels, parameters):
+        self.ParameterGroups = groups
+        self.ParameterLabels = labels
+        self.Parameters = parameters
+
+
+class ParametersGen:
+    def generate(self, template_path):
+        with open(template_path, 'r') as template:
+            cfn_yaml = load_yaml(template.read())
+
+            parameter_groups = cfn_yaml['Metadata']['AWS::CloudFormation::Interface']['ParameterGroups']
+            parameter_labels = cfn_yaml['Metadata']['AWS::CloudFormation::Interface']['ParameterLabels']
+            parameters = cfn_yaml['Parameters']
+
+            # print(dump_yaml(Parameters(parameter_groups, parameter_labels, parameters)))
+            print(dump_yaml({
+                "ParameterGroups": parameter_groups,
+                "ParameterLabels": parameter_labels,
+                "Parameters": parameters
+            }))
+
+
+def main(template_path):
+    ParametersGen().generate(template_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='default parser')
+    parser.add_argument('--template', metavar='path', required=True,
+                        help='path to template')
+    args = parser.parse_args()
+
+    main(template_path=args.template)

--- a/templates/utils/cfn_parameters/parameters_gen.py
+++ b/templates/utils/cfn_parameters/parameters_gen.py
@@ -4,14 +4,10 @@ import argparse
 from cfn_tools import load_yaml, dump_yaml
 
 
-class Parameters:
-    def __init__(self, groups, labels, parameters):
-        self.ParameterGroups = groups
-        self.ParameterLabels = labels
-        self.Parameters = parameters
-
-
 class ParametersGen:
+    def __init__(self):
+        pass
+
     def generate(self, template_path):
         with open(template_path, 'r') as template:
             cfn_yaml = load_yaml(template.read())
@@ -20,7 +16,6 @@ class ParametersGen:
             parameter_labels = cfn_yaml['Metadata']['AWS::CloudFormation::Interface']['ParameterLabels']
             parameters = cfn_yaml['Parameters']
 
-            # print(dump_yaml(Parameters(parameter_groups, parameter_labels, parameters)))
             print(dump_yaml({
                 "ParameterGroups": parameter_groups,
                 "ParameterLabels": parameter_labels,

--- a/templates/utils/cfn_parameters/requirements.txt
+++ b/templates/utils/cfn_parameters/requirements.txt
@@ -1,0 +1,2 @@
+cfn-flip==1.2.3
+cfn-tools==0.1.6


### PR DESCRIPTION
Write a parameters YAML string to stdout with contents - 

```
ParameterGroups:
  - Label:
      default: Jira setup
    Parameters:
      - JiraProduct
      - JiraVersion
  - Label:
      default: Cluster nodes
    Parameters:
      - CloudWatchIntegration
      - ClusterNodeInstanceType
      - ClusterNodeMax
      - ClusterNodeMin
      - ClusterNodeVolumeSize
      - DeploymentAutomationRepository
      - DeploymentAutomationBranch
      - DeploymentAutomationPlaybook
      - DeploymentAutomationCustomParams
      - DeploymentAutomationKeyName
  - Label:
      default: Database
    Parameters:
      - DBEngine
      - DBInstanceClass
      - DBIops
      - DBMasterUserPassword
      - DBMultiAZ
      - DBPassword
      - DBStorage
      - DBStorageEncrypted
      - DBStorageType
  - Label:
      default: Networking
    Parameters:
      - InternetFacingLoadBalancer
      - CidrBlock
      - KeyPairName
      - SSLCertificateARN
  - Label:
      default: DNS (Optional)
    Parameters:
      - CustomDnsName
      - HostedZone
  - Label:
      default: Application Tuning (Optional)
    Parameters:
      - TomcatContextPath
      - CatalinaOpts
      - JvmHeapOverride
      - DBPoolMaxSize
      - DBPoolMinSize
      - DBMaxIdle
      - DBMaxWaitMillis
      - DBMinEvictableIdleTimeMillis
      - DBMinIdle
      - DBRemoveAbandoned
      - DBRemoveAbandonedTimeout
      - DBTestOnBorrow
      - DBTestWhileIdle
      - DBTimeBetweenEvictionRunsMillis
      - MailEnabled
      - TomcatAcceptCount
      - TomcatConnectionTimeout
      - TomcatDefaultConnectorPort
      - TomcatEnableLookups
      - TomcatMaxThreads
      - TomcatMinSpareThreads
      - TomcatProtocol
      - TomcatRedirectPort
  - Label:
      default: AWS Quick Start Configuration
    Parameters:
      - QSS3BucketName
      - QSS3KeyPrefix
      - ExportPrefix
ParameterLabels:
  CatalinaOpts:
    default: Catalina options
  CidrBlock:
    default: Permitted IP range
  CloudWatchIntegration:
    default: Enable CloudWatch integration
  ClusterNodeMax:
    default: Maximum number of cluster nodes
  ClusterNodeMin:
    default: Minimum number of cluster nodes
  ClusterNodeInstanceType:
    default: Cluster node instance type
  ClusterNodeVolumeSize:
    default: Cluster node instance volume size
  CustomDnsName:
    default: Existing DNS name
  DBEngine:
    default: The database engine to deploy with
  DBInstanceClass:
    default: Database instance class
  DBIops:
    default: RDS Provisioned IOPS
  DBMasterUserPassword:
    default: Master (admin) password *
  DBMaxIdle:
    default: DB Maximum Idle
  DBMaxWaitMillis:
    default: DB Maximum Wait
  DBMinEvictableIdleTimeMillis:
    default: DB Minimum Evictable Idle Time
  DBMinIdle:
    default: DB Minimum Idle Connections
  DBMultiAZ:
    default: Enable RDS Multi-AZ deployment
  DBPassword:
    default: Application user database password *
  DBPoolMaxSize:
    default: DB Pool Maximum Size
  DBPoolMinSize:
    default: DB Pool Minimum Size
  DBRemoveAbandoned:
    default: DB Remove Abandoned?
  DBRemoveAbandonedTimeout:
    default: DB Remove Abandoned Timeout
  DBStorage:
    default: Database storage
  DBStorageEncrypted:
    default: Database encryption
  DBStorageType:
    default: Database storage type
  DBTestOnBorrow:
    default: DB Test On Borrow?
  DBTestWhileIdle:
    default: DB Test While Idle?
  DBTimeBetweenEvictionRunsMillis:
    default: DB Time Between Eviction Runs
  DeploymentAutomationRepository:
    default: Deployment Automation Git Repository URL
  DeploymentAutomationBranch:
    default: Deployment Automation Branch
  DeploymentAutomationPlaybook:
    default: The Ansible playbook to invoke to initialize the instance
  DeploymentAutomationKeyName:
    default: SSH keyname to use with the repository
  DeploymentAutomationCustomParams:
    default: Custom command-line parameters for Ansible
  ExportPrefix:
    default: ASI identifier
  HostedZone:
    default: Route 53 Hosted Zone
  InternetFacingLoadBalancer:
    default: Make instance internet facing
  JiraProduct:
    default: Jira Product *
  JiraVersion:
    default: Version *
  JvmHeapOverride:
    default: JVM Heap Size Override
  KeyPairName:
    default: SSH Key Pair Name
  MailEnabled:
    default: Enable App to Process Email
  SSLCertificateARN:
    default: SSL Certificate ARN
  TomcatAcceptCount:
    default: Tomcat Accept Count
  TomcatConnectionTimeout:
    default: Tomcat Connection Timeout
  TomcatContextPath:
    default: Tomcat Context Path
  TomcatDefaultConnectorPort:
    default: Tomcat Default Connector Port
  TomcatEnableLookups:
    default: Tomcat Enable DNS Lookups
  TomcatMaxThreads:
    default: Tomcat Maximum Threads
  TomcatMinSpareThreads:
    default: Tomcat Minimum Spare Threads
  TomcatProtocol:
    default: Tomcat Protocol
  TomcatRedirectPort:
    default: Tomcat Redirect Port
  QSS3BucketName:
    default: Quick Start S3 Bucket Name
  QSS3KeyPrefix:
    default: Quick Start S3 Key Prefix
Parameters:
  CatalinaOpts:
    Default: ''
    Description: Pass in any additional jvm options to tune Catalina
    Type: String
  CidrBlock:
    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
    ConstraintDescription: Must be a valid IP CIDR range of the form x.x.x.x/x.
    Description: CIDR Block allowed to access the Atlassian product. This should be
      set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
    Type: String
    MinLength: 9
    MaxLength: 18
  CloudWatchIntegration:
    Default: Metrics and Logs
    Type: String
    Description: Enables CloudWatch metrics with or without log gathering. If cost
      is an issue, you can disable this altogether.
    AllowedValues:
      - 'Off'
      - Metrics Only
      - Metrics and Logs
    ConstraintDescription: Must be 'Off', 'Metrics Only', or 'Metrics and Logs'
  ClusterNodeInstanceType:
    Default: c5.xlarge
    AllowedValues:
      - c4.large
      - c4.xlarge
      - c4.2xlarge
      - c4.4xlarge
      - c4.8xlarge
      - c5.large
      - c5.xlarge
      - c5.2xlarge
      - c5.4xlarge
      - c5.9xlarge
      - c5.18xlarge
      - c5d.large
      - c5d.xlarge
      - c5d.2xlarge
      - c5d.4xlarge
      - c5d.9xlarge
      - c5d.18xlarge
      - d2.xlarge
      - d2.2xlarge
      - d2.4xlarge
      - d2.8xlarge
      - h1.2xlarge
      - h1.4xlarge
      - h1.8xlarge
      - h1.16xlarge
      - i3.large
      - i3.xlarge
      - i3.2xlarge
      - i3.4xlarge
      - i3.8xlarge
      - i3.16xlarge
      - i3.metal
      - m4.large
      - m4.xlarge
      - m4.2xlarge
      - m4.4xlarge
      - m4.10xlarge
      - m4.16xlarge
      - m5.large
      - m5.xlarge
      - m5.2xlarge
      - m5.4xlarge
      - m5.12xlarge
      - m5.24xlarge
      - m5d.large
      - m5d.xlarge
      - m5d.2xlarge
      - m5d.4xlarge
      - m5d.12xlarge
      - m5d.24xlarge
      - r4.large
      - r4.xlarge
      - r4.2xlarge
      - r4.4xlarge
      - r4.8xlarge
      - r4.16xlarge
      - r5.large
      - r5.xlarge
      - r5.2xlarge
      - r5.4xlarge
      - r5.12xlarge
      - r5.24xlarge
      - r5d.large
      - r5d.xlarge
      - r5d.2xlarge
      - r5d.4xlarge
      - r5d.12xlarge
      - r5d.24xlarge
      - t2.medium
      - t2.large
      - t2.xlarge
      - t2.2xlarge
      - t3.medium
      - t3.large
      - t3.xlarge
      - t3.2xlarge
      - x1.16xlarge
      - x1.32xlarge
      - x1e.xlarge
      - x1e.2xlarge
      - x1e.4xlarge
      - x1e.8xlarge
      - x1e.16xlarge
      - x1e.32xlarge
      - z1d.large
      - z1d.xlarge
      - z1d.2xlarge
      - z1d.3xlarge
      - z1d.6xlarge
      - z1d.12xlarge
    ConstraintDescription: Must be an EC2 instance type from the selection list
    Description: Instance type for the cluster application nodes.
    Type: String
  ClusterNodeMax:
    Description: Maximum number of nodes in the cluster.
    Default: 1
    Type: Number
  ClusterNodeMin:
    Default: 1
    Description: Set to 1 for new deployment. Can be updated post launch.
    Type: Number
  ClusterNodeVolumeSize:
    Default: 50
    Description: Size of cluster node root volume in Gb (note - size based upon Application
      indexes x 4)
    Type: Number
  CustomDnsName:
    Default: ''
    Description: 'Use custom existing DNS name for your Data Center instance. This
      will take precedence over HostedZone. Please note: you must own the domain and
      configure it to point at the load balancer.'
    Type: String
  DBEngine:
    Default: PostgreSQL
    Description: Database Engine to use for the application. PostgreSQL or Amazon
      Aurora PostgreSQL
    AllowedValues:
      - PostgreSQL
      - Amazon Aurora PostgreSQL
    ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
    Type: String
  DBInstanceClass:
    Default: db.m5.large
    AllowedValues:
      - db.m5.large
      - db.m5.xlarge
      - db.m5.2xlarge
      - db.m5.4xlarge
      - db.m5.12xlarge
      - db.m5.24xlarge
      - db.r5.large
      - db.r5.xlarge
      - db.r5.2xlarge
      - db.r5.4xlarge
      - db.r5.12xlarge
      - db.r5.24xlarge
      - db.r4.large
      - db.r4.xlarge
      - db.r4.2xlarge
      - db.r4.4xlarge
      - db.r4.8xlarge
      - db.r4.16xlarge
      - db.m4.large
      - db.m4.xlarge
      - db.m4.2xlarge
      - db.m4.4xlarge
      - db.m4.10xlarge
      - db.m4.16xlarge
      - db.t3.medium
      - db.t3.large
      - db.t3.xlarge
      - db.t3.2xlarge
      - db.t2.medium
      - db.t2.large
      - db.t2.xlarge
      - db.t2.2xlarge
    ConstraintDescription: Must be a valid RDS instance class, from the selection
      list
    Description: RDS instance type (must be r family if using Aurora).
    Type: String
  DBIops:
    Default: 1000
    ConstraintDescription: Must be in the range 1000 - 30000
    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This
      value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage
      must be between 3.00 and 10.00 (not used for Aurora).'
    MaxValue: 30000
    MinValue: 1000
    Type: Number
  DBMasterUserPassword:
    AllowedPattern: ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase,
      1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] -
      _ + % &'
    Description: 'Password for the master (''postgres'') account. Must be at least
      8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following
      symbols: ! # $ { * : [ = , ] - _ + % &'
    NoEcho: true
    MaxLength: 128
    MinLength: 8
    Type: String
  DBMaxIdle:
    Default: 20
    Description: The maximum number of database connections that are allowed to remain
      idle in the pool
    Type: Number
  DBMaxWaitMillis:
    Default: 10000
    Description: The length of time (in milliseconds) that Jira is allowed to wait
      for a database connection to become available (while there are no free ones
      available in the pool), before returning an error
    Type: Number
  DBMinEvictableIdleTimeMillis:
    Default: 180000
    Description: The minimum amount of time an object may sit idle in the database
      connection pool before it is eligible for eviction by the idle object eviction
    Type: Number
  DBMinIdle:
    Default: 10
    Description: The minimum number of idle database connections that are kept open
      at any time
    Type: Number
  DBMultiAZ:
    Description: Whether to provision a multi-AZ RDS instance.
    Default: 'true'
    AllowedValues:
      - 'true'
      - 'false'
    ConstraintDescription: Must be 'true' or 'false'.
    Type: String
  DBPassword:
    AllowedPattern: (?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase,
      1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] -
      _ @ + % &'
    Description: 'Database password used by Jira. Must be at least 8 characters and
      include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols:
      ! # $ { * : [ = , ] - _ @ + % &'
    MinLength: 8
    MaxLength: 128
    NoEcho: true
    Type: String
  DBPoolMaxSize:
    Default: 20
    Description: The maximum number of database connections that can be opened at
      any time
    Type: Number
  DBPoolMinSize:
    Default: 20
    Description: The minimum number of idle database connections that are kept open
      at any time
    Type: Number
  DBRemoveAbandoned:
    Default: 'true'
    AllowedValues:
      - 'true'
      - 'false'
    Description: Flag to remove abandoned database connections if they exceed the
      Removed Abandoned Timeout
    Type: String
  DBRemoveAbandonedTimeout:
    Default: 60
    Description: The length of time (in seconds) that a database connection can be
      idle before it is considered abandoned
    Type: Number
  DBStorage:
    Default: 200
    Description: Database allocated storage size, in gigabytes (GB). If you choose
      Provisioned IOPS, storage should be between 100 and 6144 (not used for Aurora).
    Type: Number
  DBStorageEncrypted:
    Default: 'false'
    AllowedValues:
      - 'true'
      - 'false'
    Description: Whether or not to encrypt the database
    Type: String
  DBStorageType:
    Default: General Purpose (SSD)
    AllowedValues:
      - General Purpose (SSD)
      - Provisioned IOPS
    ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
    Description: Database storage type (not used for Aurora).
    Type: String
  DBTestOnBorrow:
    Default: 'false'
    AllowedValues:
      - 'true'
      - 'false'
    Description: Tests if the database connection is valid when it is borrowed from
      the database connection pool by Jira
    Type: String
  DBTestWhileIdle:
    Default: 'true'
    AllowedValues:
      - 'true'
      - 'false'
    Description: Periodically tests if the database connection is valid when it is
      idle
    Type: String
  DBTimeBetweenEvictionRunsMillis:
    Default: 60000
    Description: The number of milliseconds to sleep between runs of the idle object
      eviction thread. When non-positive, no idle object eviction thread will be run
    Type: Number
  DeploymentAutomationRepository:
    Default: https://bitbucket.org/atlassian/dc-deployments-automation.git
    Type: String
    Description: The deployment automation repository to use for per-node initialization.
      Leave this as default unless you have customizations.
  DeploymentAutomationBranch:
    Default: master
    Type: String
    Description: The deployment automation repository branch to pull from.
  DeploymentAutomationPlaybook:
    Default: aws_jira_dc_node.yml
    Type: String
    Description: The Ansible playbook to invoke to initialize the Jira node on first
      start.
  DeploymentAutomationCustomParams:
    Default: ''
    Type: String
    Description: Additional command-line options for the `ansible-playbook` command.
      See https://bitbucket.org/atlassian/dc-deployments-automation/src/master/README.md
      for more information about overriding parameters. (Optional)
  DeploymentAutomationKeyName:
    Default: ''
    Type: String
    Description: Named Key Pair name to use with this repository. The key should be
      imported into the SSM parameter store. (Optional)
  ExportPrefix:
    Default: ATL-
    Description: Each Atlassian Standard Infrastructure (ASI) uses a unique identifier.
      If you have multiple ASIs within the same AWS region, use this field to specify
      where to deploy Jira.
    Type: String
  HostedZone:
    Default: ''
    ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
    Description: The domain name of the Route53 PRIVATE Hosted Zone in which to create
      cnames
    Type: String
  InternetFacingLoadBalancer:
    Default: 'true'
    AllowedValues:
      - 'true'
      - 'false'
    ConstraintDescription: Must be 'true' or 'false'.
    Description: Controls whether the load balancer should be visible to the internet
      (true) or only within the VPC (false).
    Type: String
  JiraProduct:
    Default: Software
    Description: The Jira product to install.
    Type: String
    ConstraintDescription: Must be "Core", "Software", or "ServiceDesk"
    AllowedValues:
      - Core
      - Software
      - ServiceDesk
  JiraVersion:
    Default: 8.5.3
    AllowedPattern: (\d+\.\d+\.\d+(-?.*))|(latest)
    ConstraintDescription: Must be a valid version number or 'latest'; for example,
      8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
    Description: The version of Jira Software or Jira Service Desk to install. Find
      valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software),
      https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO
      (Atlassian Enterprise Releases).
    Type: String
  JvmHeapOverride:
    Default: ''
    Description: Override the default amount of memory to allocate to the JVM for
      your instance type - set size in meg or gig e.g. 1024m or 1g
    Type: String
  KeyPairName:
    ConstraintDescription: Must be the name of an existing EC2 Key Pair.
    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't
      provide one, the Atlassian Standard Infrastructure stack's key pair will be
      used.
    Type: String
    Default: ''
  MailEnabled:
    AllowedValues:
      - 'true'
      - 'false'
    ConstraintDescription: Must be 'true' or 'false'.
    Default: 'true'
    Description: Enable mail processing and sending
    Type: String
  SSLCertificateARN:
    Default: ''
    Description: Amazon Resource Name (ARN) of your SSL certificate. Supplying this
      will automatically enable HTTPS on the product and load balancer, configured
      to use the corresponding certificate. If you want to use your own certificate
      that you generated outside of Amazon, you need to first import it to AWS Certificate
      Manager. After a successful import, you'll receive the ARN. If you want to create
      a certificate with AWS Certificate Manager (ACM certificate), you will receive
      the ARN after it's successfully created.
    MinLength: 0
    MaxLength: 90
    Type: String
  TomcatAcceptCount:
    Default: 10
    Description: The maximum queue length for incoming connection requests when all
      possible request processing threads are in use
    Type: Number
  TomcatConnectionTimeout:
    Default: 20000
    Description: The number of milliseconds this Connector will wait, after accepting
      a connection, for the request URI line to be presented
    Type: Number
  TomcatContextPath:
    Default: ''
    AllowedPattern: ^(\/[A-z_\-0-9\.]+)?$
    Description: The context path of this web application, which is matched against
      the beginning of each request URI to select the appropriate web application
      for processing. If used, must include leading "/"
    Type: String
  TomcatDefaultConnectorPort:
    Default: 8080
    Description: The port on which to serve the application
    Type: Number
  TomcatEnableLookups:
    Default: 'false'
    AllowedValues:
      - 'true'
      - 'false'
    Description: Set to true if you want calls to request.getRemoteHost() to perform
      DNS lookups in order to return the actual host name of the remote client
    Type: String
  TomcatMaxThreads:
    Default: 200
    Description: The maximum number of request processing threads to be created by
      this Connector, which therefore determines the maximum number of simultaneous
      requests that can be handled
    Type: Number
  TomcatMinSpareThreads:
    Default: 10
    Description: The minimum number of threads always kept running
    Type: Number
  TomcatProtocol:
    Default: HTTP/1.1
    Description: Sets the protocol to handle incoming traffic
    Type: String
  TomcatRedirectPort:
    Default: 8443
    Description: The port number for Catalina to use when automatically redirecting
      a non-SSL connector actioning a redirect to a SSL URI
    Type: Number
  QSS3BucketName:
    Default: aws-quickstart
    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
      (-).
    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name
      can include numbers, lowercase letters, uppercase letters, and hyphens (-).
      It cannot start or end with a hyphen (-).
    Type: String
  QSS3KeyPrefix:
    Default: quickstart-atlassian-jira/
    AllowedPattern: ^[0-9a-zA-Z-/]*$
    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
      uppercase letters, hyphens (-), and forward slash (/).
    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
      forward slash (/).
    Type: String
```