### PR TITLE
CHET-149: Unschedule jobs on plugin disable

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -19,7 +19,7 @@ import com.atlassian.migration.datacenter.api.db.DatabaseMigrationStatus
 import com.atlassian.migration.datacenter.api.db.stageToStatus
 import com.atlassian.migration.datacenter.core.aws.db.DatabaseMigrationService
 import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRestoreService
-import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncService
+import com.atlassian.migration.datacenter.core.fs.captor.DefaultS3FinalSyncService
 import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
@@ -46,7 +46,7 @@ class FinalSyncEndpoint(
         private val databaseMigrationService: DatabaseMigrationService,
         private val migrationService: MigrationService,
         private val ssmPsqlDatabaseRestoreService: SsmPsqlDatabaseRestoreService,
-        private val finalSyncService: S3FinalSyncService
+        private val finalSyncService: DefaultS3FinalSyncService
 ) {
     private val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationService.java
@@ -127,7 +127,7 @@ public class DatabaseMigrationService {
 
     public void abortMigration() throws InvalidMigrationStageError {
         // We always try to remove scheduled job if the system is in inconsistent state
-        migrationRunner.abortJobIfPresesnt(getScheduledJobId());
+        unscheduleMigration();
 
         if (!migrationService.getCurrentStage().isDBPhase() || s3UploadService == null) {
             throw new InvalidMigrationStageError(
@@ -138,6 +138,10 @@ public class DatabaseMigrationService {
         logger.warn("Aborting running DB migration");
 
         migrationService.error("DB migration was aborted");
+    }
+
+    public void unscheduleMigration() {
+        this.migrationRunner.abortJobIfPresent(getScheduledJobId());
     }
 
     private JobId getScheduledJobId() {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -131,7 +131,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
     @Override
     public void abortMigration() throws InvalidMigrationStageError {
         // We always try to remove scheduled job if the system is in inconsistent state
-        migrationRunner.abortJobIfPresesnt(getScheduledJobId());
+        unscheduleMigration();
 
         if (!isRunning()) {
             throw new InvalidMigrationStageError(
@@ -145,6 +145,11 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService 
         bulkCopy.abortCopy();
 
         migrationService.error("File system migration was aborted");
+    }
+
+    @Override
+    public void unscheduleMigration() {
+        migrationRunner.abortJobIfPresent(getScheduledJobId());
     }
 
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.fs.captor
+
+interface S3FinalSyncService {
+    fun scheduleSync(): Boolean
+    fun abortMigration()
+    fun unscheduleMigration()
+    fun getFinalSyncStatus() : FinalFileSyncStatus
+
+}

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/util/MigrationRunner.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/util/MigrationRunner.java
@@ -64,7 +64,7 @@ public class MigrationRunner
         }
     }
 
-    public boolean abortJobIfPresesnt(JobId jobId) {
+    public boolean abortJobIfPresent(JobId jobId) {
         if (schedulerService.getJobDetails(jobId) == null) {
             return false;
         }

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/DefaultS3FinalSyncServiceTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/fs/captor/DefaultS3FinalSyncServiceTest.kt
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test
 const val queueUrl = "https://sqs/account/queues/foo"
 const val dlQueUrl = "https://sqs/account/queus/deadletter"
 
-internal class S3FinalSyncServiceTest {
+internal class DefaultS3FinalSyncServiceTest {
 
     @MockK
     lateinit var migrationRunner: MigrationRunner
@@ -49,7 +49,7 @@ internal class S3FinalSyncServiceTest {
     lateinit var attachmentSyncManager: AttachmentSyncManager
 
     @InjectMockKs
-    lateinit var sut: S3FinalSyncService
+    lateinit var sut: DefaultS3FinalSyncService
 
     @BeforeEach
     fun init() {

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -71,6 +71,7 @@ import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager;
 import com.atlassian.migration.datacenter.core.fs.captor.DefaultAttachmentSyncManager;
 import com.atlassian.migration.datacenter.core.fs.captor.QueueWatcher;
 import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncRunner;
+import com.atlassian.migration.datacenter.core.fs.captor.DefaultS3FinalSyncService;
 import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncService;
 import com.atlassian.migration.datacenter.core.fs.captor.SqsQueueWatcher;
 import com.atlassian.migration.datacenter.core.fs.copy.S3BulkCopy;
@@ -81,6 +82,7 @@ import com.atlassian.migration.datacenter.core.fs.jira.captor.DefaultAttachmentC
 import com.atlassian.migration.datacenter.core.fs.jira.listener.JiraIssueAttachmentListener;
 import com.atlassian.migration.datacenter.core.util.EncryptionManager;
 import com.atlassian.migration.datacenter.core.util.MigrationRunner;
+import com.atlassian.migration.datacenter.plugin.LifecycleEventListener;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService;
@@ -399,8 +401,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public S3FinalSyncService s3FinalSyncService(MigrationRunner migrationRunner, S3FinalSyncRunner finalSyncRunner, MigrationService migrationService, SqsApi sqsApi, QueueWatcher queueWatcher, AttachmentSyncManager attachmentSyncManager) {
-        return new S3FinalSyncService(migrationRunner, finalSyncRunner, migrationService, sqsApi, attachmentSyncManager);
+    public DefaultS3FinalSyncService s3FinalSyncService(MigrationRunner migrationRunner, S3FinalSyncRunner finalSyncRunner, MigrationService migrationService, SqsApi sqsApi, AttachmentSyncManager attachmentSyncManager) {
+        return new DefaultS3FinalSyncService(migrationRunner, finalSyncRunner, migrationService, sqsApi, attachmentSyncManager);
     }
 
     @Bean
@@ -445,5 +447,10 @@ public class MigrationAssistantBeanConfiguration {
             QuickstartWithVPCMigrationStackInputGatheringStrategy withVpcStrategy,
             QuickstartStandaloneMigrationStackInputGatheringStrategy standaloneStrategy) {
         return new MigrationStackInputGatheringStrategyFactory(withVpcStrategy, standaloneStrategy);
+    }
+
+    @Bean
+    public LifecycleEventListener lifecycleEventListener(EventPublisher eventPublisher, DatabaseMigrationService databaseMigrationService, FilesystemMigrationService filesystemMigrationService, DefaultS3FinalSyncService s3FinalSyncService){
+        return new LifecycleEventListener(eventPublisher, databaseMigrationService, filesystemMigrationService, s3FinalSyncService);
     }
 }

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/plugin/LifecycleEventListener.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/plugin/LifecycleEventListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.plugin;
+
+import com.atlassian.event.api.EventListener;
+import com.atlassian.event.api.EventPublisher;
+import com.atlassian.migration.datacenter.core.aws.db.DatabaseMigrationService;
+import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncService;
+import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.plugin.event.events.PluginDisabledEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+public class LifecycleEventListener implements InitializingBean, DisposableBean {
+    private static final Logger log = LoggerFactory.getLogger(LifecycleEventListener.class);
+    private static final String PLUGIN_KEY = "com.atlassian.migration.datacenter.jira-plugin";
+    private final EventPublisher eventPublisher;
+    private final DatabaseMigrationService databaseMigrationService;
+    private final FilesystemMigrationService filesystemMigrationService;
+    private final S3FinalSyncService defaultS3FinalSyncService;
+
+    public LifecycleEventListener(EventPublisher eventPublisher, DatabaseMigrationService databaseMigrationService, FilesystemMigrationService filesystemMigrationService, S3FinalSyncService defaultS3FinalSyncService) {
+        this.eventPublisher = eventPublisher;
+        this.databaseMigrationService = databaseMigrationService;
+        this.filesystemMigrationService = filesystemMigrationService;
+        this.defaultS3FinalSyncService = defaultS3FinalSyncService;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        this.eventPublisher.unregister(this);
+        unregisterJobs();
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.eventPublisher.register(this);
+    }
+
+    @EventListener
+    public void onPluginDisabled(PluginDisabledEvent event) {
+        if (PLUGIN_KEY.equals(event.getPlugin().getKey())) {
+            unregisterJobs();
+        }
+    }
+
+    private void unregisterJobs() {
+        try{
+            this.databaseMigrationService.unscheduleMigration();
+            this.filesystemMigrationService.unscheduleMigration();
+            this.defaultS3FinalSyncService.unscheduleMigration();
+        } catch (Exception ex) {
+            log.info("error while unregistering all scheduled jobs. Message {}", ex.getMessage());
+        }
+    }
+}

--- a/jira-plugin/src/test/java/com/atlassian/migration/datacenter/plugin/LifecycleEventListenerTest.java
+++ b/jira-plugin/src/test/java/com/atlassian/migration/datacenter/plugin/LifecycleEventListenerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.plugin;
+
+import com.atlassian.event.api.EventPublisher;
+import com.atlassian.migration.datacenter.core.aws.db.DatabaseMigrationService;
+import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncService;
+import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService;
+import com.atlassian.plugin.Plugin;
+import com.atlassian.plugin.event.events.PluginDisabledEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LifecycleEventListenerTest {
+
+    private LifecycleEventListener eventListener;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private DatabaseMigrationService databaseMigrationService;
+
+    @Mock
+    private FilesystemMigrationService filesystemMigrationService;
+
+    @Mock
+    private S3FinalSyncService s3FinalSyncService;
+
+    @Mock
+    private Plugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        eventListener = new LifecycleEventListener(eventPublisher, databaseMigrationService, filesystemMigrationService, s3FinalSyncService);
+    }
+
+    @Test
+    void shouldUnscheduleJobsOnPluginDisable() {
+        when(plugin.getKey()).thenReturn("com.atlassian.migration.datacenter.jira-plugin");
+        eventListener.onPluginDisabled(new PluginDisabledEvent(plugin));
+
+        verify(databaseMigrationService).unscheduleMigration();
+        verify(filesystemMigrationService).unscheduleMigration();
+        verify(s3FinalSyncService).unscheduleMigration();
+    }
+}

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/fs/FilesystemMigrationService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/fs/FilesystemMigrationService.kt
@@ -52,4 +52,10 @@ interface FilesystemMigrationService {
      */
     @Throws(InvalidMigrationStageError::class)
     fun abortMigration()
+
+    /**
+     * UnSchedules a migration job that may be in progress. No-op when a running job does not exist.
+     *
+     */
+    fun unscheduleMigration()
 }


### PR DESCRIPTION
Quick implementation of plugin disable event listener. 

Unfortunately, this does not work as expected as the scheduled job keys are based on a constant with the current migration ID appended to it.

The current migration ID is fetched from the database using `ao`. However, at the time of disable, the osgi bean is destroyed, leaving the ao reference that we inject into our services in an `IllegalState`

See: https://github.com/atlassian-labs/dc-migration-assistant/blob/master/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/captor/S3FinalSyncService.kt#L69

The error that we see when we try to access ao in the disable event flow looks something like - 
```
java.lang.IllegalStateException: Invalid BundleContext.
        at org.apache.felix.framework.BundleContextImpl.checkValidity(BundleContextImpl.java:511)
        at org.apache.felix.framework.BundleContextImpl.getService(BundleContextImpl.java:451)
```