### PR TITLE
CHET-528: Add retry transition for final sync

### DIFF
--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
@@ -19,47 +19,78 @@ package com.atlassian.migration.datacenter.spi
  * Represents all possible states of an on-premise to cloud migration.
  */
 enum class MigrationStage {
-    NOT_STARTED(),
-    AUTHENTICATION(NOT_STARTED),
+    NOT_STARTED {
+        override val validAncestorStages = emptySet<MigrationStage>()
+    },
+    AUTHENTICATION {
+        override val validAncestorStages = setOf(NOT_STARTED)
+    },
+    PROVISION_APPLICATION {
+        override val validAncestorStages = setOf(AUTHENTICATION)
+    },
+    PROVISION_APPLICATION_WAIT {
+        override val validAncestorStages = setOf(PROVISION_APPLICATION)
+    },
+    PROVISION_MIGRATION_STACK {
+        override val validAncestorStages = setOf(PROVISION_APPLICATION_WAIT)
+    },
+    PROVISION_MIGRATION_STACK_WAIT {
+        override val validAncestorStages = setOf(PROVISION_MIGRATION_STACK)
+    },
+    PROVISIONING_ERROR {
+        override val validAncestorStages = setOf(PROVISION_APPLICATION, PROVISION_APPLICATION_WAIT, PROVISION_MIGRATION_STACK, PROVISION_MIGRATION_STACK_WAIT)
+    },
+    FS_MIGRATION_COPY {
+        override val validAncestorStages = setOf(PROVISION_MIGRATION_STACK_WAIT)
+    },
+    FS_MIGRATION_COPY_WAIT {
+        override val validAncestorStages = setOf(FS_MIGRATION_COPY)
+    },
+    FS_MIGRATION_ERROR {
+        override val validAncestorStages =  setOf(FS_MIGRATION_COPY, FS_MIGRATION_COPY_WAIT)
+    },
+    OFFLINE_WARNING {
+        override val validAncestorStages = setOf(FS_MIGRATION_COPY_WAIT)
+    },
 
-    PROVISION_APPLICATION(AUTHENTICATION),
-    PROVISION_APPLICATION_WAIT(PROVISION_APPLICATION),
-    PROVISION_MIGRATION_STACK(PROVISION_APPLICATION_WAIT),
-    PROVISION_MIGRATION_STACK_WAIT(PROVISION_MIGRATION_STACK),
-    PROVISIONING_ERROR(PROVISION_APPLICATION, PROVISION_APPLICATION_WAIT, PROVISION_MIGRATION_STACK, PROVISION_MIGRATION_STACK_WAIT),
+    DB_MIGRATION_EXPORT {
+        override val validAncestorStages: Set<MigrationStage>
+            get() = setOf(OFFLINE_WARNING, FINAL_SYNC_ERROR)
+    },
+    DB_MIGRATION_EXPORT_WAIT {
+        override val validAncestorStages = setOf(DB_MIGRATION_EXPORT)
+    },
+    DB_MIGRATION_UPLOAD {
+        override val validAncestorStages = setOf(DB_MIGRATION_EXPORT_WAIT)
+    },
+    DB_MIGRATION_UPLOAD_WAIT {
+        override val validAncestorStages = setOf(DB_MIGRATION_UPLOAD)
+    },
+    DATA_MIGRATION_IMPORT {
+        override val validAncestorStages = setOf(DB_MIGRATION_UPLOAD_WAIT)
+    },
+    DATA_MIGRATION_IMPORT_WAIT {
+        override val validAncestorStages = setOf(DATA_MIGRATION_IMPORT)
+    },
+    FINAL_SYNC_WAIT {
+        override val validAncestorStages = setOf(DATA_MIGRATION_IMPORT_WAIT)
+    },
+    FINAL_SYNC_ERROR {
+        override val validAncestorStages = setOf(DB_MIGRATION_EXPORT, DB_MIGRATION_EXPORT_WAIT, DB_MIGRATION_UPLOAD, DB_MIGRATION_UPLOAD_WAIT, DATA_MIGRATION_IMPORT, DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_WAIT)
+    },
+    VALIDATE {
+        override val validAncestorStages = setOf(FINAL_SYNC_WAIT)
+    },
+    FINISHED {
+        override val validAncestorStages = setOf(VALIDATE)
+    },
+    ERROR {
+        override val validAncestorStages = emptySet<MigrationStage>()
+    };
 
-    FS_MIGRATION_COPY(PROVISION_MIGRATION_STACK_WAIT),
-    FS_MIGRATION_COPY_WAIT(FS_MIGRATION_COPY),
-    FS_MIGRATION_ERROR(FS_MIGRATION_COPY, FS_MIGRATION_COPY_WAIT),
+    var exception: Throwable? = null
 
-    OFFLINE_WARNING(FS_MIGRATION_COPY_WAIT),
-
-    DB_MIGRATION_EXPORT(OFFLINE_WARNING),
-    DB_MIGRATION_EXPORT_WAIT(DB_MIGRATION_EXPORT),
-    DB_MIGRATION_UPLOAD(DB_MIGRATION_EXPORT_WAIT),
-    DB_MIGRATION_UPLOAD_WAIT(DB_MIGRATION_UPLOAD),
-    DATA_MIGRATION_IMPORT(DB_MIGRATION_UPLOAD_WAIT),
-    DATA_MIGRATION_IMPORT_WAIT(DATA_MIGRATION_IMPORT),
-    FINAL_SYNC_WAIT(DATA_MIGRATION_IMPORT),
-    FINAL_SYNC_ERROR(DB_MIGRATION_EXPORT, DB_MIGRATION_EXPORT_WAIT, DB_MIGRATION_UPLOAD, DB_MIGRATION_UPLOAD_WAIT, DATA_MIGRATION_IMPORT, DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_WAIT),
-
-    VALIDATE(FINAL_SYNC_WAIT),
-    FINISHED(VALIDATE),
-    ERROR();
-
-    private val validFromStages: List<MigrationStage>
-    var exception: Throwable?
-
-    constructor() {
-        exception = null;
-        this.validFromStages = listOf()
-    }
-
-    constructor(vararg validFromStages: MigrationStage) {
-        exception = null;
-        this.validFromStages = validFromStages.asList()
-    }
-
+    abstract val validAncestorStages: Set<MigrationStage>
 
     fun isValidTransition(to: MigrationStage): Boolean {
         when (this) {
@@ -71,18 +102,29 @@ enum class MigrationStage {
         return when (to) {
             ERROR -> true
             else -> {
-                to.validFromStages.any { it == this }
+                to.validAncestorStages.any { it == this }
             }
         }
     }
 
+
+
     fun isAfter(stage: MigrationStage): Boolean {
+        return isAfter(stage, mutableSetOf())
+    }
+
+    private fun isAfter(stage: MigrationStage, visited: MutableSet<MigrationStage>): Boolean {
         if (this == stage || this == NOT_STARTED) return false
         if (this == FINISHED || this == ERROR) return true
-        return this.validFromStages.map {
+        // If we encounter a cycle and haven't found the stage return false
+        if (visited.contains(stage)) return false
+        return this.validAncestorStages.map {
             when (it) {
                 stage -> true
-                else -> it.isAfter(stage)
+                else -> {
+                    visited.add(it)
+                    return it.isAfter(stage, visited)
+                }
             }
         }.contains(true)
     }

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
@@ -47,14 +47,14 @@ enum class MigrationStage {
         override val validAncestorStages = setOf(FS_MIGRATION_COPY)
     },
     FS_MIGRATION_ERROR {
-        override val validAncestorStages =  setOf(FS_MIGRATION_COPY, FS_MIGRATION_COPY_WAIT)
+        override val validAncestorStages = setOf(FS_MIGRATION_COPY, FS_MIGRATION_COPY_WAIT)
     },
     OFFLINE_WARNING {
         override val validAncestorStages = setOf(FS_MIGRATION_COPY_WAIT)
     },
 
     DB_MIGRATION_EXPORT {
-        override val validAncestorStages: Set<MigrationStage>
+        override val validAncestorStages
             get() = setOf(OFFLINE_WARNING, FINAL_SYNC_ERROR)
     },
     DB_MIGRATION_EXPORT_WAIT {
@@ -73,7 +73,8 @@ enum class MigrationStage {
         override val validAncestorStages = setOf(DATA_MIGRATION_IMPORT)
     },
     FINAL_SYNC_WAIT {
-        override val validAncestorStages = setOf(DATA_MIGRATION_IMPORT_WAIT)
+        override val validAncestorStages
+            get() = setOf(DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_ERROR)
     },
     FINAL_SYNC_ERROR {
         override val validAncestorStages = setOf(DB_MIGRATION_EXPORT, DB_MIGRATION_EXPORT_WAIT, DB_MIGRATION_UPLOAD, DB_MIGRATION_UPLOAD_WAIT, DATA_MIGRATION_IMPORT, DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_WAIT)
@@ -108,7 +109,6 @@ enum class MigrationStage {
     }
 
 
-
     fun isAfter(stage: MigrationStage): Boolean {
         return isAfter(stage, mutableSetOf())
     }
@@ -135,7 +135,7 @@ enum class MigrationStage {
             this.toString().startsWith("DB_")
 
     fun isErrorStage(): Boolean {
-        return when(this) {
+        return when (this) {
             ERROR, FS_MIGRATION_ERROR, PROVISIONING_ERROR, FINAL_SYNC_ERROR -> true
             else -> false
         }


### PR DESCRIPTION
## Summary

* Refactor migration stage so that retry transitions are not special cases
* Implement cycle detection in is after
* Add transition from FINAL_SYNC_ERROR to DB_MIGRATION_EXPORT and FINAL_SYNC_WAIT