### PR TITLE
CHET-427: only use prefix part of ASI select to feed quickstart form

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ExistingASIConfiguration.tsx
@@ -79,7 +79,7 @@ const ASIPrefixOptionsFromList = (ASIs: Array<ASIDescription>): Array<OptionType
         )}: ${asi.stackName})`;
     return ASIs.map(asi => ({
         label: asiToOptionValue(asi),
-        value: asiToOptionValue(asi),
+        value: asi.prefix,
         key: asi.prefix,
     }));
 };


### PR DESCRIPTION
There was a bug where the stack name was included as part of the prefix. Now we just get the sweet prefix
![image](https://user-images.githubusercontent.com/21027663/83225826-f89db080-a1c3-11ea-98d1-bb2841abdcd4.png)
