### PR TITLE
CHET-408: create a context wrapper to handle the case when older vers…

### DIFF
--- a/frontend/config/webpack.constants.js
+++ b/frontend/config/webpack.constants.js
@@ -26,7 +26,9 @@ const FRONTEND_OUTPUT_DIR = path.join(rootDir, 'target', 'classes');
 const PLUGIN_KEY = 'com.atlassian.migration.datacenter.jira-plugin';
 const ENTRY_POINT = { 'dc-migration-assistant': path.join(FRONTEND_SRC_DIR, 'index.tsx') };
 
-const MY_I18N_FILES = ['dc-migration-assistant.properties'].map(file => path.join(I18N_SRC_DIR, 'i18n', file));
+const MY_I18N_FILES = ['dc-migration-assistant.properties'].map(file =>
+    path.join(I18N_SRC_DIR, 'i18n', file)
+);
 const WRM_OUTPUT = path.resolve(
     './',
     'target',

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -44,8 +44,6 @@
      delete window.fetch;
     </script>
     <script src="https://unpkg.com/unfetch/polyfill"></script>
-
-    <sc
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/main/dc-migration-assistant-fe/utils/RoutePaths.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/utils/RoutePaths.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line import/no-unresolved
-import contextPath from 'wrm/context-path';
+import contextPathWrapper from './context-path-wrapper';
 
 const routePrefix = ((): string => {
     const awsMigrationServletPath = '/plugins/servlet/dc-migration-assistant';
-    const pathname = contextPath(); // eslint-disable-line no-undef
+    const pathname = contextPathWrapper();
 
     if (pathname.includes(awsMigrationServletPath)) {
         return pathname;

--- a/frontend/src/main/dc-migration-assistant-fe/utils/api.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/utils/api.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line import/no-unresolved
-import contextPath from 'wrm/context-path';
+import contextPathWrapper from './context-path-wrapper';
 
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
@@ -23,7 +22,7 @@ type FetchHeader = Record<string, string>;
 type FetchOption = string | FetchHeader;
 type FetchOptions = Record<string, FetchOption>;
 
-const addToOptionsIfexists = (
+const addToOptionsIfExists = (
     newOption: FetchOption,
     currentOptions: FetchOptions
 ): FetchOptions => {
@@ -52,9 +51,9 @@ export const callAppRest = (
         options = { ...options, body: JSON.stringify(body) };
     }
 
-    options = addToOptionsIfexists(headers, options);
+    options = addToOptionsIfExists(headers, options);
 
-    const basePath = `${contextPath()}/rest/dc-migration/1.0/${path}`;
+    const basePath = `${contextPathWrapper()}/rest/dc-migration/1.0/${path}`;
     const callPath = queryParams ? `${basePath}?${queryParams}` : basePath;
 
     return fetch(callPath, options);

--- a/frontend/src/main/dc-migration-assistant-fe/utils/context-path-wrapper.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/utils/context-path-wrapper.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line import/no-unresolved
+import contextPath from 'wrm/context-path';
+
+const contextPathWrapper = (): string => {
+    try {
+        return contextPath();
+    } catch (typeError) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (window.hasOwnProperty('contextPath')) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            return window.contextPath;
+        }
+        throw typeError;
+    }
+};
+
+export default contextPathWrapper;

--- a/jira-e2e-tests/docker-compose.yml
+++ b/jira-e2e-tests/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - postgresql
     ports:
       - '2990:8080'
+      - '5005:5005'
     environment:
       - 'ATL_JDBC_URL=jdbc:postgresql://postgresql/jira'
       - 'ATL_JDBC_USER=jiradb'
@@ -32,7 +33,7 @@ services:
       - 'ATL_DB_DRIVER=org.postgresql.Driver'
       - 'ATL_DB_TYPE=postgres72'
       - 'ATL_TOMCAT_CONTEXTPATH=/jira'
-      - 'JVM_SUPPORT_RECOMMENDED_ARGS=-Dspring.profiles.active=allowAnyTransition,gaFeature -Djira.onboarding.cyoa=false -Datlassian.darkfeature.jira.onboarding.cyoa=false -Datlassian.darkfeature.jira.onboarding.feature.disabled=true  -Datlassian.mail.senddisabled=false -Djira.startup.warnings.disable=true -Dtroubleshooting.dev.mode=true'
+      - 'JVM_SUPPORT_RECOMMENDED_ARGS=-Dspring.profiles.active=allowAnyTransition,gaFeature -Djira.onboarding.cyoa=false -Datlassian.darkfeature.jira.onboarding.cyoa=false -Datlassian.darkfeature.jira.onboarding.feature.disabled=true  -Datlassian.mail.senddisabled=false -Djira.startup.warnings.disable=true -Dtroubleshooting.dev.mode=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005'
     command: >
       bash -c '
           waitport postgresql 5432 &&

--- a/jira-plugin/src/main/resources/atlassian-plugin.xml
+++ b/jira-plugin/src/main/resources/atlassian-plugin.xml
@@ -44,34 +44,11 @@
         <dependency>com.atlassian.soy.soy-template-plugin:soy-deps</dependency>
     </web-resource>
 
-    <web-item key="refapp-menu-item" name="Refapp DC Migration Plugin" section="system.admin/general" weight="10"
-              application="refapp">
-        <label key="atlassian.migration.datacenter.title"/>
-        <description>Refapp admin menu item for this app</description>
-        <link linkId="dc-migration-assistant">/plugins/servlet/dc-migration-assistant</link>
-    </web-item>
-
     <web-item key="migrationAssistantItem" name="Jira DC Migration Plugin" section="admin_system_menu/advanced_menu_section"
               weight="200"
               application="jira">
         <label key="atlassian.migration.datacenter.title"/>
         <description>Jira admin menu item for this app</description>
-        <link linkId="dc-migration-assistant">/plugins/servlet/dc-migration-assistant</link>
-    </web-item>
-
-    <web-item key="bitbucket-menu-item" name="Bitbucket DC Migration Plugin" section="atl.admin/admin-support-section"
-              weight="10"
-              application="bitbucket">
-        <label key="atlassian.migration.datacenter.title"/>
-        <description>Bitbucket admin menu item for this plugin</description>
-        <link linkId="dc-migration-assistant">/plugins/servlet/dc-migration-assistant</link>
-    </web-item>
-
-    <web-item key="confluence-menu-item" name="Confluence DC Migration Plugin" section="system.admin/administration"
-              weight="10"
-              application="confluence">
-        <label key="atlassian.migration.datacenter.title"/>
-        <description>Confluence admin menu item for this plugin</description>
         <link linkId="dc-migration-assistant">/plugins/servlet/dc-migration-assistant</link>
     </web-item>
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
                 <artifactId>atlassian-plugins-osgi-javaconfig</artifactId>
                 <version>${atlassian.plugins.osgi.javaconfig.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-crypto</artifactId>


### PR DESCRIPTION
Jira 7.13 did not expose `contextPath` as a method. However, this property is available on the window object. This PR creates a wrapper to first load the contextPath from `wrm/context-path`. If this is not available, read the property from the window.

Quick follow - optionally, bundle JQuery for older versions of Jira to prevent errors when AJS is invoked.

Migration in progress on Jira 7.13 

<img width="1680" alt="Screenshot 2020-06-23 at 19 59 46" src="https://user-images.githubusercontent.com/1063972/85391230-3dcbbd00-b58d-11ea-9d84-19b23ff1362e.png">
