### PR TITLE
CHET-435: deploy standalone or with vpc

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
@@ -45,8 +45,11 @@ class CloudFormationEndpoint(private val deploymentService: ApplicationDeploymen
     @Produces(MediaType.APPLICATION_JSON)
     fun provisionInfrastructure(provisioningConfig: ProvisioningConfig): Response {
         return try {
-            val stackName = provisioningConfig.stackName!!
-            deploymentService.deployApplication(stackName, provisioningConfig.params!!)
+            val stackName = provisioningConfig.stackName
+            when(provisioningConfig.deploymentMode) {
+                ProvisioningConfig.DeploymentMode.WITH_NETWORK -> deploymentService.deployApplicationWithNetwork(stackName, provisioningConfig.params)
+                ProvisioningConfig.DeploymentMode.STANDALONE -> deploymentService.deployApplication(stackName, provisioningConfig.params)
+            }
             //Should be updated to URI location after get stack details Endpoint is built
             Response.status(Response.Status.ACCEPTED).entity(stackName).build()
         } catch (e: InvalidMigrationStageError) {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -131,6 +131,16 @@ class QuickstartDeploymentServiceTest {
         deploySimpleStack();
 
         verify(mockCfnApi).provisionStack(
+                "https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc.template.yaml",
+                STACK_NAME, STACK_PARAMS);
+    }
+
+    @Test
+    void shouldDeployQuickStartWithVpc() throws InvalidMigrationStageError
+    {
+        deployWithVpcStack();
+
+        verify(mockCfnApi).provisionStack(
                 "https://trebuchet-public-resources.s3.amazonaws.com/quickstart-jira-dc-with-vpc.template.yaml",
                 STACK_NAME, STACK_PARAMS);
     }
@@ -235,5 +245,9 @@ class QuickstartDeploymentServiceTest {
 
     private void deploySimpleStack() throws InvalidMigrationStageError {
         deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
+    }
+
+    private void deployWithVpcStack() throws InvalidMigrationStageError {
+        deploymentService.deployApplicationWithNetwork(STACK_NAME, STACK_PARAMS);
     }
 }

--- a/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
@@ -69,15 +69,13 @@ const deployInfra = (
     stackName: string,
     params: DeploymentParameters,
     mode: DeploymentMode
-): Promise<void> => {
+): Promise<Response> => {
     const payload: CreateStackInput = {
         stackName,
         params,
         deploymentMode: mode,
     };
-    return callAppRest('POST', RestApiPathConstants.CreateStackPath, payload)
-        .then(() => Promise.resolve())
-        .catch(() => Promise.reject());
+    return callAppRest('POST', RestApiPathConstants.CreateStackPath, payload);
 };
 
 export const provisioning = {
@@ -139,13 +137,16 @@ export const provisioning = {
 
         return stackData.map(data => ({ prefix: data.prefix, stackName: data.name }));
     },
-    deployApplication: async (stackName: string, params: DeploymentParameters): Promise<void> => {
+    deployApplication: async (
+        stackName: string,
+        params: DeploymentParameters
+    ): Promise<Response> => {
         return deployInfra(stackName, params, 'STANDALONE');
     },
     deployApplicationWithNetwork: async (
         stackName: string,
         params: DeploymentParameters
-    ): Promise<void> => {
+    ): Promise<Response> => {
         return deployInfra(stackName, params, 'WITH_NETWORK');
     },
 };

--- a/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/provisioning.ts
@@ -150,4 +150,3 @@ export const provisioning = {
         return deployInfra(stackName, params, 'WITH_NETWORK');
     },
 };
-

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ApplicationDeploymentService.kt
@@ -18,6 +18,16 @@ package com.atlassian.migration.datacenter.spi.infrastructure
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 
 interface ApplicationDeploymentService : DeploymentService {
+
+    /**
+     * Deploys the application into an existing virtual network
+     */
     @Throws(InvalidMigrationStageError::class)
     fun deployApplication(deploymentId: String, params: Map<String, String>)
+
+    /**
+     * Deploys application in its own virtual network
+     */
+    @Throws(InvalidMigrationStageError::class)
+    fun deployApplicationWithNetwork(deploymentId: String, params: Map<String, String>)
 }

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfig.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfig.kt
@@ -16,6 +16,9 @@
 package com.atlassian.migration.datacenter.spi.infrastructure
 
 class ProvisioningConfig(val stackName: String, params: Map<String, Any>, val deploymentMode: DeploymentMode) {
+    // We need this unused constructor so that Jackson can deserialize JSON into the provisioning config
+    constructor() : this("", mapOf(), DeploymentMode.STANDALONE)
+
     var params = params.mapValues { it.value.toString() }
 
     enum class DeploymentMode {

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfig.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfig.kt
@@ -15,20 +15,10 @@
  */
 package com.atlassian.migration.datacenter.spi.infrastructure
 
-class ProvisioningConfig {
-    var templateUrl: String?
-    var stackName: String?
-    var params: Map<String, String>?
+class ProvisioningConfig(val stackName: String, params: Map<String, Any>, val deploymentMode: DeploymentMode) {
+    var params = params.mapValues { it.value.toString() }
 
-    constructor() {
-        templateUrl = null
-        stackName = null
-        params = null
-    }
-
-    constructor (templateUrl: String, stackName: String, params: Map<String, Any>) {
-        this.templateUrl = templateUrl
-        this.stackName = stackName
-        this.params = params?.mapValues { it.value.toString() }
+    enum class DeploymentMode {
+        WITH_NETWORK, STANDALONE;
     }
 }

--- a/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfigTest.kt
+++ b/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfigTest.kt
@@ -7,14 +7,14 @@ import java.util.*
 class ProvisioningConfigTest {
     @Test
     fun shouldGetListParametersAsCommaSeparatedValues() {
-        val config = ProvisioningConfig("https://template.url", "stackName", object : HashMap<String, Any>() {
+        val config = ProvisioningConfig("stackName", object : HashMap<String, Any>() {
             init {
                 put("password", "iamsupersecure.trustme")
                 put("instanceCount", 2)
                 put("multiAZ", false)
             }
-        })
-        val params = config.params!!
+        }, ProvisioningConfig.DeploymentMode.WITH_NETWORK)
+        val params = config.params
         Assertions.assertEquals("iamsupersecure.trustme", params["password"])
         Assertions.assertEquals("2", params["instanceCount"])
         Assertions.assertEquals("false", params["multiAZ"])

--- a/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfigTest.kt
+++ b/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/ProvisioningConfigTest.kt
@@ -1,6 +1,8 @@
 package com.atlassian.migration.datacenter.spi.infrastructure
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -15,8 +17,35 @@ class ProvisioningConfigTest {
             }
         }, ProvisioningConfig.DeploymentMode.WITH_NETWORK)
         val params = config.params
-        Assertions.assertEquals("iamsupersecure.trustme", params["password"])
-        Assertions.assertEquals("2", params["instanceCount"])
-        Assertions.assertEquals("false", params["multiAZ"])
+        assertEquals("iamsupersecure.trustme", params["password"])
+        assertEquals("2", params["instanceCount"])
+        assertEquals("false", params["multiAZ"])
+    }
+
+    @Test
+    fun shouldBeDeserialisable() {
+        val jiraProductJSONKey = "JiraProduct"
+        val jiraProductJSONValue = "Software"
+        val stackName = "bpartridge-treb-20"
+        val instanceCountKey = "instanceCount"
+        val instanceCountValue = "2"
+        val json = """
+            {
+                "stackName": "$stackName",
+                "params": {
+                    "$jiraProductJSONKey": "$jiraProductJSONValue",
+                    "$instanceCountKey": "$instanceCountValue"
+                },
+                "deploymentMode": "WITH_NETWORK"
+            }
+        """.trimMargin()
+
+        val mapper = ObjectMapper()
+        val config = mapper.readValue(json, ProvisioningConfig::class.java)
+
+        assertEquals(jiraProductJSONValue, config.params[jiraProductJSONKey])
+        assertEquals(instanceCountValue, config.params[instanceCountKey])
+        assertEquals(stackName, config.stackName)
+        assertEquals(ProvisioningConfig.DeploymentMode.WITH_NETWORK, config.deploymentMode)
     }
 }


### PR DESCRIPTION
## Summary

* Implement ability to deploy with-vpc or standalone quickstart in backend
* Expose configurable deployment via API
* Call API with deployment mode depending on user choice in ASI configuration screen

## Note

* Currently, the JSON is not deserializing nicely into the `ProvisioningConfig` expected by the backend. Will probably have to work on this next week.