### PR TITLE
Hotfix/s3 qs url

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -43,7 +43,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     static final String SECURITY_GROUP_NAME_STACK_OUTPUT_KEY = "SGname";
 
     private final Logger logger = LoggerFactory.getLogger(QuickstartDeploymentService.class);
-    private static final String JIRA_TEMPLATE_REPO = "https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/";
+    private static final String JIRA_TEMPLATE_REPO = "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/";
     private static final String QUICKSTART_WITH_VPC_TEMPLATE_URL = JIRA_TEMPLATE_REPO + "quickstart-jira-dc-with-vpc.template.yaml";
     private static final String QUICKSTART_STANDALONE_TEMPLATE_URL = JIRA_TEMPLATE_REPO + "quickstart-jira-dc.template.yaml";
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -180,6 +180,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         logger.info("Storing stack name in migration context");
 
         context.setApplicationDeploymentId(deploymentId);
+        context.save();
     }
 
     @Override

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -130,7 +130,7 @@ class QuickstartDeploymentServiceTest {
         deploySimpleStack();
 
         verify(mockCfnApi).provisionStack(
-                "https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/quickstart-jira-dc.template.yaml",
+                "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc.template.yaml",
                 STACK_NAME, STACK_PARAMS);
     }
 
@@ -140,7 +140,7 @@ class QuickstartDeploymentServiceTest {
         deployWithVpcStack();
 
         verify(mockCfnApi).provisionStack(
-                "https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/quickstart-jira-dc-with-vpc.template.yaml",
+                "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc-with-vpc.template.yaml",
                 STACK_NAME, STACK_PARAMS);
     }
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -238,7 +238,9 @@ class QuickstartDeploymentServiceTest {
         Thread.sleep(100);
 
         verify(mockContext).setServiceUrl(testServiceUrl);
-        verify(mockContext, times(2)).save();
+        //Caters to the last save call in deployApplication com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java:106.
+        // That call must be removed and each setter should save automatically, or the entire block needs to be run in a transaction
+        verify(mockContext, times(3)).save();
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -54,6 +54,7 @@ import static com.atlassian.migration.datacenter.core.aws.infrastructure.Quickst
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -149,6 +150,7 @@ class QuickstartDeploymentServiceTest {
         deploymentService.deployApplication(STACK_NAME, STACK_PARAMS);
 
         verify(dbCredentialsStorageService).storeCredentials(TEST_DB_PASSWORD);
+        verify(mockContext, atLeastOnce()).save();
     }
 
     @Test

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-DEFAULT_QUICKSTART_WITH_VPC_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/quickstart-jira-dc-with-vpc.template.yaml
-DEFAULT_QUICKSTART_STANDALONE_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/develop/templates/quickstart-jira-dc.template.yaml
+DEFAULT_QUICKSTART_WITH_VPC_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/master/templates/quickstart-jira-dc-with-vpc.template.yaml
+DEFAULT_QUICKSTART_STANDALONE_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/master/templates/quickstart-jira-dc.template.yaml


### PR DESCRIPTION
1. Prevent creation of keys like `atl-null-migration-app-rds-password` in SSM. More importantly, store deploymentId in context
2. Update template URL to use `master` on github