### PR TITLE
no-issue: make compose pick up latest jira dockerimage by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+*.md    @ddomingorh
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following users will be requested for review when someone opens a pull request.
+*       @bpar476 @nanux @tarka @theghostwhoforks
+
+

--- a/jira-e2e-tests/.env
+++ b/jira-e2e-tests/.env
@@ -1,0 +1,1 @@
+JIRA_VERSION=latest


### PR DESCRIPTION
docker-compose fails when it is run without passing a build-arg or an env variable specifying the `jira_version` based docker image to pull. Adding a .env and defaulting to latest will ensure that current workflows continue to work