### PR TITLE
CHET-503: Fix null pointer exception when checking command status

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ssm/SuccessfulSSMCommandConsumer.java
@@ -69,7 +69,7 @@ public abstract class SuccessfulSSMCommandConsumer<T> {
                 logger.error("interrupted while waiting for s3 sync ssm command to be delivered", e);
                 throw new UnsuccessfulSSMCommandInvocationException("Interrupted while waiting to check command status", e);
             }
-        } while (!isFinished(command.status()) || attempt == maxCommandStatusRetries);
+        } while (attempt == maxCommandStatusRetries || command == null || !isFinished(command.status()));
 
         throw new UnsuccessfulSSMCommandInvocationException(
                 String.format(


### PR DESCRIPTION
Currently seeing this as part of a migration 

```
2020-06-25 04:02:05,443+0000 Caesium-2-3 DEBUG ServiceRunner     [c.a.m.d.c.aws.ssm.SuccessfulSSMCommandConsumer] Checking delivery of s3 sync ssm command. Attempt 1
2020-06-25 04:02:05,443+0000 Caesium-2-3 DEBUG ServiceRunner     [c.a.m.d.c.aws.ssm.SSMApi] getting status of command 93d58ca3-518d-4bcb-b151-439d84558902 on instance i-0c53b7aed246b7d8a
2020-06-25 04:02:05,487+0000 Caesium-2-3 DEBUG ServiceRunner     [c.a.m.d.c.aws.ssm.SuccessfulSSMCommandConsumer] Command does not exist - maybe it hasn't reached the EC2 instance yet. Will continue retrying
2020-06-25 04:02:15,487+0000 Caesium-2-3 ERROR ServiceRunner     [c.a.scheduler.core.JobLauncher] Scheduled job with ID 'com.atlassian.migration.datacenter.fs.S3UploadJobRunner2' failed
java.lang.NullPointerException
	at com.atlassian.migration.datacenter.core.aws.ssm.SuccessfulSSMCommandConsumer.handleCommandOutput(SuccessfulSSMCommandConsumer.java:72)
	at com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSystemDownloader.initiateFileSystemDownload(S3SyncFileSystemDownloader.java:63)
	at com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSystemDownloadManager.downloadFileSystem(S3SyncFileSystemDownloadManager.java:41)
	at com.atlassian.migration.datacenter.core.fs.S3FilesystemMigrationService.startMigration(S3FilesystemMigrationService.java:118)
	at com.atlassian.migration.datacenter.core.fs.S3UploadJobRunner.runJob(S3UploadJobRunner.java:61)
	at com.atlassian.scheduler.core.JobLauncher.runJob(JobLauncher.java:134)
	at com.atlassian.scheduler.core.JobLauncher.launchAndBuildResponse(JobLauncher.java:106)
	at com.atlassian.scheduler.core.JobLauncher.launch(JobLauncher.java:90)
	at com.atlassian.scheduler.caesium.impl.CaesiumSchedulerService.launchJob(CaesiumSchedulerService.java:435)
	at com.atlassian.scheduler.caesium.impl.CaesiumSchedulerService.executeClusteredJob(CaesiumSchedulerService.java:430)
	at com.atlassian.scheduler.caesium.impl.CaesiumSchedulerService.executeClusteredJobWithRecoveryGuard(CaesiumSchedulerService.java:454)
	at com.atlassian.scheduler.caesium.impl.CaesiumSchedulerService.executeQueuedJob(CaesiumSchedulerService.java:382)
	at com.atlassian.scheduler.caesium.impl.SchedulerQueueWorker.executeJob(SchedulerQueueWorker.java:66)
	at com.atlassian.scheduler.caesium.impl.SchedulerQueueWorker.executeNextJob(SchedulerQueueWorker.java:60)
	at com.atlassian.scheduler.caesium.impl.SchedulerQueueWorker.run(SchedulerQueueWorker.java:35)
	at java.lang.Thread.run(Thread.java:748)
```

As part of the while conditional lets also check whether `command` is `null`. 