### PR TITLE
no-issue: add jacoco

### DIFF
--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -81,10 +81,10 @@ jobs:
 
       - name: Archive code coverage results
         if: matrix.profile == '!integration' && matrix.java == 8
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: code-coverage-report
-          path: '**/target/site/jacoco-unit-test-coverage-report'
+          path: ./**/target/site/jacoco-unit-test-coverage-report/
 
   deploy:
     name: Deploy to dogfooding instance

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -79,6 +79,12 @@ jobs:
           name: plugin-jar
           path: jira-plugin/target/jira-plugin-1.0.0.jar
 
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v1
+        with:
+          name: code-coverage-report
+          path: '**/target/site/jacoco-unit-test-coverage-report'
+
   deploy:
     name: Deploy to dogfooding instance
     runs-on: ubuntu-latest

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -80,6 +80,7 @@ jobs:
           path: jira-plugin/target/jira-plugin-1.0.0.jar
 
       - name: Archive code coverage results
+        if: matrix.profile == '!integration' && matrix.java == 8
         uses: actions/upload-artifact@v1
         with:
           name: code-coverage-report

--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,61 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</destFile>
+                            <propertyName>surefire.jacoco.args</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-unit-test-coverage-report</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <excludes>
+                                        <exclude>*Test</exclude>
+                                        <exclude>*IT</exclude>
+                                    </excludes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!-- Set this limit when we want to fail builds for low coverage-->
+                                            <minimum>0</minimum>
+                                        </limit>
+                                    </limits>
+                                    <!-- Merge Unit & Integration test reports? See: https://natritmeyer.com/howto/reporting-aggregated-unit-and-integration-test-coverage-with-jacoco/ -->
+                                </rule>
+                            </rules>
+                            <dataFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</dataFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -299,6 +354,7 @@
                     <includes>
                         <include>**/*Test*</include>
                     </includes>
+                    <argLine>${surefire.jacoco.args}</argLine>
                 </configuration>
             </plugin>
 
@@ -467,6 +523,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.version>1.3.70</kotlin.version>
         <jackson.version>2.10.3</jackson.version>
+        <jacoco.version>0.8.5</jacoco.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <jira.api.version>7.13.12</jira.api.version>


### PR DESCRIPTION
Add jacoco to parent pom. No coverage limit has been set for the project. 

This is only plugged in with the unit test phase and not with integration tests