### PR TITLE
CHET-527: track final sync fs errors

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -55,7 +55,7 @@ class FinalSyncEndpoint(
         )
     }
 
-    data class FSSyncStatus(val uploaded: Int, val downloaded: Int, val hasProgressedToNextStage: Boolean)
+    data class FSSyncStatus(val uploaded: Int, val downloaded: Int, val failed: Int, val hasProgressedToNextStage: Boolean)
     data class FinalSyncStatus(val db: DatabaseMigrationStatus, val fs: FSSyncStatus)
 
     @PUT
@@ -102,7 +102,7 @@ class FinalSyncEndpoint(
         val isCurrentStageAfterFinalSync = currentStage.isAfter(MigrationStage.FINAL_SYNC_WAIT)
         val fsSyncStatus = finalSyncService.getFinalSyncStatus()
 
-        val fs = FSSyncStatus(fsSyncStatus.uploadedFileCount, fsSyncStatus.uploadedFileCount - fsSyncStatus.enqueuedFileCount, isCurrentStageAfterFinalSync)
+        val fs = FSSyncStatus(fsSyncStatus.uploadedFileCount, fsSyncStatus.uploadedFileCount - fsSyncStatus.enqueuedFileCount - fsSyncStatus.failedFileCount, fsSyncStatus.failedFileCount, isCurrentStageAfterFinalSync)
         val status = FinalSyncStatus(db, fs)
 
         return try {

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpointTest.kt
@@ -76,7 +76,7 @@ internal class FinalSyncEndpointTest {
     fun shouldReportDbSyncStatus() {
         every { databaseMigrationService.elapsedTime } returns Optional.of(Duration.ofSeconds(20))
         every { migrationService.currentStage } returns MigrationStage.DATA_MIGRATION_IMPORT
-        every { s3FinalSyncService.getFinalSyncStatus() } returns FinalFileSyncStatus(0, 0)
+        every { s3FinalSyncService.getFinalSyncStatus() } returns FinalFileSyncStatus(0, 0, 0)
 
         val resp = sut.getMigrationStatus()
         val json = resp.entity as String
@@ -91,14 +91,15 @@ internal class FinalSyncEndpointTest {
     fun shouldReportFsSyncStatus() {
         every { databaseMigrationService.elapsedTime } returns Optional.of(Duration.ofSeconds(0))
         every { migrationService.currentStage } returns MigrationStage.DATA_MIGRATION_IMPORT
-        every { s3FinalSyncService.getFinalSyncStatus() } returns FinalFileSyncStatus(150, 50)
+        every { s3FinalSyncService.getFinalSyncStatus() } returns FinalFileSyncStatus(150, 50, 12)
 
         val resp = sut.getMigrationStatus()
         val json = resp.entity as String
 
         val result = mapper.readValue<FinalSyncEndpoint.FinalSyncStatus>(json)
         assertEquals(150, result.fs.uploaded)
-        assertEquals(100, result.fs.downloaded)
+        assertEquals(88, result.fs.downloaded)
+        assertEquals(12, result.fs.failed)
     }
 
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -82,6 +82,7 @@ public class DatabaseMigrationService {
         try {
             bucketName = migrationHelperDeploymentService.getMigrationS3BucketName();
         } catch (InfrastructureDeploymentError infrastructureDeploymentError) {
+            migrationService.error(infrastructureDeploymentError);
             throw new DatabaseMigrationFailure("error getting migration bucket", infrastructureDeploymentError);
         }
 

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
@@ -60,8 +60,9 @@ class S3FinalSyncService(private val migrationRunner: MigrationRunner,
         val uploadedFileCount =  attachmentSyncManager.capturedAttachmentCountForCurrentMigration
 
         val itemsInQueue = sqsApi.getQueueLength(migrationQueueUrl)
+        val itemsFailedToDownload = sqsApi.getQueueLength(currentContext.migrationDLQueueUrl)
 
-        return FinalFileSyncStatus(uploadedFileCount, itemsInQueue)
+        return FinalFileSyncStatus(uploadedFileCount, itemsInQueue, itemsFailedToDownload)
     }
 
     private fun getScheduledJobId(): JobId {
@@ -69,4 +70,4 @@ class S3FinalSyncService(private val migrationRunner: MigrationRunner,
     }
 }
 
-class FinalFileSyncStatus(val uploadedFileCount: Int, val enqueuedFileCount: Int)
+class FinalFileSyncStatus(val uploadedFileCount: Int, val enqueuedFileCount: Int, val failedFileCount: Int)

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncServiceTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncServiceTest.kt
@@ -25,44 +25,80 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
-import io.mockk.verifyAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
+const val queueUrl = "https://sqs/account/queues/foo"
+const val dlQueUrl = "https://sqs/account/queus/deadletter"
 
 internal class S3FinalSyncServiceTest {
 
-    @MockK lateinit var  migrationRunner : MigrationRunner
-    @MockK lateinit var  jobRunner: S3FinalSyncRunner
-    @MockK lateinit var  migrationService: MigrationService
+    @MockK
+    lateinit var migrationRunner: MigrationRunner
+    @MockK
+    lateinit var jobRunner: S3FinalSyncRunner
+    @MockK
+    lateinit var migrationService: MigrationService
 
-    @MockK lateinit var  migrationContext: MigrationContext
-    @MockK lateinit var  sqsApi: SqsApi
-    @MockK lateinit var  attachmentSyncManager: AttachmentSyncManager
+    @MockK
+    lateinit var migrationContext: MigrationContext
+    @MockK
+    lateinit var sqsApi: SqsApi
+    @MockK
+    lateinit var attachmentSyncManager: AttachmentSyncManager
 
     @InjectMockKs
     lateinit var sut: S3FinalSyncService
 
     @BeforeEach
-    fun init() = MockKAnnotations.init(this)
+    fun init() {
+        MockKAnnotations.init(this)
+        every { migrationService.currentContext } returns migrationContext
+        every { migrationContext.migrationQueueUrl } returns queueUrl
+        every { migrationContext.migrationDLQueueUrl } returns dlQueUrl
+    }
+
 
     @Test
     fun shouldGetFinalSyncStatus() {
-        val queueUrl = "https://sqs/account/queues/foo"
-
-        every { migrationService.currentContext } returns migrationContext
-        every { migrationContext.migrationQueueUrl } returns queueUrl
-        every { sqsApi.getQueueLength(queueUrl) } returns 42
-        every { attachmentSyncManager.capturedAttachmentCountForCurrentMigration } returns 21
+        givenElementsInMigrationQueueIs(42)
+        givenElementsInDeadLetterQueueIs(0)
+        givenFilesCapturedIs(21)
 
         val finalSyncStatus = sut.getFinalSyncStatus()
 
         assertEquals(42, finalSyncStatus.enqueuedFileCount)
         assertEquals(21, finalSyncStatus.uploadedFileCount)
+        assertEquals(0, finalSyncStatus.failedFileCount)
 
         verify {
             sqsApi.getQueueLength(queueUrl)
         }
+    }
+
+    @Test
+    fun shouldGetErrorsInFinalSync() {
+        givenFilesCapturedIs(40)
+        givenElementsInMigrationQueueIs(0)
+        givenElementsInDeadLetterQueueIs(40)
+
+        val finalSyncStatus = sut.getFinalSyncStatus()
+
+        assertEquals(40, finalSyncStatus.uploadedFileCount)
+        assertEquals(0, finalSyncStatus.enqueuedFileCount)
+        assertEquals(40, finalSyncStatus.failedFileCount)
+    }
+
+    private fun givenFilesCapturedIs(numFiles: Int) {
+        every { attachmentSyncManager.capturedAttachmentCountForCurrentMigration } returns numFiles
+    }
+
+    private fun givenElementsInMigrationQueueIs(numElements: Int) {
+        every { sqsApi.getQueueLength(queueUrl) } returns numElements
+    }
+
+    private fun givenElementsInDeadLetterQueueIs(numElements: Int) {
+        every { sqsApi.getQueueLength(dlQueUrl) } returns numElements
     }
 }


### PR DESCRIPTION
## Summary
* Use deadletter queue as measure of errors for fs final sync

TODO: when retrying the fs migration, move everything from the DLQ to the migration queue