### PR TITLE
CHET-420: Update warning page text

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -79,6 +79,7 @@ const props: MigrationTransferProps = {
     heading: I18n.getText('atlassian.migration.datacenter.db.title'),
     description: I18n.getText('atlassian.migration.datacenter.db.description'),
     nextText: I18n.getText('atlassian.migration.datacenter.fs.nextStep'),
+    startButtonText: I18n.getText('atlassian.migration.datacenter.db.startButton'),
     startMigrationPhase: startDbMigration,
     inProgressStages: dbMigrationInProgressStages,
     getProgress: getProgressFromStatus,

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -50,7 +50,7 @@ export type MigrationTransferProps = {
      */
     nextRoute: string;
     /**
-     * @see MigrationProgressProps
+     * @see MigrationTransferActionsProps
      */
     startButtonText?: string;
     /**

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -52,6 +52,10 @@ export type MigrationTransferProps = {
     /**
      * @see MigrationProgressProps
      */
+    startButtonText?: string;
+    /**
+     * @see MigrationProgressProps
+     */
     startMoment?: moment.Moment;
     /**
      * The MigrationStages where this transfer is "in progress"
@@ -100,6 +104,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
     heading,
     nextText,
     nextRoute,
+    startButtonText,
     startMoment,
     getProgress,
     inProgressStages,
@@ -235,6 +240,7 @@ export const MigrationTransferPage: FunctionComponent<MigrationTransferProps> = 
                         <MigrationTransferActions
                             finished={finished}
                             nextText={nextText}
+                            startButtonText={startButtonText}
                             nextRoute={nextRoute}
                             startMigrationPhase={startMigration}
                             onRefresh={updateProgress}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPageActions.tsx
@@ -33,6 +33,10 @@ export type MigrationTransferActionsProps = {
      */
     nextText: string;
     /**
+     * The text to display on the start button that initiates the migration transfer. Defaults to `Start`
+     */
+    startButtonText?: string;
+    /**
      * The path to take the user to whent hey click the "next" action button
      */
     nextRoute: string;
@@ -62,6 +66,7 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
     finished,
     nextText,
     nextRoute,
+    startButtonText,
     startMigrationPhase,
     onRefresh: updateTransferProgress,
     started,
@@ -83,7 +88,7 @@ export const MigrationTransferActions: FunctionComponent<MigrationTransferAction
             appearance="primary"
             onClick={startMigrationPhase}
         >
-            Start
+            {startButtonText ?? 'Start'}
         </Button>
     );
 

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -106,8 +106,10 @@ atlassian.migration.datacenter.warning.section.list.dnsRedirection=Redirect the 
 atlassian.migration.datacenter.warning.capturedFiles.description=We noticed these files were added while copying your content, you may want to copy them to your instance yourself
 
 # Database sync page
-atlassian.migration.datacenter.db.title=Step 6 of 8: Sync database
-atlassian.migration.datacenter.db.description=Now that you've blocked user access to the instance, we can now sync its database with your new AWS deployment. You can close this page and return anytime to check its progress.
+atlassian.migration.datacenter.db.title=Step 6 of 8: Final Sync
+atlassian.migration.datacenter.db.description=Now that you've blocked user access to the instance, we can copy its database and sync any new content changes. \
+  You can close this page and return anytime to check its progress.
+atlassian.migration.datacenter.db.startButton=Sync now!
 atlassian.migration.datacenter.db.status.not_started=Not started
 atlassian.migration.datacenter.db.status.failed=Failed
 atlassian.migration.datacenter.db.status.exporting=Exporting

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -46,7 +46,7 @@ atlassian.migration.datacenter.home.continue.button=Continue
 atlassian.migration.datacenter.overview.title=Migration Overview
 
 # Authentication page
-atlassian.migration.datacenter.step.authenticate.title=Step 1 of 7: Connect to AWS
+atlassian.migration.datacenter.step.authenticate.title=Step 1 of 8: Connect to AWS
 atlassian.migration.datacenter.authenticate.aws.description=Enter your AWS Access Keys below. This will allow us to deploy and migrate under your AWS account. Generate these Access Keys from the AWS Console.
 atlassian.migration.datacenter.authenticate.aws.accessKeyId.label=AWS access key ID
 atlassian.migration.datacenter.authenticate.aws.secretAccessKey.label=AWS secret access key
@@ -55,7 +55,7 @@ atlassian.migration.datacenter.authenticate.aws.region.error=You must choose a r
 atlassian.migration.datacenter.authenticate.aws.submit=Connect
 
 # Quickstart ASI selection
-atlassian.migration.datacenter.provision.aws.asi.title=Step 2 of 7: Configure ASI
+atlassian.migration.datacenter.provision.aws.asi.title=Step 2 of 8: Configure ASI
 atlassian.migration.datacenter.provision.aws.asi.description=The Atlassian Standard Infrastructure (ASI) is a virtual private cloud specifically customized to host Atlassian Data Center products.
 atlassian.migration.datacenter.provision.aws.asi.found=We found an existing ASI in your region. You can deploy to this ASI, or create a new one
 atlassian.migration.datacenter.provision.aws.asi.chooseDeploymentMethod.label=Deploy to
@@ -66,7 +66,7 @@ atlassian.migration.datacenter.provision.aws.asi.prefix=ASI identifier
 atlassian.migration.datacenter.provision.aws.asi.belongsTo=belongs to stack
 
 # Quickstart provisioning page
-atlassian.migration.datacenter.provision.aws.title=Step 3 of 7: Deploy on AWS
+atlassian.migration.datacenter.provision.aws.title=Step 3 of 8: Deploy on AWS
 atlassian.migration.datacenter.provision.aws.description=Configure and deploy new, cluster-ready infrastructure on AWS
 atlassian.migration.datacenter.provision.aws.form.stackName.helper=Stack name can include letters (A-Z and a-z), numbers (0-9), and dashes (-)
 atlassian.migration.datacenter.provision.aws.form.deploy=Deploy
@@ -82,7 +82,7 @@ atlassian.migration.datacenter.provision.aws.status.badServer=Bad response from 
 atlassian.migration.datacenter.provision.aws.status.error=Provisioning error
 
 # Copy Content page
-atlassian.migration.datacenter.fs.title=Step 4 of 7: Copy Content
+atlassian.migration.datacenter.fs.title=Step 4 of 8: Copy Content
 atlassian.migration.datacenter.fs.description=Copy your instance's content to the AWS infrastructure you just deployed. This might take several hours (no downtime), depending on how much content you have. You can close this page and return anytime to check its progress. Meanwhile, we recommend you start preparing for the next phase which will involve blocking user access to your instance.
 atlassian.migration.datacenter.fs.startCopy=Start copying
 atlassian.migration.datacenter.fs.nextStep=Next
@@ -97,15 +97,16 @@ atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 1
 atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and restart the migration.
 
 # Warning page
-atlassian.migration.datacenter.warning.title=Step 5 of 7: Redirect users
-atlassian.migration.datacenter.warning.description=Take your Jira instance offline to prevent users from accessing it. This will allow us to sync your database properly. User access during this phase could prevent some data from being copied.
-atlassian.migration.datacenter.warning.section.header=To take your Jira instance offline:
+atlassian.migration.datacenter.warning.title=Step 5 of 8: Block user access
+atlassian.migration.datacenter.warning.description=We're about to copy your database and sync all remaining content. That means you'll need to prevent users from accessing your current instance. \
+  User access during the next phase could prevent us from migrating all your data.
+atlassian.migration.datacenter.warning.section.header=To block user access:
 atlassian.migration.datacenter.warning.section.list.loggedOutUsers=Make sure that users are logged out
 atlassian.migration.datacenter.warning.section.list.dnsRedirection=Redirect the DNS to a maintenance page
 atlassian.migration.datacenter.warning.capturedFiles.description=We noticed these files were added while copying your content, you may want to copy them to your instance yourself
 
 # Database sync page
-atlassian.migration.datacenter.db.title=Step 6 of 7: Sync database
+atlassian.migration.datacenter.db.title=Step 6 of 8: Sync database
 atlassian.migration.datacenter.db.description=Now that you've blocked user access to the instance, we can now sync its database with your new AWS deployment. You can close this page and return anytime to check its progress.
 atlassian.migration.datacenter.db.status.not_started=Not started
 atlassian.migration.datacenter.db.status.failed=Failed
@@ -120,7 +121,7 @@ atlassian.migration.datacenter.db.error.s3link=View the errors in S3
 
 
 # Validation page
-atlassian.migration.datacenter.step.validation.phrase=Step 7 of 7: Validation
+atlassian.migration.datacenter.step.validation.phrase=Step 7 of 8: Validation
 atlassian.migration.datacenter.step.validation.redirect.home=Click here to visit the migration home page
 atlassian.migration.datacenter.step.validation.incorrect.stage.error.title=You have reached this page out of a pre-defined order of migration steps
 atlassian.migration.datacenter.step.validation.incorrect.stage.error.description=You may have arrived at this page by clicking on a direct link. \


### PR DESCRIPTION
1. Changes step numbers to include the 8th step
2. Changes db sync to final sync
3. Updates start button text for db sync only (`Sync Now`, `Start` for the rest of the migration transfer stages) using the `nullish` operator


<img width="951" alt="Screenshot 2020-05-29 at 13 57 59" src="https://user-images.githubusercontent.com/1063972/83221131-56c49680-a1b8-11ea-895c-b75796fe3f45.png">

<img width="843" alt="Screenshot 2020-05-29 at 14 23 50" src="https://user-images.githubusercontent.com/1063972/83221140-5af0b400-a1b8-11ea-8671-9be810df83d2.png">

Start button text now reads as Sync now

<img width="829" alt="Screenshot 2020-05-29 at 14 23 56" src="https://user-images.githubusercontent.com/1063972/83221142-5c21e100-a1b8-11ea-9ec2-9ffd6d996c9d.png">
