### PR TITLE
Output md5 and contents for migration-helper.yml

### DIFF
--- a/.github/workflows/migration_template_uploader.yml
+++ b/.github/workflows/migration_template_uploader.yml
@@ -3,7 +3,7 @@ name: UploadMigrationTemplate
 on: [push]
 
 env:
-  MASTER: refs/heads/hot-fix-migration-template-github-action
+  MASTER: refs/heads/master
   AWS_S3_BUCKET: trebuchet-public-resources
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/migration_template_uploader.yml
+++ b/.github/workflows/migration_template_uploader.yml
@@ -3,12 +3,12 @@ name: UploadMigrationTemplate
 on: [push]
 
 env:
-  MASTER_BRANCH: ${{ secrets.MASTER_BRANCH }}
-  AWS_S3_BUCKET: ${{ secrets.S3_AWS_BUCKET }}
+  MASTER: refs/heads/master
+  AWS_S3_BUCKET: trebuchet-public-resources
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: 'us-east-1'
-  
+
 jobs:
   upload:
     runs-on: ubuntu-latest
@@ -18,10 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Generate migration stack template
-        if: github.ref == env.MASTER_BRANCH
-        run: make rendertemplate -C ./templates/migration-stack
+        if: github.ref == env.MASTER
+        run: |
+          make rendertemplate -C ./templates/migration-stack
+          echo "migration-helper.yml md5 is: [`md5sum ./templates/migration-stack/migration-helper.yml`]"
+          echo "Outputting migration-helper.yml contents to stdout now..."
+          cat ./templates/migration-stack/migration-helper.yml
       - name: Upload Migration stack template
-        if: github.ref == env.MASTER_BRANCH
+        if: github.ref == env.MASTER
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read --exclude '*' --include 'migration-helper.yml'

--- a/.github/workflows/migration_template_uploader.yml
+++ b/.github/workflows/migration_template_uploader.yml
@@ -3,7 +3,7 @@ name: UploadMigrationTemplate
 on: [push]
 
 env:
-  MASTER: refs/heads/master
+  MASTER: refs/heads/hot-fix-migration-template-github-action
   AWS_S3_BUCKET: trebuchet-public-resources
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Jira / Confluence Server to DC (AWS) Helper
+
 Parameters:
   NetworkPrivateSubnet:
     Description: "Private SubnetId where Migration helper will be placed - Must have connection to desitnation Storage"

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -589,4 +589,3 @@ Outputs:
   MigrationBucket:
     Description: "The name of the s3 bucket to be used for facilitating this migration"
     Value: !Ref MigrationBucket
-

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -1,7 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Jira / Confluence Server to DC (AWS) Helper
 Parameters:
-
   NetworkPrivateSubnet:
     Description: "Private SubnetId where Migration helper will be placed - Must have connection to desitnation Storage"
     Type: String
@@ -45,7 +44,6 @@ Parameters:
     Default: '/efs/jira/shared'
 
 Resources:
-
   #S3 Bucket for Database Transfer
   #Stack deletion fails when the bucket is non-empty. To fix this, we need a lambda that cleans the bucket - https://stackoverflow.com/questions/40383470/can-i-force-cloudformation-to-delete-non-empty-s3-bucket
   # Until then, set the Deletion policy to retain
@@ -361,6 +359,7 @@ Resources:
       Path: /
       Roles:
         - !Ref HelperInstanceProfileRole
+        
   HelperInstanceProfileRole:
     Type: AWS::IAM::Role
     Properties:
@@ -429,6 +428,7 @@ Resources:
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+        
   HelperSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -444,6 +444,7 @@ Resources:
       HelperSG: !Ref HelperSecurityGroup
       EFSSG: !Ref EFSSecurityGroup
       RDSSG: !Ref RDSSecurityGroup
+      
   MigrationStackResourceAccess:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -496,6 +497,7 @@ Resources:
             except Exception as e:
                 responseData = {'Error': str(e)}
                 cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
+                
   MigrationStackResourceAccessExecutionRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -589,9 +591,3 @@ Outputs:
   MigrationBucket:
     Description: "The name of the s3 bucket to be used for facilitating this migration"
     Value: !Ref MigrationBucket
-    
-    
-    
-    
-    
-    

--- a/templates/migration-stack/pkg/migration-helper.yml.src
+++ b/templates/migration-stack/pkg/migration-helper.yml.src
@@ -589,3 +589,9 @@ Outputs:
   MigrationBucket:
     Description: "The name of the s3 bucket to be used for facilitating this migration"
     Value: !Ref MigrationBucket
+    
+    
+    
+    
+    
+    


### PR DESCRIPTION
There is potentially an issue where `migration-helper.yml` is not re-generated and uploaded when changes are made to `migration-helper.yml.src`. To help root cause this we now, output the `md5sum` and contents of `migration-helper.yml` when generated.

Testing shows that changes made to `migration-helper.yml.src` result in different md5's being generated between runs

*run 1*
`migration-helper.yml md5 is: [413c23a5b406f1e35ed330c8d2ebf076  ./templates/migration-stack/migration-helper.yml]`

*run 2*
`migration-helper.yml md5 is: [014afb645fb675564ebe1dfa0ab76384  ./templates/migration-stack/migration-helper.yml]`

*run 3*
`migration-helper.yml md5 is: [ab3d4dd6e3809563df24d3279a9546ea  ./templates/migration-stack/migration-helper.yml]`

This suggests that a new version of `migration-helper.yml` is generated each time a change is made to `migration-helper.yml.src`