### PR TITLE
CHET-503: Allow SSM API execution without upper boundary

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreService.java
@@ -35,8 +35,6 @@ public class SsmPsqlDatabaseRestoreService {
 
     private static final Logger logger = LoggerFactory.getLogger(SsmPsqlDatabaseRestoreService.class);
 
-    private final int maxCommandRetries;
-
     private final SSMApi ssm;
     private final AWSMigrationHelperDeploymentService migrationHelperDeploymentService;
     private final MigrationStageCallback migrationStageCallback;
@@ -44,17 +42,10 @@ public class SsmPsqlDatabaseRestoreService {
     private final String restoreDocumentName = "restoreDatabaseBackupToRDS";
     private String commandId;
 
-    SsmPsqlDatabaseRestoreService(SSMApi ssm, int maxCommandRetries,
-                                  AWSMigrationHelperDeploymentService migrationHelperDeploymentService, MigrationStageCallback migrationStageCallback) {
+    public SsmPsqlDatabaseRestoreService(SSMApi ssm, AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback migrationStageCallback) {
         this.ssm = ssm;
-        this.maxCommandRetries = maxCommandRetries;
         this.migrationHelperDeploymentService = migrationHelperDeploymentService;
         this.migrationStageCallback = migrationStageCallback;
-    }
-
-    public SsmPsqlDatabaseRestoreService(SSMApi ssm,
-                                         AWSMigrationHelperDeploymentService migrationHelperDeploymentService, DatabaseRestoreStageTransitionCallback migrationStageCallback) {
-        this(ssm, 10, migrationHelperDeploymentService, migrationStageCallback);
     }
 
     public void restoreDatabase()
@@ -82,7 +73,7 @@ public class SsmPsqlDatabaseRestoreService {
         migrationStageCallback.transitionToServiceWaitStage();
 
         try {
-            consumer.handleCommandOutput(maxCommandRetries);
+            consumer.handleCommandOutput();
             migrationStageCallback.transitionToServiceNextStage();
         } catch (SuccessfulSSMCommandConsumer.UnsuccessfulSSMCommandInvocationException
                 | SuccessfulSSMCommandConsumer.SSMCommandInvocationProcessingError e) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
@@ -82,6 +82,7 @@ public abstract class SuccessfulSSMCommandConsumer<T> {
         return status.equals(CommandInvocationStatus.FAILED) ||
                 status.equals(CommandInvocationStatus.CANCELLED) ||
                 status.equals(CommandInvocationStatus.TIMED_OUT) ||
+                status.equals(CommandInvocationStatus.DELAYED) ||
                 status.equals(CommandInvocationStatus.SUCCESS);
     }
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/restore/SsmPsqlDatabaseRestoreServiceTest.java
@@ -54,7 +54,7 @@ class SsmPsqlDatabaseRestoreServiceTest {
 
     @BeforeEach
     void setUp() {
-        sut = new SsmPsqlDatabaseRestoreService(ssmApi, 1, migrationHelperDeploymentService, callback);
+        sut = new SsmPsqlDatabaseRestoreService(ssmApi, migrationHelperDeploymentService, callback);
     }
 
     @Test

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -98,7 +98,7 @@
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <jvmArgs>${amps.jvm.args} -Dspring.profiles.active=${amps.spring.profiles}</jvmArgs>
+                    <jvmArgs>${amps.jvm.args}</jvmArgs>
                     <enableQuickReload>true</enableQuickReload>
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>


### PR DESCRIPTION
This prevents SSMApi consumer to fail after 100 seconds even when the command is still running.