### PR TITLE
CHET-457: delete resources endpoint

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpoint.kt
@@ -28,7 +28,7 @@ import javax.ws.rs.core.Response
  * REST API endpoint for cleaning up migration resources
  */
 @Path("/aws/cleanup")
-class AWSResourceCleanupEndpoint(val cleanupService: MigrationInfrastructureCleanupService) {
+class AWSResourceCleanupEndpoint(private val cleanupService: MigrationInfrastructureCleanupService) {
 
     companion object {
         private val logger = LoggerFactory.getLogger(AWSResourceCleanupEndpoint::class.java)

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpoint.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.api.aws
+
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
+import org.slf4j.LoggerFactory
+import javax.ws.rs.DELETE
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType.APPLICATION_JSON
+import javax.ws.rs.core.Response
+
+/**
+ * REST API endpoint for cleaning up migration resources
+ */
+@Path("/aws/cleanup")
+class AWSResourceCleanupEndpoint(val cleanupService: MigrationInfrastructureCleanupService) {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AWSResourceCleanupEndpoint::class.java)
+    }
+
+    @DELETE
+    @Produces(APPLICATION_JSON)
+    fun cleanupMigrationInfrastructure(): Response {
+        val builder = try {
+            val started = cleanupService.scheduleMigrationInfrastructureCleanup()
+
+            if (started) {
+                Response.status(Response.Status.ACCEPTED)
+            } else {
+                Response.status(Response.Status.CONFLICT)
+            }
+        } catch (e: Exception) {
+            logger.error("Unable to cleanup migration infrastructure", e)
+            Response.serverError()
+        }
+
+        return builder.build()
+    }
+}

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpointTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.api.aws
+
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class AWSResourceCleanupEndpointTest {
+
+    lateinit var sut: AWSResourceCleanupEndpoint
+}

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/aws/AWSResourceCleanupEndpointTest.kt
@@ -16,11 +16,54 @@
 
 package com.atlassian.migration.datacenter.api.aws
 
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.lang.Exception
+import javax.ws.rs.core.Response.Status.ACCEPTED
+import javax.ws.rs.core.Response.Status.CONFLICT
+import javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR
+import kotlin.test.assertEquals
 
 @ExtendWith(MockKExtension::class)
 internal class AWSResourceCleanupEndpointTest {
 
+    @MockK
+    lateinit var cleanupService: MigrationInfrastructureCleanupService
+
+    @InjectMockKs
     lateinit var sut: AWSResourceCleanupEndpoint
+
+    @Test
+    fun shouldReturnAcceptedWhenCleanupStarts() {
+        every { cleanupService.scheduleMigrationInfrastructureCleanup() } returns true
+
+        val resp = sut.cleanupMigrationInfrastructure()
+
+        assertEquals(ACCEPTED.statusCode, resp.status)
+    }
+
+    @Test
+    fun shouldReturnConflictWhenCleanupDoesntStart() {
+        every { cleanupService.scheduleMigrationInfrastructureCleanup() } returns false
+
+        val resp = sut.cleanupMigrationInfrastructure()
+
+        assertEquals(CONFLICT.statusCode, resp.status)
+    }
+
+    @Test
+    fun shouldReturnServerErrorWhenCleanupErrors() {
+        every { cleanupService.scheduleMigrationInfrastructureCleanup() } throws Exception()
+
+        val resp = sut.cleanupMigrationInfrastructure()
+
+        assertEquals(INTERNAL_SERVER_ERROR.statusCode, resp.status)
+    }
+
+
 }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationInfrastructureCleanupService.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationInfrastructureCleanupService.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws.infrastructure
+
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureCleanupStatus
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class AWSMigrationInfrastructureCleanupService : MigrationInfrastructureCleanupService {
+
+    companion object {
+        val logger: Logger = LoggerFactory.getLogger(AWSMigrationInfrastructureCleanupService::class.java)
+    }
+
+    override fun getMigrationInfrastructureCleanupStatus(): InfrastructureCleanupStatus {
+        logger.info("querying state of AWS resource cleanup")
+
+        return InfrastructureCleanupStatus.CLEANUP_COMPLETE
+    }
+
+    override fun scheduleMigrationInfrastructureCleanup(): Boolean {
+        logger.info("cleaning up AWS migration infrastructure")
+        return true
+    }
+}

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -44,6 +44,7 @@ import com.atlassian.migration.datacenter.core.aws.db.restore.DatabaseRestoreSta
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService;
 import com.atlassian.migration.datacenter.core.aws.db.restore.TargetDbCredentialsStorageService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
+import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationInfrastructureCleanupService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AtlassianInfrastructureService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.QuickstartDeploymentService;
 import com.atlassian.migration.datacenter.core.aws.region.AvailabilityZoneManager;
@@ -67,6 +68,7 @@ import com.atlassian.migration.datacenter.core.util.EncryptionManager;
 import com.atlassian.migration.datacenter.core.util.MigrationRunner;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.scheduler.SchedulerService;
 
@@ -297,5 +299,10 @@ public class MigrationAssistantBeanConfiguration {
     @Bean
     public S3FinalSyncService s3FinalSyncService(MigrationRunner migrationRunner, S3FinalSyncRunner finalSyncRunner, MigrationService migrationService) {
         return new S3FinalSyncService(migrationRunner, finalSyncRunner, migrationService);
+    }
+
+    @Bean
+    public MigrationInfrastructureCleanupService awsMigrationInfrastructureCleanupService() {
+        return new AWSMigrationInfrastructureCleanupService();
     }
 }

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureCleanupStatus.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureCleanupStatus.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.spi.infrastructure
+
+enum class InfrastructureCleanupStatus {
+    CLEANUP_NOT_STARTED, CLEANUP_IN_PROGRESS, CLEANUP_COMPLETE, CLEANUP_FAILED
+}

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureCleanupService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/MigrationInfrastructureCleanupService.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.spi.infrastructure
+
+interface MigrationInfrastructureCleanupService {
+
+    /**
+     * Schedules the cleanup of any infrastructure that is not required
+     * after the migration has been completed or failed
+     *
+     * @return true if the cleanup was scheduled successfully and false otherwise
+     */
+    fun scheduleMigrationInfrastructureCleanup(): Boolean
+
+    fun getMigrationInfrastructureCleanupStatus(): InfrastructureCleanupStatus
+}


### PR DESCRIPTION
# Summary

* Implement interface for cleaning up migration infrastructure
* Implement api for starting migration infrastructure cleanup
* Implement dummy cleanup service

## Screenshots
API being called from postman
![image](https://user-images.githubusercontent.com/21027663/83702042-d803a980-a64e-11ea-97b0-76ac915b4ed7.png)

Cleanup being logged in Jira logs
![image](https://user-images.githubusercontent.com/21027663/83702074-ee116a00-a64e-11ea-9557-a0e77451a10a.png)
