### PR TITLE
CHET-529: [core] ensure state is correct when completing FS final sync

### DIFF
--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/SqsQueueWatcher.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/SqsQueueWatcher.kt
@@ -43,6 +43,7 @@ class SqsQueueWatcher(private val sqsAPi: SqsApi,
         try {
             val completableFuture = this.awaitRunnableToComplete(::checkForStateToBeInFsSyncAwait)
                     .thenCompose { awaitRunnableToComplete(::checkForQueueToBeEmpty) }
+                    .thenCompose { awaitRunnableToComplete(::checkForStateToBeInFsSyncAwait) }
                     .thenApply {
                         migrationService.transition(VALIDATE)
                     }

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/SqsQueueWatcherTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/SqsQueueWatcherTest.kt
@@ -51,7 +51,7 @@ internal class SqsQueueWatcherTest {
     fun shouldTransitionMigrationStateToValidate() {
         val migrationQueueUrl = "https://sqs/migrationQueue"
 
-        every { migrationService.currentStage } returns MigrationStage.DB_MIGRATION_EXPORT_WAIT andThen MigrationStage.DB_MIGRATION_UPLOAD andThen MigrationStage.DATA_MIGRATION_IMPORT_WAIT andThen MigrationStage.FINAL_SYNC_WAIT
+        every { migrationService.currentStage } returns MigrationStage.DB_MIGRATION_EXPORT_WAIT andThen MigrationStage.DB_MIGRATION_UPLOAD andThen MigrationStage.DATA_MIGRATION_IMPORT_WAIT andThen MigrationStage.FINAL_SYNC_WAIT andThen MigrationStage.DB_MIGRATION_EXPORT andThen MigrationStage.FINAL_SYNC_WAIT
         every { migrationService.transition(MigrationStage.VALIDATE) } answers {}
         every { migrationService.currentContext } returns mockContext
         every { mockContext.migrationQueueUrl } returns migrationQueueUrl
@@ -61,7 +61,7 @@ internal class SqsQueueWatcherTest {
 
         Assertions.assertTrue(isQueueDrained, "Expected Queue to be drained, but wasn't")
 
-        verify(exactly = 4) { migrationService.currentStage }
+        verify(exactly = 6) { migrationService.currentStage }
         verify(exactly = 4) { sqsApi.getQueueLength(migrationQueueUrl) }
         verify {
             migrationService.transition(MigrationStage.VALIDATE)


### PR DESCRIPTION
From the ticket:

>These things happen in the state machine during the final sync
>
 >   The FS sync tries to transition to VALIDATE from FINAL_SYNC_WAIT when it completes
>
>   The DB migration makes assertions about what state of the state machine it is in and does transitions
>
>Therefore to successfully “retry” each operation individually (under current implementation, before starting this story)
>
  >  The state must be FINAL_SYNC_WAIT when the FS sync finishes and cannot change after entering that state (outside of from the FS final sync itself transitioning to VALIDATE)
>
  >  The state must be DB_MIGRATION_EXPORT when the DB migration starts and must not be changed underneath it until it completes
>
>This can lead to issues when both operations are restarted. Consider this:
>
  >  FS sync is restarted → Move the migration state to FINAL_SYNC_WAIT so that it can complete. The DB migration is still in progress.
>
    >The DB migration fails while the FS sync is retrying. It is restarted → Move the migration state to DB_MIGRATION_EXPORT so that it can start.
>
    >The FS sync retry completes and tries to transition to VALIDATE → ILLEGAL_TRANSITION
>
>This could be fixed many ways, my current best guess is to modify the FS sync to go from:
>
  >  Wait for state to be FINAL_SYNC_WAIT
>
 >   Poll queue length until it’s empty
>
 >   Transition to validate
>
>To
>
  >  Wait for state to be FINAL_SYNC_WAIT
>
  >  Poll queue length until it’s empty
>
  >  Wait for state to be FINAL_SYNC_WAIT
>
  >  Transition to validate