### PR TITLE
Chet 525 clear context

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
@@ -120,8 +120,8 @@ class CloudFormationEndpoint(
         return when (val currentStage = migrationService.currentStage) {
             MigrationStage.ERROR, //Only until we change transitioning to errors in provisioning steps
             MigrationStage.PROVISIONING_ERROR -> {
-                applicationDeploymentService.clearPersistedStackDetails
-                helperDeploymentService.clearPersistedStackDetails
+                applicationDeploymentService.clearPersistedStackDetails()
+                helperDeploymentService.clearPersistedStackDetails()
                 migrationService.transition(MigrationStage.PROVISION_APPLICATION)
                 Response.ok().build()
             }

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
@@ -120,6 +120,8 @@ class CloudFormationEndpoint(
         return when (val currentStage = migrationService.currentStage) {
             MigrationStage.ERROR, //Only until we change transitioning to errors in provisioning steps
             MigrationStage.PROVISIONING_ERROR -> {
+                applicationDeploymentService.clearPersistedStackDetails
+                helperDeploymentService.clearPersistedStackDetails
                 migrationService.transition(MigrationStage.PROVISION_APPLICATION)
                 Response.ok().build()
             }

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpointTest.kt
@@ -248,6 +248,8 @@ internal class CloudFormationEndpointTest {
         val response = endpoint.resetProvisioningStage()
         assertEquals(Response.Status.OK.statusCode, response.status)
         verify { migrationSerivce.transition(MigrationStage.PROVISION_APPLICATION) }
+        verify { deploymentService.clearPersistedStackDetails() }
+        verify { helperDeploymentService.clearPersistedStackDetails() }
     }
 
     @Test

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -231,4 +231,9 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
 
         currentContext.save();
     }
+
+    @Override
+    public void clearPersistedStackDetails() {
+        resetStackOutputs();
+    }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -78,8 +78,6 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
      */
     @Override
     public void deployMigrationInfrastructure(Map<String, String> params) throws InvalidMigrationStageError {
-        resetStackOutputs();
-
         migrationService.assertCurrentStage(MigrationStage.PROVISION_MIGRATION_STACK);
 
         String migrationStackDeploymentId = constructMigrationStackDeploymentIdentifier();
@@ -216,8 +214,8 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
         context.save();
     }
 
-    //Probably useful when we retry a specific migration stage (In which case we can make every retryable an interface that removes a specific part of the context? or we can remove the migration context when we restart a quickstart deployment, in which case, this can be removed)
-    private void resetStackOutputs() {
+    @Override
+    public void clearPersistedStackDetails() {
         MigrationContext currentContext = migrationService.getCurrentContext();
         currentContext.setFsRestoreSsmDocument("");
         currentContext.setFsRestoreStatusSsmDocument("");
@@ -229,11 +227,7 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
         currentContext.setMigrationQueueUrl("");
         currentContext.setMigrationDLQueueUrl("");
 
+        currentContext.setHelperStackDeploymentId("");
         currentContext.save();
-    }
-
-    @Override
-    public void clearPersistedStackDetails() {
-        resetStackOutputs();
     }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -77,9 +77,7 @@ public abstract class CloudformationDeploymentService {
 
     protected InfrastructureDeploymentState getDeploymentStatus(String stackName) {
         requireNonNull(stackName);
-        InfrastructureDeploymentState status = cfnApi.getStatus(stackName);
-
-        return status;
+        return cfnApi.getStatus(stackName);
     }
 
     private void beginWatchingDeployment(String stackName) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -201,4 +201,15 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     public InfrastructureDeploymentState getDeploymentStatus() {
         return super.getDeploymentStatus(migrationService.getCurrentContext().getApplicationDeploymentId());
     }
+
+    @Override
+    public void clearPersistedStackDetails() {
+        MigrationContext currentContext = migrationService.getCurrentContext();
+
+        currentContext.setServiceUrl("");
+        currentContext.setDeploymentMode(null);
+        currentContext.setApplicationDeploymentId("");
+
+        currentContext.save();
+    }
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -28,6 +28,7 @@ import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig;
 import com.atlassian.scheduler.SchedulerService;
 import net.java.ao.EntityManager;
 import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
@@ -48,6 +49,7 @@ import static com.atlassian.migration.datacenter.spi.MigrationStage.PROVISION_AP
 import static com.atlassian.migration.datacenter.spi.MigrationStage.PROVISION_APPLICATION_WAIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
@@ -247,31 +247,24 @@ class AWSMigrationHelperDeploymentServiceTest {
 
     //Migration context stub object/data-class may make this test simpler
     private void expectStackDetailsToBePersistedInMigrationContext() {
-        doNothing().when(mockContext).setFsRestoreSsmDocument("");
         doNothing().when(mockContext).setFsRestoreSsmDocument(FS_DOWNLOAD_DOC);
         lenient().when(mockContext.getFsRestoreSsmDocument()).thenReturn(FS_DOWNLOAD_DOC);
 
-        doNothing().when(mockContext).setFsRestoreStatusSsmDocument("");
         doNothing().when(mockContext).setFsRestoreStatusSsmDocument(FS_DOWNLOAD_STATUS_DOC);
         lenient().when(mockContext.getFsRestoreStatusSsmDocument()).thenReturn(FS_DOWNLOAD_STATUS_DOC);
 
-        doNothing().when(mockContext).setRdsRestoreSsmDocument("");
         doNothing().when(mockContext).setRdsRestoreSsmDocument(DB_RESTORE_DOC);
         lenient().when(mockContext.getRdsRestoreSsmDocument()).thenReturn(DB_RESTORE_DOC);
 
-        doNothing().when(mockContext).setMigrationStackAsgIdentifier("");
         doNothing().when(mockContext).setMigrationStackAsgIdentifier(MIGRATION_ASG);
         lenient().when(mockContext.getMigrationStackAsgIdentifier()).thenReturn(MIGRATION_ASG);
 
-        doNothing().when(mockContext).setMigrationBucketName("");
         doNothing().when(mockContext).setMigrationBucketName(MIGRATION_BUCKET);
         lenient().when(mockContext.getMigrationBucketName()).thenReturn(MIGRATION_BUCKET);
 
-        doNothing().when(mockContext).setMigrationQueueUrl("");
         doNothing().when(mockContext).setMigrationQueueUrl(QUEUE_PHYSICAL_RESOURCE_ID);
         lenient().when(mockContext.getMigrationQueueUrl()).thenReturn(QUEUE_PHYSICAL_RESOURCE_ID);
 
-        doNothing().when(mockContext).setMigrationDLQueueUrl("");
         doNothing().when(mockContext).setMigrationDLQueueUrl(DEAD_LETTER_QUEUE_PHYSICAL_RESOURCE_ID);
         lenient().when(mockContext.getMigrationDLQueueUrl()).thenReturn(DEAD_LETTER_QUEUE_PHYSICAL_RESOURCE_ID);
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/MigrationHelperDeploymentServiceCleanupTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/MigrationHelperDeploymentServiceCleanupTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.dto.MigrationContext;
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.infrastructure.DeploymentService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MigrationHelperDeploymentServiceCleanupTest {
+
+    @Mock
+    MigrationService migrationService;
+
+    @Mock
+    MigrationContext migrationContext;
+
+    @Test
+    void shouldClearMigrationStackPersistedStackDetails(){
+        DeploymentService migrationHelperService = new AWSMigrationHelperDeploymentService(null, () -> null, migrationService);
+        when(migrationService.getCurrentContext()).thenReturn(migrationContext);
+
+        migrationHelperService.clearPersistedStackDetails();
+
+        verify(migrationContext).setFsRestoreStatusSsmDocument("");
+        verify(migrationContext).setFsRestoreSsmDocument("");
+        verify(migrationContext).setRdsRestoreSsmDocument("");
+        verify(migrationContext).setMigrationBucketName("");
+        verify(migrationContext).setMigrationStackAsgIdentifier("");
+        verify(migrationContext).setMigrationDLQueueUrl("");
+        verify(migrationContext).setMigrationQueueUrl("");
+
+        verify(migrationContext).save();
+    }
+
+
+}

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceCleanupTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceCleanupTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.atlassian.migration.datacenter.core.aws.infrastructure;
+
+import com.atlassian.migration.datacenter.dto.MigrationContext;
+import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.infrastructure.DeploymentService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class QuickstartDeploymentServiceCleanupTest {
+
+    @Mock
+    MigrationService migrationService;
+
+    @Mock
+    MigrationContext migrationContext;
+
+    @Test
+    void shouldClearMigrationStackPersistedStackDetails(){
+        DeploymentService migrationHelperService = new QuickstartDeploymentService(null, migrationService, null, null, null);
+        when(migrationService.getCurrentContext()).thenReturn(migrationContext);
+
+        migrationHelperService.clearPersistedStackDetails();
+
+        verify(migrationContext).setDeploymentMode(null);
+        verify(migrationContext).setApplicationDeploymentId("");
+        verify(migrationContext).setServiceUrl("");
+
+        verify(migrationContext).save();
+    }
+
+
+}

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -102,7 +102,7 @@ class QuickstartDeploymentServiceTest {
     void setUp() {
         Properties properties = new Properties();
         final String passwordPropertyKey = "password";
-        lenient().doAnswer(invocation -> {
+        doAnswer(invocation -> {
             properties.setProperty(passwordPropertyKey, invocation.getArgument(0));
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
@@ -246,17 +246,6 @@ class QuickstartDeploymentServiceTest {
         }
 
         verify(mockContext).setDeploymentMode(mode);
-    }
-
-    @Test
-    void shouldClearPersistedStackInformation(){
-        when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
-        deploymentService.clearPersistedStackDetails();
-
-        verify(mockContext).setDeploymentMode(null);
-        verify(mockContext).setApplicationDeploymentId("");
-        verify(mockContext).setServiceUrl("");
-        verify(mockContext).save();
     }
 
     private void givenStackDeploymentWillBeInProgress() {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -102,7 +102,7 @@ class QuickstartDeploymentServiceTest {
     void setUp() {
         Properties properties = new Properties();
         final String passwordPropertyKey = "password";
-        doAnswer(invocation -> {
+        lenient().doAnswer(invocation -> {
             properties.setProperty(passwordPropertyKey, invocation.getArgument(0));
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
@@ -246,6 +246,17 @@ class QuickstartDeploymentServiceTest {
         }
 
         verify(mockContext).setDeploymentMode(mode);
+    }
+
+    @Test
+    void shouldClearPersistedStackInformation(){
+        when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
+        deploymentService.clearPersistedStackDetails();
+
+        verify(mockContext).setDeploymentMode(null);
+        verify(mockContext).setApplicationDeploymentId("");
+        verify(mockContext).setServiceUrl("");
+        verify(mockContext).save();
     }
 
     private void givenStackDeploymentWillBeInProgress() {

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/DeploymentService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/DeploymentService.kt
@@ -16,5 +16,6 @@
 package com.atlassian.migration.datacenter.spi.infrastructure
 
 interface DeploymentService {
+    fun clearPersistedStackDetails()
     val deploymentStatus: InfrastructureDeploymentState
 }


### PR DESCRIPTION
1. Creates a method in the interface to clear persisted stack details 
2. Invokes the above method from a `reset` API call
3. Updates tests and removes unnecessary stubings as we do not call reset stack outputs before deploying the template

The error column is not flushed as part of this. 