### PR TITLE
CHET 448: Refactor db endpoint to be "final sync endpoint"

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.atlassian.migration.datacenter.api.db
+package com.atlassian.migration.datacenter.api
 
+import com.atlassian.migration.datacenter.api.db.DatabaseMigrationStatus
+import com.atlassian.migration.datacenter.api.db.stageToStatus
 import com.atlassian.migration.datacenter.core.aws.db.DatabaseMigrationService
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService
 import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncService
@@ -35,8 +37,8 @@ import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
-@Path("/migration/db")
-class DatabaseMigrationEndpoint(
+@Path("/migration/final-sync")
+class FinalSyncEndpoint(
         private val databaseMigrationService: DatabaseMigrationService,
         private val migrationService: MigrationService,
         private val ssmPsqlDatabaseRestoreService: SsmPsqlDatabaseRestoreService,
@@ -81,7 +83,7 @@ class DatabaseMigrationEndpoint(
                 .build()
     }
 
-    @Path("/report")
+    @Path("/status")
     @Produces(MediaType.APPLICATION_JSON)
     @GET
     fun getMigrationStatus(): Response {
@@ -124,7 +126,7 @@ class DatabaseMigrationEndpoint(
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/logs")
+    @Path("/db-logs")
     fun getCommandOutputs(): Response {
         return try {
             Response.ok(ssmPsqlDatabaseRestoreService.fetchCommandResult()).build()

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -101,7 +101,7 @@ class FinalSyncEndpoint(
         } catch (e: JsonProcessingException) {
             Response
                     .serverError()
-                    .entity("Unable to get db migration status. Please contact support and show them this error: ${e.message}")
+                    .entity("Unable to get sync status. Please contact support and show them this error: ${e.message}")
                     .build()
         }
     }
@@ -112,15 +112,16 @@ class FinalSyncEndpoint(
     fun abortMigration(): Response {
         return try {
             databaseMigrationService.abortMigration()
-            finalSyncService.abortMigration()
             Response
                     .ok(mapOf("cancelled" to true))
                     .build()
         } catch (e: InvalidMigrationStageError) {
             Response
                     .status(Response.Status.CONFLICT)
-                    .entity(mapOf("error" to "db migration is not in progress"))
+                    .entity(mapOf("error" to "sync is not in progress"))
                     .build()
+        } finally {
+            finalSyncService.abortMigration()
         }
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -134,13 +134,13 @@ public class DatabaseMigrationService {
 
         if (!migrationService.getCurrentStage().isDBPhase() || s3UploadService == null) {
             throw new InvalidMigrationStageError(
-                    String.format("Invalid migration stage when cancelling filesystem migration: %s",
+                    String.format("Invalid migration stage when cancelling db migration: %s",
                             migrationService.getCurrentStage()));
         }
 
-        logger.warn("Aborting running filesystem migration");
+        logger.warn("Aborting running DB migration");
 
-        migrationService.error("File system migration was aborted");
+        migrationService.error("DB migration was aborted");
     }
 
     private JobId getScheduledJobId() {

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
@@ -35,7 +35,7 @@ class S3FinalSyncService(private val migrationRunner: MigrationRunner, private v
         val result = migrationRunner.runMigration(jobId, jobRunner)
 
         if (!result) {
-            logger.error("Unable to start database migration job.")
+            logger.error("Unable to start s3 final sync migration job.")
         }
         return result
     }
@@ -44,12 +44,12 @@ class S3FinalSyncService(private val migrationRunner: MigrationRunner, private v
         // We always try to remove scheduled job if the system is in inconsistent state
         migrationRunner.abortJobIfPresesnt(getScheduledJobId())
 
-        logger.warn("Aborting running filesystem migration")
+        logger.warn("Aborting running final file sync")
 
         migrationService.error("Aborted final file sync")
     }
 
     private fun getScheduledJobId(): JobId {
-        return JobId.of(DatabaseMigrationJobRunner.KEY + migrationService.currentMigration.id)
+        return JobId.of(jobRunner.key + migrationService.currentMigration.id)
     }
 }

--- a/frontend/src/main/dc-migration-assistant-fe/api/final-sync.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/final-sync.ts
@@ -17,10 +17,10 @@
 import { I18n } from '@atlassian/wrm-react-i18n';
 import { MigrationDuration } from './common';
 
-const dbAPIBase = 'migration/db';
-export const dbStatusReportEndpoint = `${dbAPIBase}/report`;
+const dbAPIBase = 'migration/final-sync';
+export const dbStatusReportEndpoint = `${dbAPIBase}/status`;
 export const dbStartEndpoint = `${dbAPIBase}/start`;
-export const dbLogsEndpoint = `${dbAPIBase}/logs`;
+export const dbLogsEndpoint = `${dbAPIBase}/db-logs`;
 
 export enum DBMigrationStatus {
     NOT_STARTED = 'NOT_STARTED',
@@ -42,6 +42,8 @@ export const statusToI18nString = (status: DBMigrationStatus): string => {
             return I18n.getText('atlassian.migration.datacenter.db.status.uploading');
         case 'done':
             return I18n.getText('atlassian.migration.datacenter.db.status.done');
+        case 'importing':
+            return I18n.getText('atlassian.migration.datacenter.db.status.importing');
         default:
             return I18n.getText('atlassian.migration.datacenter.db.status.unknown');
     }

--- a/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/db/DatabaseMigration.tsx
@@ -28,7 +28,7 @@ import {
     dbLogsEndpoint,
     DBMigrationStatus,
     CommandDetails,
-} from '../../api/db';
+} from '../../api/final-sync';
 import { MigrationStage } from '../../api/migration';
 import { validationPath } from '../../utils/RoutePaths';
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
@@ -18,7 +18,7 @@ import React, { FunctionComponent } from 'react';
 import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 
-import { CommandDetails as CommandResult } from '../../api/db';
+import { CommandDetails as CommandResult } from '../../api/final-sync';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 
 const ErrorFragment = styled.div`

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.tsx
@@ -27,7 +27,7 @@ import { ProgressCallback, Progress } from './Progress';
 import { migration, MigrationStage } from '../../api/migration';
 import { MigrationProgress } from './MigrationTransferProgress';
 import { migrationErrorPath } from '../../utils/RoutePaths';
-import { CommandDetails as CommandResult } from '../../api/db';
+import { CommandDetails as CommandResult } from '../../api/final-sync';
 import { MigrationErrorSection } from './MigrationErrorSection';
 
 const POLL_INTERVAL_MILLIS = 3000;

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -114,6 +114,7 @@ atlassian.migration.datacenter.db.status.not_started=Not started
 atlassian.migration.datacenter.db.status.failed=Failed
 atlassian.migration.datacenter.db.status.exporting=Exporting
 atlassian.migration.datacenter.db.status.uploading=Uploading
+atlassian.migration.datacenter.db.status.importing=Importing
 atlassian.migration.datacenter.db.status.done=Complete
 atlassian.migration.datacenter.db.status.unknown=Unknown Status
 atlassian.migration.datacenter.db.completeMessage=Database has been successfully migrated


### PR DESCRIPTION
# Summary

* Rename endpoint class
* Update endpoint paths
* Update frontend calls of endpoint
* Fix some bugs with aborting the final sync
* Fix some incorrect logging strings
* Fix bug with missing DB status to i18n mapping