### PR TITLE
CHET-534: clear dead letter queue

### DIFF
--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/SqsApi.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/SqsApi.kt
@@ -21,4 +21,6 @@ import com.atlassian.migration.datacenter.core.exceptions.AwsQueueError
 interface SqsApi {
     @Throws(AwsQueueError::class)
     fun getQueueLength(queueUrl: String) : Int
+
+    fun emptyQueue(queueUrl: String)
 }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/exceptions/AwsQueueError.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/exceptions/AwsQueueError.kt
@@ -26,7 +26,5 @@ open class AwsQueueError : Exception {
 
 class AwsQueueConnectionException(message: String, cause: Throwable) : AwsQueueError(message, cause)
 class AwsQueueApiUnsuccessfulResponse(message: String) : AwsQueueError(message)
-class AwsQueueBadRequestError : AwsQueueError {
-    constructor(message: String) : super(message)
-    constructor(message: String, throwable: Throwable) : super(message, throwable)
+class AwsQueueBadRequestError(message: String) : AwsQueueError(message) {
 }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/exceptions/AwsQueueError.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/exceptions/AwsQueueError.kt
@@ -19,10 +19,14 @@ package com.atlassian.migration.datacenter.core.exceptions
 
 open class AwsQueueError : Exception {
     constructor(message: String) : super(message)
+    constructor(cause: Throwable) : super(cause)
     constructor(message: String, throwable: Throwable) : super(message, throwable)
 
 }
 
 class AwsQueueConnectionException(message: String, cause: Throwable) : AwsQueueError(message, cause)
 class AwsQueueApiUnsuccessfulResponse(message: String) : AwsQueueError(message)
-class AwsQueueBadRequestError(message: String) : AwsQueueError(message)
+class AwsQueueBadRequestError : AwsQueueError {
+    constructor(message: String) : super(message)
+    constructor(message: String, throwable: Throwable) : super(message, throwable)
+}


### PR DESCRIPTION
When a message fails to be processed from the migration queue 5 times, it will be pushed to the dead letter queue. We use this queue to measure failures for the final file sync. When retrying, we empty the queue so that we can start fresh. Any entries in that queue will be re-uploaded anyway when retrying