### PR TITLE
CHET-442: Fix S3 url in CFN deployment service

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -43,7 +43,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     static final String SECURITY_GROUP_NAME_STACK_OUTPUT_KEY = "SGname";
 
     private final Logger logger = LoggerFactory.getLogger(QuickstartDeploymentService.class);
-    private static final String JIRA_TEMPLATE_REPO = "https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/";
+    private static final String JIRA_TEMPLATE_REPO = "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/";
     private static final String QUICKSTART_WITH_VPC_TEMPLATE_URL = JIRA_TEMPLATE_REPO + "quickstart-jira-dc-with-vpc.template.yaml";
     private static final String QUICKSTART_STANDALONE_TEMPLATE_URL = JIRA_TEMPLATE_REPO + "quickstart-jira-dc.template.yaml";
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -130,7 +130,7 @@ class QuickstartDeploymentServiceTest {
         deploySimpleStack();
 
         verify(mockCfnApi).provisionStack(
-                "https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/quickstart-jira-dc.template.yaml",
+                "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc.template.yaml",
                 STACK_NAME, STACK_PARAMS);
     }
 
@@ -140,7 +140,7 @@ class QuickstartDeploymentServiceTest {
         deployWithVpcStack();
 
         verify(mockCfnApi).provisionStack(
-                "https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/quickstart-jira-dc-with-vpc.template.yaml",
+                "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml",
                 STACK_NAME, STACK_PARAMS);
     }
 


### PR DESCRIPTION
Use S3 URL in Backend instead of github URL