### PR TITLE
CHET-526: independent final sync processes from API

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -93,6 +93,7 @@ class FinalSyncEndpoint(
     fun retryFsSync(): Response {
         return when (migrationService.currentStage) {
             MigrationStage.FINAL_SYNC_ERROR -> {
+                migrationService.transition(MigrationStage.FINAL_SYNC_WAIT)
                 Response.status(if (finalSyncService.scheduleSync()) Response.Status.ACCEPTED else Response.Status.CONFLICT)
             }
             else -> Response.status(Response.Status.BAD_REQUEST)

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -89,7 +89,6 @@ class FinalSyncEndpoint(
     }
 
     @PUT
-    @Produces(MediaType.APPLICATION_JSON)
     @Path("/retry/fs")
     fun retryFsSync(): Response {
         return when (migrationService.currentStage) {
@@ -98,6 +97,13 @@ class FinalSyncEndpoint(
             }
             else -> Response.status(Response.Status.BAD_REQUEST)
         }.build()
+    }
+
+    @PUT
+    @Path("/retry/db")
+    fun retryDbMigration(): Response {
+        databaseMigrationService.scheduleMigration()
+        return Response.accepted().build()
     }
 
     @Path("/status")

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -93,13 +93,21 @@ class FinalSyncEndpoint(
     @PUT
     @Path("/retry/fs")
     fun retryFsSync(): Response {
-        return retryMigrationOperation(finalSyncService::scheduleSync, MigrationStage.FINAL_SYNC_WAIT)
+        try {
+            finalSyncService.abortMigration()
+        } finally {
+            return retryMigrationOperation(finalSyncService::scheduleSync, MigrationStage.FINAL_SYNC_WAIT)
+        }
     }
 
     @PUT
     @Path("/retry/db")
     fun retryDbMigration(): Response {
-        return retryMigrationOperation(databaseMigrationService::scheduleMigration, MigrationStage.DB_MIGRATION_EXPORT)
+        try {
+            databaseMigrationService.abortMigration()
+        } finally {
+            return retryMigrationOperation(databaseMigrationService::scheduleMigration, MigrationStage.DB_MIGRATION_EXPORT)
+        }
     }
 
     @Path("/status")

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -92,8 +92,12 @@ class FinalSyncEndpoint(
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/retry/fs")
     fun retryFsSync(): Response {
-        finalSyncService.scheduleSync()
-        return Response.accepted().build()
+        return when (migrationService.currentStage) {
+            MigrationStage.FINAL_SYNC_ERROR -> {
+                Response.status(if (finalSyncService.scheduleSync()) Response.Status.ACCEPTED else Response.Status.CONFLICT)
+            }
+            else -> Response.status(Response.Status.BAD_REQUEST)
+        }.build()
     }
 
     @Path("/status")

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -103,8 +103,13 @@ class FinalSyncEndpoint(
     @PUT
     @Path("/retry/db")
     fun retryDbMigration(): Response {
-        databaseMigrationService.scheduleMigration()
-        return Response.accepted().build()
+        return when (migrationService.currentStage) {
+            MigrationStage.FINAL_SYNC_ERROR -> {
+                databaseMigrationService.scheduleMigration()
+                Response.status(Response.Status.ACCEPTED)
+            }
+            else -> Response.status(Response.Status.BAD_REQUEST)
+        }.build()
     }
 
     @Path("/status")

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -90,8 +90,9 @@ class FinalSyncEndpoint(
 
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/start/fs")
-    fun runFsSync(): Response {
+    @Path("/retry/fs")
+    fun retryFsSync(): Response {
+        finalSyncService.scheduleSync()
         return Response.accepted().build()
     }
 

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -88,6 +88,13 @@ class FinalSyncEndpoint(
                 .build()
     }
 
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/start/fs")
+    fun runFsSync(): Response {
+        return Response.accepted().build()
+    }
+
     @Path("/status")
     @Produces(MediaType.APPLICATION_JSON)
     @GET

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -105,8 +105,7 @@ class FinalSyncEndpoint(
     fun retryDbMigration(): Response {
         return when (migrationService.currentStage) {
             MigrationStage.FINAL_SYNC_ERROR -> {
-                databaseMigrationService.scheduleMigration()
-                Response.status(Response.Status.ACCEPTED)
+                Response.status(if (databaseMigrationService.scheduleMigration()) Response.Status.ACCEPTED else Response.Status.CONFLICT)
             }
             else -> Response.status(Response.Status.BAD_REQUEST)
         }.build()

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -105,6 +105,7 @@ class FinalSyncEndpoint(
     fun retryDbMigration(): Response {
         return when (migrationService.currentStage) {
             MigrationStage.FINAL_SYNC_ERROR -> {
+                migrationService.transition(MigrationStage.DB_MIGRATION_EXPORT)
                 Response.status(if (databaseMigrationService.scheduleMigration()) Response.Status.ACCEPTED else Response.Status.CONFLICT)
             }
             else -> Response.status(Response.Status.BAD_REQUEST)

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -36,10 +36,12 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.Duration
 import java.util.Optional
+import javax.ws.rs.core.Response
 import kotlin.test.assertEquals
 
 
@@ -103,7 +105,11 @@ internal class FinalSyncEndpointTest {
 
     @Test
     fun shouldStartFsSync() {
-        
+        every { s3FinalSyncService.scheduleSync() } returns true
+        val res = sut.retryFsSync()
+        assertEquals(Response.Status.ACCEPTED.statusCode, res.status)
+
+        verify { s3FinalSyncService.scheduleSync() }
     }
 
 }

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -161,6 +161,15 @@ internal class FinalSyncEndpointTest {
         verify(exactly = 0) { databaseMigrationService.scheduleMigration() }
     }
 
+    @Test
+    fun shouldReturnConflictWhenDbMigrationCantBeRestarted() {
+        givenFinalSyncHasFailed()
+        andDbRestartWillFail()
+        
+        val res = sut.retryDbMigration()
+        assertResponseStatusIs(Response.Status.CONFLICT, res)
+    }
+
     private fun givenMigrationHasSucceeded() {
         every { migrationService.currentStage } returns MigrationStage.VALIDATE
     }

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -101,4 +101,9 @@ internal class FinalSyncEndpointTest {
         assertEquals(100, result.fs.downloaded)
     }
 
+    @Test
+    fun shouldStartFsSync() {
+        
+    }
+
 }

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -153,6 +153,15 @@ internal class FinalSyncEndpointTest {
     }
 
     @Test
+    fun shouldTransitionToDbMigrationExportWhenRestartingDbMigration() {
+        givenFinalSyncHasFailed()
+        andDbRestartWillSucceed()
+
+        sut.retryDbMigration()
+        verify { migrationService.transition(MigrationStage.DB_MIGRATION_EXPORT) }
+    }
+
+    @Test
     fun shouldNotStartDbMigrationWhenMigrationIsNotError() {
         givenMigrationHasSucceeded()
 
@@ -165,7 +174,7 @@ internal class FinalSyncEndpointTest {
     fun shouldReturnConflictWhenDbMigrationCantBeRestarted() {
         givenFinalSyncHasFailed()
         andDbRestartWillFail()
-        
+
         val res = sut.retryDbMigration()
         assertResponseStatusIs(Response.Status.CONFLICT, res)
     }
@@ -177,6 +186,7 @@ internal class FinalSyncEndpointTest {
     private fun givenFinalSyncHasFailed() {
         every { migrationService.currentStage } returns MigrationStage.FINAL_SYNC_ERROR
         justRun { migrationService.transition(MigrationStage.FINAL_SYNC_WAIT) }
+        justRun { migrationService.transition(MigrationStage.DB_MIGRATION_EXPORT) }
     }
 
     private fun andFsRestartWillSucceed() {

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -36,6 +36,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -114,6 +115,15 @@ internal class FinalSyncEndpointTest {
     }
 
     @Test
+    fun shouldTransitionToFinalSyncWaitWhenRestartingFSSync() {
+        givenFinalSyncHasFailed()
+        andFsRestartWillSucceed()
+        sut.retryFsSync()
+
+        verify { migrationService.transition(MigrationStage.FINAL_SYNC_WAIT) }
+    }
+
+    @Test
     fun shouldNotStartFsSyncWhenMigrationIsNotError() {
         every { migrationService.currentStage } returns MigrationStage.VALIDATE
 
@@ -144,6 +154,7 @@ internal class FinalSyncEndpointTest {
 
     private fun givenFinalSyncHasFailed() {
         every { migrationService.currentStage } returns MigrationStage.FINAL_SYNC_ERROR
+        justRun { migrationService.transition(MigrationStage.FINAL_SYNC_WAIT) }
     }
 
     private fun andFsRestartWillSucceed() {

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -125,7 +125,7 @@ internal class FinalSyncEndpointTest {
 
     @Test
     fun shouldNotStartFsSyncWhenMigrationIsNotError() {
-        every { migrationService.currentStage } returns MigrationStage.VALIDATE
+        givenMigrationHasSucceeded()
 
         val res = sut.retryFsSync()
         assertResponseStatusIs(Response.Status.BAD_REQUEST, res)
@@ -150,6 +150,19 @@ internal class FinalSyncEndpointTest {
 
         assertResponseStatusIs(Response.Status.ACCEPTED, res)
         verify { databaseMigrationService.scheduleMigration() }
+    }
+
+    @Test
+    fun shouldNotStartDbMigrationWhenMigrationIsNotError() {
+        givenMigrationHasSucceeded()
+
+        val res = sut.retryDbMigration()
+        assertResponseStatusIs(Response.Status.BAD_REQUEST, res)
+        verify(exactly = 0) { databaseMigrationService.scheduleMigration() }
+    }
+
+    private fun givenMigrationHasSucceeded() {
+        every { migrationService.currentStage } returns MigrationStage.VALIDATE
     }
 
     private fun givenFinalSyncHasFailed() {

--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
         <localstack.version>0.2.1</localstack.version>
         <maven-frontend-plugin.version>1.9.1</maven-frontend-plugin.version>
         <mockito.version>3.2.4</mockito.version>
-        <mockk.version>1.9.3</mockk.version>
+        <mockk.version>1.10.0</mockk.version>
         <postgres.driver.version>42.2.10</postgres.driver.version>
         <sal.version>4.0.0</sal.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
## Summary

* New endpoints: `/migration/final-sync/retry/{db,fs}`
* Only does retry if state is `FINAL_SYNC_ERROR`
* Each will move the state machine to the starting state for the respective process then start the process.