### PR TITLE
CHET-420: Move away from using parameters file. Use cfn-yaml parser t…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
         "@reduxjs/toolkit": "^1.0.4",
         "@testing-library/react": "^9.3.2",
         "@testing-library/user-event": "^8.1.0",
+        "@types/js-yaml": "^3.12.4",
         "@types/react": "^16.9.19",
         "@types/react-router-dom": "^5.1.3",
         "@types/when-dom-ready": "^1.2.0",
@@ -66,7 +67,8 @@
         "webpack-sources": "^1.4.3",
         "when-dom-ready": "^1.2.12",
         "write-file-webpack-plugin": "^4.5.1",
-        "yaml": "^1.7.2"
+        "yaml": "^1.7.2",
+        "yaml-cfn": "^0.2.3"
     },
     "devDependencies": {
         "@atlassian/i18n-properties-loader": "^0.7.3",

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.test.tsx
@@ -34,28 +34,30 @@ const VALIDATION_NUMBER_TEST_PARAMETER_MAX = 3;
 const VALIDATION_NUMBER_TEST_PARAMETER_ERROR_MESSAGE = `must be between ${VALIDATION_NUMBER_TEST_PARAMETER_MIN} and ${VALIDATION_NUMBER_TEST_PARAMETER_MAX}`;
 
 const mockCfnYaml = `
-ParameterGroups:
-  - Label:
-      default: ${FIRST_PARAM_GROUP_NAME}
-    Parameters:
-      - ParamOne
-      - ParamTwo
-  - Label:
-      default: ${SECOND_PARAM_GROUP_NAME}
-    Parameters:
-      - ParamThree
-      - ParamFour
-
-ParameterLabels:
-  ParamOne:
-    default: Param One
-  ParamTwo:
-    default: Param Two
-  ParamThree:
-    default: ${VALIDATION_NUMBER_TEST_PARAMETER_LABEL}
-  ParamFour:
-    default: ${VALIDATION_TEST_PARAMETER_LABEL}
-
+AWSTemplateFormatVersion: 2010-09-09
+Description: Atlassian Jira Data Center QS(0035)
+Metadata:
+    AWS::CloudFormation::Interface:
+        ParameterGroups:
+          - Label:
+              default: ${FIRST_PARAM_GROUP_NAME}
+            Parameters:
+              - ParamOne
+              - ParamTwo
+          - Label:
+              default: ${SECOND_PARAM_GROUP_NAME}
+            Parameters:
+              - ParamThree
+              - ParamFour
+        ParameterLabels:
+          ParamOne:
+            default: Param One
+          ParamTwo:
+            default: Param Two
+          ParamThree:
+            default: ${VALIDATION_NUMBER_TEST_PARAMETER_LABEL}
+          ParamFour:
+            default: ${VALIDATION_TEST_PARAMETER_LABEL}
 Parameters:
   ParamOne:
     Type: String

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartTypes.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartTypes.ts
@@ -50,3 +50,9 @@ export type QuickstartParameter = {
     paramLabel: string;
     paramProperties: QuickstartParameterProperties;
 };
+
+export type QuickstartTemplateForm = {
+    Parameters: Record<string, QuickStartParameterYamlNode>;
+    ParameterLabels: Record<string, QuickstartParamLabelYamlNode>;
+    ParameterGroups: Array<QuickstartParamGroupYamlNode>;
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2215,6 +2215,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-yaml@^3.12.4":
+  version "3.12.4"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.4.tgz#7d3b534ec35a0585128e2d332db1403ebe057e25"
+  integrity sha512-fYMgzN+9e28R81weVN49inn/u798ruU91En1ZnGvSZzCRc5jXx9B2EDhlRaWmcO1RIxFHL8AajRXzxDuJu93+A==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -8414,6 +8419,14 @@ js-tokens@^3.0.2:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@^3.10.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.13.0, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -14115,6 +14128,13 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=
+
+yaml-cfn@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/yaml-cfn/-/yaml-cfn-0.2.3.tgz#2f528d79a971970bf74e8386408eb324fe330f6d"
+  integrity sha512-cCeX3mGhQdQJR1gdq2hJloXMh+Fkeq86Q0hyPs7UjBhaXwHYJJ+S+CbW+Fkm1FHXGhtUhcavnA+RM9ulLn6lOg==
+  dependencies:
+    js-yaml "^3.10.0"
 
 yaml@^1.7.2:
   version "1.8.3"


### PR DESCRIPTION
…o parse the full template, including custom tags

Parse the template directly without requirring a parameters file. To do so, this we need to add `cfn-yaml` and `@types/js-yaml` to parse the custom tags that CFn templates introduce.

Tests have been modified to use the full template file.