### PR TITLE
Chet 464 final sync uploaded count

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalService.java
@@ -24,10 +24,6 @@ public class DatabaseArchivalService {
     private DatabaseExtractor databaseExtractor;
     private MigrationStageCallback migrationStageCallback;
 
-    public DatabaseArchivalService(DatabaseExtractor databaseExtractor) {
-        this.databaseExtractor = databaseExtractor;
-    }
-
     public DatabaseArchivalService(DatabaseExtractor databaseExtractor, MigrationStageCallback migrationStageCallback) {
         this.databaseExtractor = databaseExtractor;
         this.migrationStageCallback = migrationStageCallback;

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadService.java
@@ -12,6 +12,7 @@
 
 package com.atlassian.migration.datacenter.core.aws.db;
 
+import com.atlassian.migration.datacenter.core.aws.MigrationStageCallback;
 import com.atlassian.migration.datacenter.core.fs.Crawler;
 import com.atlassian.migration.datacenter.core.fs.DirectoryStreamCrawler;
 import com.atlassian.migration.datacenter.core.fs.FilesystemUploader;
@@ -28,14 +29,14 @@ import java.util.function.Supplier;
 
 public class DatabaseArtifactS3UploadService {
     private final Supplier<S3AsyncClient> s3AsyncClientSupplier;
-    private DatabaseUploadStageTransitionCallback uploadStageTransitionCallback;
+    private final MigrationStageCallback migrationStageCallback;
     private S3AsyncClient s3AsyncClient;
     private final FileSystemMigrationReport fileSystemMigrationReport;
 
-    public DatabaseArtifactS3UploadService(Supplier<S3AsyncClient> s3AsyncClientSupplier, DatabaseUploadStageTransitionCallback uploadStageTransitionCallback) {
+    public DatabaseArtifactS3UploadService(Supplier<S3AsyncClient> s3AsyncClientSupplier, MigrationStageCallback migrationStageCallback) {
         this.s3AsyncClientSupplier = s3AsyncClientSupplier;
         this.fileSystemMigrationReport = new DefaultFileSystemMigrationReport();
-        this.uploadStageTransitionCallback = uploadStageTransitionCallback;
+        this.migrationStageCallback = migrationStageCallback;
     }
 
     @PostConstruct
@@ -45,13 +46,13 @@ public class DatabaseArtifactS3UploadService {
 
     public FileSystemMigrationReport upload(Path target, String targetBucketName) throws InvalidMigrationStageError, FilesystemUploader.FileUploadException {
         s3AsyncClient = s3AsyncClientSupplier.get();
-        this.uploadStageTransitionCallback.assertInStartingStage();
+        this.migrationStageCallback.assertInStartingStage();
         FilesystemUploader filesystemUploader = buildFileSystemUploader(target, targetBucketName, fileSystemMigrationReport, s3AsyncClient);
 
-        this.uploadStageTransitionCallback.transitionToServiceWaitStage();
+        this.migrationStageCallback.transitionToServiceWaitStage();
         filesystemUploader.uploadDirectory(target);
 
-        this.uploadStageTransitionCallback.transitionToServiceNextStage();
+        this.migrationStageCallback.transitionToServiceNextStage();
         return fileSystemMigrationReport;
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -43,7 +43,6 @@ public class DatabaseMigrationService {
     private final DatabaseArchivalService databaseArchivalService;
     private final DatabaseArchiveStageTransitionCallback stageTransitionCallback;
     private final DatabaseArtifactS3UploadService s3UploadService;
-    private final DatabaseUploadStageTransitionCallback uploadStageTransitionCallback;
     private final SsmPsqlDatabaseRestoreService restoreService;
     private final MigrationService migrationService;
     private final MigrationRunner migrationRunner;
@@ -55,14 +54,12 @@ public class DatabaseMigrationService {
                                     MigrationRunner migrationRunner, DatabaseArchivalService databaseArchivalService,
                                     DatabaseArchiveStageTransitionCallback stageTransitionCallback,
                                     DatabaseArtifactS3UploadService s3UploadService,
-                                    DatabaseUploadStageTransitionCallback uploadStageTransitionCallback,
                                     SsmPsqlDatabaseRestoreService restoreService,
                                     AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this.tempDirectory = tempDirectory;
         this.databaseArchivalService = databaseArchivalService;
         this.stageTransitionCallback = stageTransitionCallback;
         this.s3UploadService = s3UploadService;
-        this.uploadStageTransitionCallback = uploadStageTransitionCallback;
         this.restoreService = restoreService;
         this.migrationService = migrationService;
         this.migrationRunner = migrationRunner;
@@ -86,7 +83,7 @@ public class DatabaseMigrationService {
         String bucketName = migrationHelperDeploymentService.getMigrationS3BucketName();
 
         try {
-            report = s3UploadService.upload(pathToDatabaseFile, bucketName, this.uploadStageTransitionCallback);
+            report = s3UploadService.upload(pathToDatabaseFile, bucketName);
         } catch (FilesystemUploader.FileUploadException e) {
             migrationService.error(e);
             throw new DatabaseMigrationFailure("Error when uploading database dump to S3", e);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -16,7 +16,6 @@
 
 package com.atlassian.migration.datacenter.core.aws.db;
 
-import com.atlassian.migration.datacenter.core.aws.db.restore.DatabaseRestoreStageTransitionCallback;
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
 import com.atlassian.migration.datacenter.core.db.DatabaseMigrationJobRunner;
@@ -46,7 +45,6 @@ public class DatabaseMigrationService {
     private final DatabaseArtifactS3UploadService s3UploadService;
     private final DatabaseUploadStageTransitionCallback uploadStageTransitionCallback;
     private final SsmPsqlDatabaseRestoreService restoreService;
-    private final DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback;
     private final MigrationService migrationService;
     private final MigrationRunner migrationRunner;
     private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
@@ -54,20 +52,18 @@ public class DatabaseMigrationService {
     private final AtomicReference<Optional<LocalDateTime>> startTime = new AtomicReference<>(Optional.empty());
 
     public DatabaseMigrationService(Path tempDirectory, MigrationService migrationService,
-            MigrationRunner migrationRunner, DatabaseArchivalService databaseArchivalService,
-            DatabaseArchiveStageTransitionCallback stageTransitionCallback,
-            DatabaseArtifactS3UploadService s3UploadService,
-            DatabaseUploadStageTransitionCallback uploadStageTransitionCallback,
-            SsmPsqlDatabaseRestoreService restoreService,
-            DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback,
-            AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
+                                    MigrationRunner migrationRunner, DatabaseArchivalService databaseArchivalService,
+                                    DatabaseArchiveStageTransitionCallback stageTransitionCallback,
+                                    DatabaseArtifactS3UploadService s3UploadService,
+                                    DatabaseUploadStageTransitionCallback uploadStageTransitionCallback,
+                                    SsmPsqlDatabaseRestoreService restoreService,
+                                    AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this.tempDirectory = tempDirectory;
         this.databaseArchivalService = databaseArchivalService;
         this.stageTransitionCallback = stageTransitionCallback;
         this.s3UploadService = s3UploadService;
         this.uploadStageTransitionCallback = uploadStageTransitionCallback;
         this.restoreService = restoreService;
-        this.restoreStageTransitionCallback = restoreStageTransitionCallback;
         this.migrationService = migrationService;
         this.migrationRunner = migrationRunner;
         this.migrationHelperDeploymentService = migrationHelperDeploymentService;
@@ -97,7 +93,7 @@ public class DatabaseMigrationService {
         }
 
         try {
-            restoreService.restoreDatabase(restoreStageTransitionCallback);
+            restoreService.restoreDatabase();
         } catch (Exception e) {
             migrationService.error(e);
             throw new DatabaseMigrationFailure("Error when restoring database", e);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -41,7 +41,6 @@ public class DatabaseMigrationService {
 
     private final Path tempDirectory;
     private final DatabaseArchivalService databaseArchivalService;
-    private final DatabaseArchiveStageTransitionCallback stageTransitionCallback;
     private final DatabaseArtifactS3UploadService s3UploadService;
     private final SsmPsqlDatabaseRestoreService restoreService;
     private final MigrationService migrationService;
@@ -52,13 +51,11 @@ public class DatabaseMigrationService {
 
     public DatabaseMigrationService(Path tempDirectory, MigrationService migrationService,
                                     MigrationRunner migrationRunner, DatabaseArchivalService databaseArchivalService,
-                                    DatabaseArchiveStageTransitionCallback stageTransitionCallback,
                                     DatabaseArtifactS3UploadService s3UploadService,
                                     SsmPsqlDatabaseRestoreService restoreService,
                                     AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         this.tempDirectory = tempDirectory;
         this.databaseArchivalService = databaseArchivalService;
-        this.stageTransitionCallback = stageTransitionCallback;
         this.s3UploadService = s3UploadService;
         this.restoreService = restoreService;
         this.migrationService = migrationService;
@@ -76,7 +73,7 @@ public class DatabaseMigrationService {
         migrationService.transition(MigrationStage.DB_MIGRATION_EXPORT);
         startTime.set(Optional.of(LocalDateTime.now()));
 
-        Path pathToDatabaseFile = databaseArchivalService.archiveDatabase(tempDirectory, stageTransitionCallback);
+        Path pathToDatabaseFile = databaseArchivalService.archiveDatabase(tempDirectory);
 
         FileSystemMigrationErrorReport report;
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
@@ -16,6 +16,7 @@
 
 package com.atlassian.migration.datacenter.core.aws.db.restore;
 
+import com.atlassian.migration.datacenter.core.aws.MigrationStageCallback;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
 import com.atlassian.migration.datacenter.core.aws.ssm.SSMApi;
 import com.atlassian.migration.datacenter.core.aws.ssm.SuccessfulSSMCommandConsumer;
@@ -32,23 +33,22 @@ public class SsmPsqlDatabaseRestoreService {
 
     private final SSMApi ssm;
     private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
+    private final MigrationStageCallback migrationStageCallback;
 
     private final String restoreDocumentName = "restoreDatabaseBackupToRDS";
-
     private String commandId;
-    private final DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback;
 
     SsmPsqlDatabaseRestoreService(SSMApi ssm, int maxCommandRetries,
-                                  AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback) {
+                                  AWSMigrationHelperDeploymentService migrationHelperDeploymentService, MigrationStageCallback migrationStageCallback) {
         this.ssm = ssm;
         this.maxCommandRetries = maxCommandRetries;
         this.migrationHelperDeploymentService = migrationHelperDeploymentService;
-        this.restoreStageTransitionCallback = restoreStageTransitionCallback;
+        this.migrationStageCallback = migrationStageCallback;
     }
 
     public SsmPsqlDatabaseRestoreService(SSMApi ssm,
-                                         AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback) {
-        this(ssm, 10, migrationHelperDeploymentService, restoreStageTransitionCallback);
+                                         AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback migrationStageCallback) {
+        this(ssm, 10, migrationHelperDeploymentService, migrationStageCallback);
     }
 
     public void restoreDatabase()
@@ -56,22 +56,22 @@ public class SsmPsqlDatabaseRestoreService {
         String dbRestorePlaybook = migrationHelperDeploymentService.getDbRestoreDocument();
         String migrationInstanceId = migrationHelperDeploymentService.getMigrationHostInstanceId();
 
-        this.restoreStageTransitionCallback.assertInStartingStage();
+        this.migrationStageCallback.assertInStartingStage();
 
         this.commandId = ssm.runSSMDocument(dbRestorePlaybook, migrationInstanceId, Collections.emptyMap());
 
         SuccessfulSSMCommandConsumer consumer = new EnsureSuccessfulSSMCommandConsumer(ssm, commandId,
                 migrationInstanceId);
 
-        restoreStageTransitionCallback.transitionToServiceWaitStage();
+        migrationStageCallback.transitionToServiceWaitStage();
 
         try {
             consumer.handleCommandOutput(maxCommandRetries);
-            restoreStageTransitionCallback.transitionToServiceNextStage();
+            migrationStageCallback.transitionToServiceNextStage();
         } catch (SuccessfulSSMCommandConsumer.UnsuccessfulSSMCommandInvocationException
                 | SuccessfulSSMCommandConsumer.SSMCommandInvocationProcessingError e) {
             final String errorMessage = "Error restoring database. Either download of database dump from S3 failed or pg_restore failed";
-            restoreStageTransitionCallback
+            migrationStageCallback
                     .transitionToServiceErrorStage(String.format("%s. %s", errorMessage, e.getMessage()));
             throw new DatabaseMigrationFailure(errorMessage, e);
         }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
@@ -36,25 +36,27 @@ public class SsmPsqlDatabaseRestoreService {
     private final String restoreDocumentName = "restoreDatabaseBackupToRDS";
 
     private String commandId;
+    private final DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback;
 
     SsmPsqlDatabaseRestoreService(SSMApi ssm, int maxCommandRetries,
-                                  AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
+                                  AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback) {
         this.ssm = ssm;
         this.maxCommandRetries = maxCommandRetries;
         this.migrationHelperDeploymentService = migrationHelperDeploymentService;
+        this.restoreStageTransitionCallback = restoreStageTransitionCallback;
     }
 
     public SsmPsqlDatabaseRestoreService(SSMApi ssm,
-                                         AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
-        this(ssm, 10, migrationHelperDeploymentService);
+                                         AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback) {
+        this(ssm, 10, migrationHelperDeploymentService, restoreStageTransitionCallback);
     }
 
-    public void restoreDatabase(DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback)
+    public void restoreDatabase()
             throws DatabaseMigrationFailure, InvalidMigrationStageError {
         String dbRestorePlaybook = migrationHelperDeploymentService.getDbRestoreDocument();
         String migrationInstanceId = migrationHelperDeploymentService.getMigrationHostInstanceId();
 
-        restoreStageTransitionCallback.assertInStartingStage();
+        this.restoreStageTransitionCallback.assertInStartingStage();
 
         this.commandId = ssm.runSSMDocument(dbRestorePlaybook, migrationInstanceId, Collections.emptyMap());
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/AttachmentSyncManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/AttachmentSyncManager.java
@@ -22,4 +22,5 @@ import java.util.Set;
 
 public interface AttachmentSyncManager {
     Set<FileSyncRecord> getCapturedAttachments();
+    Integer getCapturedAttachmentCountForCurrentMigration();
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentSyncManager.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentSyncManager.java
@@ -55,4 +55,15 @@ public class DefaultAttachmentSyncManager implements AttachmentSyncManager {
 
         return records;
     }
+
+    @Override
+    public Integer getCapturedAttachmentCountForCurrentMigration() {
+        Migration migration = migrationService.getCurrentMigration();
+
+        if (migration == null) {
+            return 0;
+        }
+
+        return activeObjects.count(FileSyncRecord.class, Query.select().where("migration_id = ?", migration.getID()));
+    }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/jira/listener/JiraIssueAttachmentListener.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/jira/listener/JiraIssueAttachmentListener.java
@@ -72,7 +72,6 @@ public class JiraIssueAttachmentListener implements DisposableBean {
         if (started) {
             eventPublisher.unregister(this);
             started = false;
-
         }
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/jira/listener/JiraIssueAttachmentListener.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/jira/listener/JiraIssueAttachmentListener.java
@@ -68,6 +68,14 @@ public class JiraIssueAttachmentListener implements DisposableBean {
         }
     }
 
+    public void stop() {
+        if (started) {
+            eventPublisher.unregister(this);
+            started = false;
+
+        }
+    }
+
     public boolean isStarted() {
         return started;
     }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/SqsQueueWatcher.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/SqsQueueWatcher.kt
@@ -38,6 +38,8 @@ class SqsQueueWatcher(private val sqsAPi: SqsApi,
     }
 
     override fun awaitQueueDrain(): Boolean {
+        logger.info("Waiting for migration state to be in {}. Once the stage is reached, SQS queue will be polling will begin.", MigrationStage.FINAL_SYNC_WAIT)
+
         try {
             val completableFuture = this.awaitRunnableToComplete(::checkForStateToBeInFsSyncAwait)
                     .thenCompose { awaitRunnableToComplete(::checkForQueueToBeEmpty) }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArchivalServiceTest.java
@@ -46,14 +46,14 @@ class DatabaseArchivalServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new DatabaseArchivalService(databaseExtractor);
+        service = new DatabaseArchivalService(databaseExtractor, migrationStageCallback);
     }
 
     @Test
     void shouldArchiveDatabaseSuccessfully() throws Exception {
         when(this.databaseExtractor.startDatabaseDump(tempDir.resolve("db.dump"))).thenReturn(process);
         when(process.waitFor()).thenReturn(0);
-        Path target = service.archiveDatabase(tempDir, migrationStageCallback);
+        Path target = service.archiveDatabase(tempDir);
         assertTrue(target.endsWith("db.dump"));
 
         verify(this.migrationStageCallback).assertInStartingStage();
@@ -66,7 +66,7 @@ class DatabaseArchivalServiceTest {
         doThrow(InvalidMigrationStageError.class).when(migrationStageCallback).assertInStartingStage();
 
         assertThrows(InvalidMigrationStageError.class, () -> {
-            service.archiveDatabase(tempDir, migrationStageCallback);
+            service.archiveDatabase(tempDir);
         });
     }
 
@@ -75,7 +75,7 @@ class DatabaseArchivalServiceTest {
         doThrow(InvalidMigrationStageError.class).when(migrationStageCallback).transitionToServiceWaitStage();
 
         assertThrows(InvalidMigrationStageError.class, () -> {
-            service.archiveDatabase(tempDir, migrationStageCallback);
+            service.archiveDatabase(tempDir);
         });
         verify(migrationStageCallback).assertInStartingStage();
     }
@@ -88,7 +88,7 @@ class DatabaseArchivalServiceTest {
         doThrow(InvalidMigrationStageError.class).when(migrationStageCallback).transitionToServiceNextStage();
 
         assertThrows(InvalidMigrationStageError.class, () -> {
-            service.archiveDatabase(tempDir, migrationStageCallback);
+            service.archiveDatabase(tempDir);
         });
 
         verify(migrationStageCallback).assertInStartingStage();
@@ -102,7 +102,7 @@ class DatabaseArchivalServiceTest {
         when(process.waitFor()).thenThrow(new InterruptedException(errorMessage));
 
         assertThrows(DatabaseMigrationFailure.class, () -> {
-            service.archiveDatabase(tempDir, migrationStageCallback);
+            service.archiveDatabase(tempDir);
         });
 
         verify(migrationStageCallback).assertInStartingStage();

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseArtifactS3UploadServiceTest.java
@@ -46,13 +46,13 @@ public class DatabaseArtifactS3UploadServiceTest {
 
     @Test
     void serviceShouldInstantiateS3ClientFromSupplier() throws Exception {
-        sut.upload(path, "bucketName", databaseUploadStageTransitionCallback);
+        sut.upload(path, "bucketName");
         verify(s3AsyncClientSupplier).get();
     }
 
     @Test
     void serviceShouldTransitionThroughExpectedStages() throws Exception {
-        sut.upload(path, "bucketName", databaseUploadStageTransitionCallback);
+        sut.upload(path, "bucketName");
         verify(databaseUploadStageTransitionCallback).assertInStartingStage();
         verify(databaseUploadStageTransitionCallback).transitionToServiceWaitStage();
         verify(databaseUploadStageTransitionCallback).transitionToServiceNextStage();

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -133,18 +133,20 @@ class DatabaseMigrationServiceIT {
 
         when(ssmApi.runSSMDocument(anyString(), anyString(), anyMap())).thenReturn("my-commnd");
         when(ssmApi.getSSMCommand(anyString(), anyString())).thenReturn(GetCommandInvocationResponse.builder().status(CommandInvocationStatus.SUCCESS).build());
-        SsmPsqlDatabaseRestoreService restoreService = new SsmPsqlDatabaseRestoreService(ssmApi, migrationHelperDeploymentService);
+
         DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback  = new DatabaseRestoreStageTransitionCallback(this.migrationService);
 
+        SsmPsqlDatabaseRestoreService restoreService = new SsmPsqlDatabaseRestoreService(ssmApi, migrationHelperDeploymentService, restoreStageTransitionCallback);
+
         DatabaseMigrationService service = new DatabaseMigrationService(tempDir,
-                                                                        migrationService,
-                                                                        migrationRunner,
-                                                                        databaseArchivalService,
-                                                                        archiveStageTransitionCallback,
-                                                                        s3UploadService,
-                                                                        uploadStageTransitionCallback,
-                                                                        restoreService,
-                                                                        restoreStageTransitionCallback, migrationHelperDeploymentService);
+                migrationService,
+                migrationRunner,
+                databaseArchivalService,
+                archiveStageTransitionCallback,
+                s3UploadService,
+                uploadStageTransitionCallback,
+                restoreService,
+                migrationHelperDeploymentService);
 
         FileSystemMigrationErrorReport report = service.performMigration();
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -128,7 +128,7 @@ class DatabaseMigrationServiceIT {
         MigrationStageCallback archiveStageTransitionCallback = new DatabaseArchiveStageTransitionCallback(migrationService);
         DatabaseArchivalService databaseArchivalService = new DatabaseArchivalService(DatabaseExtractorFactory.getExtractor(configuration), archiveStageTransitionCallback);
 
-        DatabaseUploadStageTransitionCallback uploadStageTransitionCallback = new DatabaseUploadStageTransitionCallback(this.migrationService);
+        MigrationStageCallback uploadStageTransitionCallback = new DatabaseUploadStageTransitionCallback(this.migrationService);
         DatabaseArtifactS3UploadService s3UploadService = new DatabaseArtifactS3UploadService(() -> s3client, uploadStageTransitionCallback);
         s3UploadService.postConstruct();
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -127,9 +127,9 @@ class DatabaseMigrationServiceIT {
         DatabaseArchivalService databaseArchivalService = new DatabaseArchivalService(DatabaseExtractorFactory.getExtractor(configuration));
         DatabaseArchiveStageTransitionCallback archiveStageTransitionCallback = new DatabaseArchiveStageTransitionCallback(migrationService);
 
-        DatabaseArtifactS3UploadService s3UploadService = new DatabaseArtifactS3UploadService(() -> s3client);
-        s3UploadService.postConstruct();
         DatabaseUploadStageTransitionCallback uploadStageTransitionCallback = new DatabaseUploadStageTransitionCallback(this.migrationService);
+        DatabaseArtifactS3UploadService s3UploadService = new DatabaseArtifactS3UploadService(() -> s3client, uploadStageTransitionCallback);
+        s3UploadService.postConstruct();
 
         when(ssmApi.runSSMDocument(anyString(), anyString(), anyMap())).thenReturn("my-commnd");
         when(ssmApi.getSSMCommand(anyString(), anyString())).thenReturn(GetCommandInvocationResponse.builder().status(CommandInvocationStatus.SUCCESS).build());
@@ -144,7 +144,6 @@ class DatabaseMigrationServiceIT {
                 databaseArchivalService,
                 archiveStageTransitionCallback,
                 s3UploadService,
-                uploadStageTransitionCallback,
                 restoreService,
                 migrationHelperDeploymentService);
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -18,6 +18,7 @@ package com.atlassian.migration.datacenter.core.aws.db;
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
+import com.atlassian.migration.datacenter.core.aws.MigrationStageCallback;
 import com.atlassian.migration.datacenter.core.aws.db.restore.DatabaseRestoreStageTransitionCallback;
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
@@ -124,8 +125,8 @@ class DatabaseMigrationServiceIT {
     @Test
     void testDatabaseMigration() throws ExecutionException, InterruptedException, InvalidMigrationStageError
     {
-        DatabaseArchivalService databaseArchivalService = new DatabaseArchivalService(DatabaseExtractorFactory.getExtractor(configuration));
-        DatabaseArchiveStageTransitionCallback archiveStageTransitionCallback = new DatabaseArchiveStageTransitionCallback(migrationService);
+        MigrationStageCallback archiveStageTransitionCallback = new DatabaseArchiveStageTransitionCallback(migrationService);
+        DatabaseArchivalService databaseArchivalService = new DatabaseArchivalService(DatabaseExtractorFactory.getExtractor(configuration), archiveStageTransitionCallback);
 
         DatabaseUploadStageTransitionCallback uploadStageTransitionCallback = new DatabaseUploadStageTransitionCallback(this.migrationService);
         DatabaseArtifactS3UploadService s3UploadService = new DatabaseArtifactS3UploadService(() -> s3client, uploadStageTransitionCallback);
@@ -142,7 +143,6 @@ class DatabaseMigrationServiceIT {
                 migrationService,
                 migrationRunner,
                 databaseArchivalService,
-                archiveStageTransitionCallback,
                 s3UploadService,
                 restoreService,
                 migrationHelperDeploymentService);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
@@ -16,7 +16,6 @@
 
 package com.atlassian.migration.datacenter.core.aws.db;
 
-import com.atlassian.migration.datacenter.core.aws.db.restore.DatabaseRestoreStageTransitionCallback;
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
 import com.atlassian.migration.datacenter.core.fs.reporting.DefaultFileSystemMigrationReport;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -79,7 +77,6 @@ public class DatabaseMigrationServiceTest {
                 s3UploadService,
                 new DatabaseUploadStageTransitionCallback(migrationService),
                 restoreService,
-                new DatabaseRestoreStageTransitionCallback(migrationService),
                 awsMigrationHelperDeploymentService);
     }
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
@@ -73,7 +73,6 @@ public class DatabaseMigrationServiceTest {
                 migrationService,
                 migrationRunner,
                 databaseArchivalService,
-                new DatabaseArchiveStageTransitionCallback(migrationService),
                 s3UploadService,
                 restoreService,
                 awsMigrationHelperDeploymentService);
@@ -88,7 +87,7 @@ public class DatabaseMigrationServiceTest {
 
         InOrder inOrder = inOrder(migrationService);
         when(awsMigrationHelperDeploymentService.getMigrationS3BucketName()).thenReturn(s3bucket);
-        when(databaseArchivalService.archiveDatabase(eq(tempDir), any())).thenReturn(filePath);
+        when(databaseArchivalService.archiveDatabase(eq(tempDir))).thenReturn(filePath);
         when(s3UploadService.upload(eq(filePath), eq(s3bucket))).thenReturn(report);
         sut.performMigration();
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceTest.java
@@ -75,7 +75,6 @@ public class DatabaseMigrationServiceTest {
                 databaseArchivalService,
                 new DatabaseArchiveStageTransitionCallback(migrationService),
                 s3UploadService,
-                new DatabaseUploadStageTransitionCallback(migrationService),
                 restoreService,
                 awsMigrationHelperDeploymentService);
     }
@@ -90,7 +89,7 @@ public class DatabaseMigrationServiceTest {
         InOrder inOrder = inOrder(migrationService);
         when(awsMigrationHelperDeploymentService.getMigrationS3BucketName()).thenReturn(s3bucket);
         when(databaseArchivalService.archiveDatabase(eq(tempDir), any())).thenReturn(filePath);
-        when(s3UploadService.upload(eq(filePath), eq(s3bucket), any())).thenReturn(report);
+        when(s3UploadService.upload(eq(filePath), eq(s3bucket))).thenReturn(report);
         sut.performMigration();
 
         inOrder.verify(migrationService).transition(MigrationStage.DB_MIGRATION_EXPORT);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreServiceTest.java
@@ -52,21 +52,21 @@ class SsmPsqlDatabaseRestoreServiceTest {
 
     @BeforeEach
     void setUp() {
-        sut = new SsmPsqlDatabaseRestoreService(ssmApi, 1, migrationHelperDeploymentService);
+        sut = new SsmPsqlDatabaseRestoreService(ssmApi, 1, migrationHelperDeploymentService, callback);
     }
 
     @Test
     void shouldBeSuccessfulWhenCommandStatusIsSuccessful() throws InvalidMigrationStageError {
         givenCommandCompletesWithStatus(CommandInvocationStatus.SUCCESS);
 
-        sut.restoreDatabase(callback);
+        sut.restoreDatabase();
     }
 
     @Test
     void shouldThrowWhenCommandStatusIsFailed() {
         givenCommandCompletesWithStatus(CommandInvocationStatus.FAILED);
 
-        assertThrows(DatabaseMigrationFailure.class, () -> sut.restoreDatabase(callback));
+        assertThrows(DatabaseMigrationFailure.class, () -> sut.restoreDatabase());
     }
 
     @Test
@@ -119,5 +119,4 @@ class SsmPsqlDatabaseRestoreServiceTest {
                         .build()
         );
     }
-
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentSyncManagerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/captor/DefaultAttachmentSyncManagerTest.java
@@ -101,6 +101,22 @@ public class DefaultAttachmentSyncManagerTest {
         assertEquals(0, sut.getCapturedAttachments().size());
     }
 
+    @Test
+    public void shouldReturnActualCountWhenFileSyncRecordExists() {
+        Migration migration = givenMigrationExists();
+        givenFileSyncRecordIsInDB("/foo/baz", migration);
+        givenFileSyncRecordIsInDB("/foo/bar", migration);
+
+        assertEquals(2, sut.getCapturedAttachmentCountForCurrentMigration());
+    }
+
+
+    @Test
+    public void shouldBeZeroWhenFileSyncRecordsDoNotExistForMigration() {
+        Migration migration = givenMigrationExists();
+        assertEquals(0, sut.getCapturedAttachmentCountForCurrentMigration());
+    }
+
     @NotNull
     private FileSyncRecord givenFileSyncRecordIsInDB(String path, Migration migration) {
         FileSyncRecord record = ao.create(FileSyncRecord.class);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/jira/listener/JiraIssueAttachmentListenerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/jira/listener/JiraIssueAttachmentListenerTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -114,5 +116,15 @@ class JiraIssueAttachmentListenerTest {
         sut.start();
 
         verify(mockPublisher, times(1)).register(sut);
+    }
+
+    @Test
+    void shouldUnRegisterOnce() {
+        sut.start();
+        sut.stop();
+        sut.stop();
+
+        assertFalse(sut.isStarted(), "Expected listener to have started");
+        verify(mockPublisher, times(1)).unregister(sut);
     }
 }

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncServiceTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncServiceTest.kt
@@ -23,6 +23,7 @@ internal class S3FinalSyncServiceTest {
 
     @MockK lateinit var  migrationContext: MigrationContext
     @MockK lateinit var  sqsApi: SqsApi
+    @MockK lateinit var  attachmentSyncManager: AttachmentSyncManager
 
     @InjectMockKs
     lateinit var sut: S3FinalSyncService
@@ -36,12 +37,13 @@ internal class S3FinalSyncServiceTest {
 
         every { migrationService.currentContext } returns migrationContext
         every { migrationContext.migrationQueueUrl } returns queueUrl
-        every {  sqsApi.getQueueLength(queueUrl) } returns 42
+        every { sqsApi.getQueueLength(queueUrl) } returns 42
+        every { attachmentSyncManager.capturedAttachmentCountForCurrentMigration } returns 21
 
         val finalSyncStatus = sut.getFinalSyncStatus()
 
         assertEquals(42, finalSyncStatus.enqueuedFileCount)
-        assertEquals(0, finalSyncStatus.uploadedFileCount)
+        assertEquals(21, finalSyncStatus.uploadedFileCount)
 
         verify {
             sqsApi.getQueueLength(queueUrl)

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -324,8 +324,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public S3FinalSyncService s3FinalSyncService(MigrationRunner migrationRunner, S3FinalSyncRunner finalSyncRunner, MigrationService migrationService, SqsApi sqsApi, QueueWatcher queueWatcher) {
-        return new S3FinalSyncService(migrationRunner, finalSyncRunner, migrationService, sqsApi);
+    public S3FinalSyncService s3FinalSyncService(MigrationRunner migrationRunner, S3FinalSyncRunner finalSyncRunner, MigrationService migrationService, SqsApi sqsApi, QueueWatcher queueWatcher, AttachmentSyncManager attachmentSyncManager) {
+        return new S3FinalSyncService(migrationRunner, finalSyncRunner, migrationService, sqsApi, attachmentSyncManager);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -186,13 +186,13 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public SsmPsqlDatabaseRestoreService ssmPsqlDatabaseRestoreService(SSMApi ssm, AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
-        return new SsmPsqlDatabaseRestoreService(ssm, migrationHelperDeploymentService);
+    public DatabaseRestoreStageTransitionCallback databaseRestoreStageTransitionCallback(MigrationService migrationService) {
+        return new DatabaseRestoreStageTransitionCallback(migrationService);
     }
 
     @Bean
-    public DatabaseRestoreStageTransitionCallback databaseRestoreStageTransitionCallback(MigrationService migrationService) {
-        return new DatabaseRestoreStageTransitionCallback(migrationService);
+    public SsmPsqlDatabaseRestoreService ssmPsqlDatabaseRestoreService(SSMApi ssm, AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback) {
+        return new SsmPsqlDatabaseRestoreService(ssm, migrationHelperDeploymentService, restoreStageTransitionCallback);
     }
 
     @Bean
@@ -202,8 +202,7 @@ public class MigrationAssistantBeanConfiguration {
                                                              DatabaseArchiveStageTransitionCallback archiveStageTransitionCallback,
                                                              DatabaseArtifactS3UploadService s3UploadService,
                                                              DatabaseUploadStageTransitionCallback uploadStageTransitionCallback,
-                                                             SsmPsqlDatabaseRestoreService restoreService,
-                                                             DatabaseRestoreStageTransitionCallback restoreStageTransitionCallback, AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
+                                                             SsmPsqlDatabaseRestoreService restoreService, AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         String tempDirectoryPath = System.getProperty("java.io.tmpdir");
         return new DatabaseMigrationService(
                 Paths.get(tempDirectoryPath),
@@ -214,7 +213,6 @@ public class MigrationAssistantBeanConfiguration {
                 s3UploadService,
                 uploadStageTransitionCallback,
                 restoreService,
-                restoreStageTransitionCallback,
                 migrationHelperDeploymentService);
     }
 

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -196,20 +196,17 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public DatabaseMigrationService databaseMigrationService(MigrationService databaseMigrationService,
+    public DatabaseMigrationService databaseMigrationService(MigrationService migrationService,
                                                              MigrationRunner migrationRunner,
                                                              DatabaseArchivalService databaseArchivalService,
-                                                             DatabaseArchiveStageTransitionCallback archiveStageTransitionCallback,
                                                              DatabaseArtifactS3UploadService s3UploadService,
-                                                             DatabaseUploadStageTransitionCallback uploadStageTransitionCallback,
                                                              SsmPsqlDatabaseRestoreService restoreService, AWSMigrationHelperDeploymentService migrationHelperDeploymentService) {
         String tempDirectoryPath = System.getProperty("java.io.tmpdir");
         return new DatabaseMigrationService(
                 Paths.get(tempDirectoryPath),
-                databaseMigrationService,
+                migrationService,
                 migrationRunner,
                 databaseArchivalService,
-                archiveStageTransitionCallback,
                 s3UploadService,
                 restoreService,
                 migrationHelperDeploymentService);
@@ -236,8 +233,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public DatabaseArchivalService databaseArchivalService(DatabaseExtractor databaseExtractor) {
-        return new DatabaseArchivalService(databaseExtractor);
+    public DatabaseArchivalService databaseArchivalService(DatabaseExtractor databaseExtractor, DatabaseArchiveStageTransitionCallback archiveStageTransitionCallback) {
+        return new DatabaseArchivalService(databaseExtractor, archiveStageTransitionCallback);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -308,8 +308,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public S3FinalSyncRunner s3FinalSyncRunner(AttachmentSyncManager attachmentSyncManager, Supplier<S3AsyncClient> s3ClientSupplier, JiraHome jiraHome, AWSMigrationHelperDeploymentService helperDeploymentService, QueueWatcher queueWatcher) {
-        return new S3FinalSyncRunner(attachmentSyncManager, s3ClientSupplier, jiraHome, helperDeploymentService, queueWatcher);
+    public S3FinalSyncRunner s3FinalSyncRunner(AttachmentSyncManager attachmentSyncManager, Supplier<S3AsyncClient> s3ClientSupplier, JiraHome jiraHome, AWSMigrationHelperDeploymentService helperDeploymentService, QueueWatcher queueWatcher, JiraIssueAttachmentListener attachmentListener) {
+        return new S3FinalSyncRunner(attachmentSyncManager, s3ClientSupplier, jiraHome, helperDeploymentService, queueWatcher, attachmentListener);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -176,13 +176,13 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public DatabaseArtifactS3UploadService databaseArtifactS3UploadService(Supplier<S3AsyncClient> s3AsyncClientSupplier) {
-        return new DatabaseArtifactS3UploadService(s3AsyncClientSupplier);
+    public DatabaseUploadStageTransitionCallback databaseUploadStageTransitionCallback(MigrationService migrationService) {
+        return new DatabaseUploadStageTransitionCallback(migrationService);
     }
 
     @Bean
-    public DatabaseUploadStageTransitionCallback databaseUploadStageTransitionCallback(MigrationService migrationService) {
-        return new DatabaseUploadStageTransitionCallback(migrationService);
+    public DatabaseArtifactS3UploadService databaseArtifactS3UploadService(Supplier<S3AsyncClient> s3AsyncClientSupplier, DatabaseUploadStageTransitionCallback uploadStageTransitionCallback) {
+        return new DatabaseArtifactS3UploadService(s3AsyncClientSupplier, uploadStageTransitionCallback);
     }
 
     @Bean
@@ -211,7 +211,6 @@ public class MigrationAssistantBeanConfiguration {
                 databaseArchivalService,
                 archiveStageTransitionCallback,
                 s3UploadService,
-                uploadStageTransitionCallback,
                 restoreService,
                 migrationHelperDeploymentService);
     }


### PR DESCRIPTION
Ok, this PR got a little bloated and now it contains -

1. A mechanism to stop attachment listener in FINAL_SYNC_WAIT stage. This is necessary as we don't want to keep listening to file records in case the migration fails and a user does not cancel/clean up the migration

2. Refactored the object graph/construction of Database migration service. We don't need to create both the service and the callback in the database service. Instead, we create the archive/upload/restore service with the callbacks

3.  We read the file system record collection for a given migration and using this, determine the number of files that have been uploaded to S3.

