### PR TITLE
CHET 434: change quickstart form based on deployment option

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.test.tsx
@@ -82,16 +82,16 @@ window.fetch = mockFetch;
 
 describe('Quick Start Provisioning Screen', () => {
     it('Should render', async () => {
-        await act(async () => {
-            const { getByText } = render(<QuickStartDeploy />);
+        act(async () => {
+            const { getByText } = render(<QuickStartDeploy deploymentMode="with-vpc" />);
 
             const formHeader = await waitForElement(() => getByText(FORM_HEADER_KEY));
             expect(formHeader).toBeTruthy();
         });
     });
     it('Should separate quickstart paramaters into their groups', async () => {
-        await act(async () => {
-            const { getByText } = render(<QuickStartDeploy />);
+        act(async () => {
+            const { getByText } = render(<QuickStartDeploy deploymentMode="with-vpc" />);
 
             const firstGroup = await waitForElement(() => getByText(FIRST_PARAM_GROUP_NAME));
             expect(firstGroup).toBeTruthy();
@@ -109,8 +109,10 @@ describe('Quick Start Provisioning Screen', () => {
         });
     });
     it('Should enforce validation on string parameters with constraints', async () => {
-        await act(async () => {
-            const { getByLabelText, getByText } = render(<QuickStartDeploy />);
+        act(async () => {
+            const { getByLabelText, getByText } = render(
+                <QuickStartDeploy deploymentMode="with-vpc" />
+            );
 
             const validationTestParameter = await waitForElement(() =>
                 getByLabelText(VALIDATION_TEST_PARAMETER_LABEL)
@@ -126,8 +128,10 @@ describe('Quick Start Provisioning Screen', () => {
         });
     });
     it('Should enforce validation on number parameters with constraints', async () => {
-        await act(async () => {
-            const { getByLabelText, getByText } = render(<QuickStartDeploy />);
+        act(async () => {
+            const { getByLabelText, getByText } = render(
+                <QuickStartDeploy deploymentMode="with-vpc" />
+            );
 
             const validationNumberTestParameter = await waitForElement(() =>
                 getByLabelText(VALIDATION_NUMBER_TEST_PARAMETER_LABEL)

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -214,14 +214,34 @@ const QuickStartDeployContainer = styled.div`
     justify-items: center;
 `;
 
-const DEFAULT_QUICKSTART_PARAMETER_URL =
+const DEFAULT_QUICKSTART_WITH_VPC_PARAMETER_URL =
     'https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc-with-vpc.template.parameters.yaml';
 
-const quickstartParametersTemplateLocation = () => {
-    const parametersUrlFromEnv = process.env.REACT_APP_QUICKSTART_PARAMETERS_URL;
+const quickstartWithVPCParametersTemplateLocation = (): string => {
+    const parametersUrlFromEnv = process.env.REACT_APP_QUICKSTART_WITH_VPC_PARAMETER_URL;
     return parametersUrlFromEnv === undefined
-        ? DEFAULT_QUICKSTART_PARAMETER_URL
+        ? DEFAULT_QUICKSTART_WITH_VPC_PARAMETER_URL
         : parametersUrlFromEnv;
+};
+
+const DEFAULT_QUICKSTART_STANDALONE_PARAMETER_URL =
+    'https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc.template.parameters.yaml';
+
+const quickstartStandaloneParametersTemplateLocation = (): string => {
+    const parametersUrlFromEnv = process.env.REACT_APP_QUICKSTART_STANDALONE_PARAMETER_URL;
+    return parametersUrlFromEnv === undefined
+        ? DEFAULT_QUICKSTART_STANDALONE_PARAMETER_URL
+        : parametersUrlFromEnv;
+};
+
+const templateForDeploymentMode = (mode: DeploymentMode): string => {
+    switch (mode) {
+        case 'standalone':
+            return quickstartStandaloneParametersTemplateLocation();
+        case 'with-vpc':
+        default:
+            return quickstartWithVPCParametersTemplateLocation();
+    }
 };
 
 type QuickStartDeployProps = {
@@ -231,6 +251,7 @@ type QuickStartDeployProps = {
 
 export const QuickStartDeploy: FunctionComponent<QuickStartDeployProps> = ({
     ASIPrefix,
+    deploymentMode,
 }): ReactElement => {
     const [params, setParams] = useState<Array<QuickstartParameterGroup>>([]);
     const [loading, setLoading] = useState<boolean>(false);
@@ -238,7 +259,7 @@ export const QuickStartDeploy: FunctionComponent<QuickStartDeployProps> = ({
 
     useEffect(() => {
         setLoading(true);
-        fetch(quickstartParametersTemplateLocation(), {
+        fetch(templateForDeploymentMode(deploymentMode), {
             method: 'GET',
         })
             .then(resp => resp.text())

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -37,6 +37,7 @@ import {
 import { callAppRest, RestApiPathConstants } from '../../../utils/api';
 import { quickstartStatusPath } from '../../../utils/RoutePaths';
 import { CancelButton } from '../../shared/CancelButton';
+import { DeploymentMode } from './QuickstartRoutes';
 
 const STACK_NAME_FIELD_NAME = 'stackName';
 
@@ -225,6 +226,7 @@ const quickstartParametersTemplateLocation = () => {
 
 type QuickStartDeployProps = {
     ASIPrefix?: string;
+    deploymentMode: DeploymentMode;
 };
 
 export const QuickStartDeploy: FunctionComponent<QuickStartDeployProps> = ({

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickstartRoutes.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickstartRoutes.tsx
@@ -20,16 +20,25 @@ import { asiConfigurationPath, quickstartPath } from '../../../utils/RoutePaths'
 import { ASIConfiguration } from './asi/ASIConfiguration';
 import { QuickStartDeploy } from './QuickStartDeploy';
 
+export type DeploymentMode = 'with-vpc' | 'standalone';
+
 export const QuickstartRoutes: FunctionComponent = () => {
     const [prefix, setPrefix] = useState<string>();
+    const [deploymentMode, setDeploymentMode] = useState<DeploymentMode>();
 
     return (
         <Switch>
             <Route exact path={asiConfigurationPath}>
-                <ASIConfiguration updateASIPrefix={setPrefix} />
+                <ASIConfiguration
+                    onSelectDeploymentMode={setDeploymentMode}
+                    updateASIPrefix={setPrefix}
+                />
             </Route>
             <Route exact path={quickstartPath}>
-                <QuickStartDeploy ASIPrefix={prefix?.length === 0 ? 'ATL-' : prefix} />
+                <QuickStartDeploy
+                    deploymentMode={deploymentMode}
+                    ASIPrefix={prefix?.length === 0 ? 'ATL-' : prefix}
+                />
             </Route>
         </Switch>
     );

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -50,7 +50,10 @@ const ButtonRow = styled.div`
     margin: 30px 0px 0px 0px;
 `;
 
-export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({ updateASIPrefix }) => {
+export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
+    updateASIPrefix,
+    onSelectDeploymentMode,
+}) => {
     const [prefix, setPrefix] = useState<string>('');
     const [readyToTransition, setReadyToTransition] = useState<boolean>(false);
     const [existingASIPrefixes, setExistingASIPrefixes] = useState<Array<ASIDescription>>([]);

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -24,9 +24,11 @@ import { I18n } from '../../../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { CancelButton } from '../../../shared/CancelButton';
 import { quickstartPath } from '../../../../utils/RoutePaths';
 import { provisioning } from '../../../../api/provisioning';
+import { DeploymentMode } from '../QuickstartRoutes';
 
 type ASIConfigurationProps = {
     updateASIPrefix: (prefix: string) => void;
+    onSelectDeploymentMode: (mode: DeploymentMode) => void;
 };
 
 const ContentContainer = styled.div`

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -82,6 +82,7 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({ upd
             <ExistingASIConfiguration
                 handlePrefixUpdated={updatePRefix}
                 existingASIs={existingASIPrefixes}
+                onSelectDeploymentMode={onSelectDeploymentMode}
             />
         ) : (
             <ASISelector existingASIs={[]} useExisting={false} handlePrefixUpdated={updatePRefix} />

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
@@ -23,15 +23,17 @@ import styled from 'styled-components';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { DeploymentMode } from '../QuickstartRoutes';
 
+const EXISTING_VPC_OPTION = 'existing';
+const NEW_VPC_OPTION = 'new';
 const radioValues = [
     {
         name: 'deploymentMode',
-        value: 'existing',
+        value: EXISTING_VPC_OPTION,
         label: I18n.getText('atlassian.migration.datacenter.provision.aws.asi.option.existing'),
     },
     {
         name: 'deploymentMode',
-        value: 'new',
+        value: NEW_VPC_OPTION,
         label: I18n.getText('atlassian.migration.datacenter.provision.aws.asi.option.new'),
     },
 ];
@@ -118,6 +120,13 @@ export const ASISelector: FunctionComponent<ASISelectorProps> = ({
     );
 };
 
+const defaultDeploymentOptionIndex = 0;
+const getDefaultDeploymentMode = (): DeploymentMode => {
+    return radioValues[defaultDeploymentOptionIndex].value === EXISTING_VPC_OPTION
+        ? 'standalone'
+        : 'with-vpc';
+};
+
 export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfigurationProps> = ({
     handlePrefixUpdated,
     existingASIs,
@@ -141,9 +150,9 @@ export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfiguratio
                 defaultValue={radioValues[0].value}
                 onChange={(event): void => {
                     handlePrefixUpdated('');
-                    const selectedExisting = event.currentTarget.value === 'existing';
+                    const selectedExisting = event.currentTarget.value === EXISTING_VPC_OPTION;
                     setUseExisting(selectedExisting);
-                    onSelectDeploymentMode(selectedExisting ? 'standalone' : 'standalone');
+                    onSelectDeploymentMode(selectedExisting ? 'standalone' : 'with-vpc');
                 }}
             />
             <ASISelector

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
@@ -18,7 +18,7 @@ import { HelperMessage } from '@atlaskit/form';
 import SectionMessage from '@atlaskit/section-message';
 import Select, { OptionType } from '@atlaskit/select';
 import TextField from '@atlaskit/textfield';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { DeploymentMode } from '../QuickstartRoutes';
@@ -133,6 +133,11 @@ export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfiguratio
     onSelectDeploymentMode,
 }) => {
     const [useExisting, setUseExisting] = useState<boolean>(true);
+
+    useEffect(() => {
+        // The default value of the radio button is existing VPC so we need to update the deployment mode based on that when first rendered
+        onSelectDeploymentMode(getDefaultDeploymentMode());
+    }, []);
 
     return (
         <>

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
@@ -21,6 +21,7 @@ import TextField from '@atlaskit/textfield';
 import React, { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 import { I18n } from '@atlassian/wrm-react-i18n';
+import { DeploymentMode } from '../QuickstartRoutes';
 
 const radioValues = [
     {
@@ -49,21 +50,23 @@ const ASISelectorContainer = styled.div`
     margin-top: 15px;
 `;
 
-type ExistingASIConfigurationProps = {
+type ExistingASIPrefixManagementProps = {
     handlePrefixUpdated: (prefix: string) => void;
     existingASIs: Array<ASIDescription>;
 };
+
+type ExistingASIConfigurationProps = {
+    onSelectDeploymentMode: (mode: DeploymentMode) => void;
+} & ExistingASIPrefixManagementProps;
 
 export type ASIDescription = {
     prefix: string;
     stackName: string;
 };
 
-type ASISelectorPropsBase = {
+type ASISelectorProps = {
     useExisting: boolean;
-};
-
-type ASISelectorProps = ASISelectorPropsBase & ExistingASIConfigurationProps;
+} & ExistingASIPrefixManagementProps;
 
 const ASIPrefixOptionsFromList = (ASIs: Array<ASIDescription>): Array<OptionType> => {
     if (ASIs.length === 0) return [];
@@ -118,6 +121,7 @@ export const ASISelector: FunctionComponent<ASISelectorProps> = ({
 export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfigurationProps> = ({
     handlePrefixUpdated,
     existingASIs,
+    onSelectDeploymentMode,
 }) => {
     const [useExisting, setUseExisting] = useState<boolean>(true);
 
@@ -137,7 +141,9 @@ export const ExistingASIConfiguration: FunctionComponent<ExistingASIConfiguratio
                 defaultValue={radioValues[0].value}
                 onChange={(event): void => {
                     handlePrefixUpdated('');
-                    setUseExisting(event.currentTarget.value === 'existing');
+                    const selectedExisting = event.currentTarget.value === 'existing';
+                    setUseExisting(selectedExisting);
+                    onSelectDeploymentMode(selectedExisting ? 'standalone' : 'standalone');
                 }}
             />
             <ASISelector


### PR DESCRIPTION
# Summary

* Hoist deployment mode to parent of quickstart and ASI configuration component
* Share deployment mode with quickstart form
* Add standalone quickstart parameters file to frontend
* Load quickstart parameters based on deployment mode