### PR TITLE
CHET-535: Prefill application version and disable the field

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
@@ -17,9 +17,8 @@
 package com.atlassian.migration.datacenter.api.application
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
-import com.fasterxml.jackson.annotation.JsonAutoDetect
-import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.slf4j.LoggerFactory
 import javax.ws.rs.GET
 import javax.ws.rs.Path
@@ -29,7 +28,7 @@ import javax.ws.rs.core.Response
 
 @Path("/application")
 class ApplicationPropertiesEndpoint(private val configuration: ApplicationConfiguration) {
-    private val mapper = ObjectMapper().setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY)
+    private val mapper = ObjectMapper().registerKotlinModule()
 
     companion object {
         val log = LoggerFactory.getLogger(ApplicationPropertiesEndpoint::class.java)

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
@@ -18,6 +18,9 @@ package com.atlassian.migration.datacenter.api.application
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
 import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.Produces
@@ -26,13 +29,20 @@ import javax.ws.rs.core.Response
 
 @Path("/application")
 class ApplicationPropertiesEndpoint(private val configuration: ApplicationConfiguration) {
+    private val mapper = ObjectMapper().setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY)
+
+    companion object {
+        val log = LoggerFactory.getLogger(ApplicationPropertiesEndpoint::class.java)
+    }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     fun getApplicationProperties(): Response {
-        return Response.ok(ApplicationProperties(configuration.applicationVersion)).build()
+        val props = ApplicationProperties(configuration.applicationVersion)
+        log.trace("Application properties: {}", props)
+
+        return Response.ok(mapper.writeValueAsString(props)).build()
     }
 
-    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     data class ApplicationProperties(val version: String)
 }

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.api.application
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+
+@Path("/application")
+class ApplicationPropertiesEndpoint(private val configuration: ApplicationConfiguration) {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    fun getApplicationProperties(): Response {
+        return Response.ok(ApplicationProperties(configuration.applicationVersion)).build()
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    data class ApplicationProperties(val version: String)
+}

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpoint.kt
@@ -36,6 +36,7 @@ class ApplicationPropertiesEndpoint(private val configuration: ApplicationConfig
     }
 
     @GET
+    @Path("/properties")
     @Produces(MediaType.APPLICATION_JSON)
     fun getApplicationProperties(): Response {
         val props = ApplicationProperties(configuration.applicationVersion)

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpointTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.api.application
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ApplicationPropertiesEndpointTest {
+
+    @MockK
+    lateinit var configuration: ApplicationConfiguration
+
+    @InjectMockKs
+    lateinit var applicationPropertiesEndpoint: ApplicationPropertiesEndpoint
+
+    @BeforeEach
+    fun init() = MockKAnnotations.init(this)
+
+    @Test
+    fun `returns correct Jira version`() {
+        val version = "8.8.3"
+        every { configuration.applicationVersion } returns version
+
+        val applicationProperties = applicationPropertiesEndpoint.getApplicationProperties()
+
+        assertEquals(
+            applicationProperties.entity,
+            ApplicationPropertiesEndpoint.ApplicationProperties(version)
+        )
+    }
+}

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpointTest.kt
@@ -48,8 +48,8 @@ class ApplicationPropertiesEndpointTest {
             ObjectMapper().writeValueAsString(ApplicationPropertiesEndpoint.ApplicationProperties(version))
 
         assertEquals(
-            applicationProperties.entity,
-            expectedProps
+            expectedProps,
+            applicationProperties.entity
         )
     }
 }

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/application/ApplicationPropertiesEndpointTest.kt
@@ -17,6 +17,7 @@
 package com.atlassian.migration.datacenter.api.application
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -43,9 +44,12 @@ class ApplicationPropertiesEndpointTest {
 
         val applicationProperties = applicationPropertiesEndpoint.getApplicationProperties()
 
+        val expectedProps =
+            ObjectMapper().writeValueAsString(ApplicationPropertiesEndpoint.ApplicationProperties(version))
+
         assertEquals(
             applicationProperties.entity,
-            ApplicationPropertiesEndpoint.ApplicationProperties(version)
+            expectedProps
         )
     }
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/application/ApplicationConfiguration.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/application/ApplicationConfiguration.java
@@ -20,7 +20,26 @@ package com.atlassian.migration.datacenter.core.application;
 import com.atlassian.migration.datacenter.spi.exceptions.ConfigurationReadException;
 
 public interface ApplicationConfiguration {
+    /**
+     * @return key of the installed plugin
+     */
     String getPluginKey();
+
+    /**
+     * @return version of the installed plugin
+     */
     String getPluginVersion();
+
+    /**
+     * @return version of the host application
+     */
+    String getApplicationVersion();
+
+    /**
+     * Parses database configuration file and returns configuration that can be used to connect to the database
+     *
+     * @return application database configuration
+     * @throws ConfigurationReadException when the configuration file cannot be parsed or read
+     */
     DatabaseConfiguration getDatabaseConfiguration() throws ConfigurationReadException;
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/application/JiraConfiguration.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/application/JiraConfiguration.java
@@ -17,6 +17,7 @@
 package com.atlassian.migration.datacenter.core.application;
 
 import com.atlassian.jira.config.util.JiraHome;
+import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.spi.exceptions.ConfigurationReadException;
 import com.atlassian.plugin.PluginAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -32,27 +33,32 @@ public class JiraConfiguration extends CommonApplicationConfiguration
 {
 
     private final JiraHome jiraHome;
+    private final BuildUtilsInfo buildUtilsInfo;
 
     public static final String PLUGIN_KEY = "com.atlassian.migration.datacenter.jira-plugin";
     private final ObjectMapper xmlMapper;
     private Optional<DatabaseConfiguration> databaseConfiguration = Optional.empty();
 
-    public JiraConfiguration(JiraHome jiraHome, PluginAccessor pluginAccessor) {
+    public JiraConfiguration(JiraHome jiraHome, PluginAccessor pluginAccessor, BuildUtilsInfo buildUtilsInfo) {
         super(pluginAccessor);
         this.jiraHome = jiraHome;
+        this.buildUtilsInfo = buildUtilsInfo;
         this.xmlMapper = new XmlMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Override
-    public String getPluginKey()
-    {
+    public String getPluginKey() {
         return PLUGIN_KEY;
     }
 
     @Override
-    public DatabaseConfiguration getDatabaseConfiguration() throws ConfigurationReadException
-    {
+    public String getApplicationVersion() {
+        return buildUtilsInfo.getVersion();
+    }
+
+    @Override
+    public DatabaseConfiguration getDatabaseConfiguration() throws ConfigurationReadException {
         if (!databaseConfiguration.isPresent()) {
             databaseConfiguration = Optional.of(parseDatabaseConfigurationFromXmlFile());
         }

--- a/frontend/src/main/dc-migration-assistant-fe/api/application.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/application.ts
@@ -18,7 +18,7 @@ import { callAppRest } from '../utils/api';
 
 const applicationPropertiesBase = 'application';
 
-export const applicationPropertiesEndpoint = `${applicationPropertiesBase}`;
+export const applicationPropertiesEndpoint = `${applicationPropertiesBase}/properties`;
 
 export type AppProperties = {
     version: string;

--- a/frontend/src/main/dc-migration-assistant-fe/api/application.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/application.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { callAppRest } from '../utils/api';
+
+const applicationPropertiesBase = 'application';
+
+export const applicationPropertiesEndpoint = `${applicationPropertiesBase}`;
+
+export type AppProperties = {
+    version: string;
+};
+
+export const fetchApplicationProperties = async (): Promise<AppProperties> => {
+    return callAppRest('GET', applicationPropertiesEndpoint).then((result: Response) =>
+        result.json()
+    );
+};

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -118,7 +118,7 @@ const QuickstartForm: FunctionComponent<QuickstartFormProps> = ({
                         const param = parameter;
                         if (ASIPrefixOverride && parameter.paramKey === 'ExportPrefix') {
                             param.paramProperties.Default = ASIPrefixOverride;
-                        } else if (parameter.paramKey === 'JiraVersion' && appVersion != '') {
+                        } else if (parameter.paramKey === 'JiraVersion' && appVersion !== '') {
                             param.paramProperties.Default = appVersion;
                         }
                         return createQuickstartFormField(param);

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/QuickStartDeploy.tsx
@@ -14,27 +14,25 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, ReactElement, ReactFragment, useEffect, useState } from 'react';
-import Form, { ErrorMessage, Field, FormHeader, FormSection, HelperMessage } from '@atlaskit/form';
+import React, {FunctionComponent, ReactElement, ReactFragment, useEffect, useState} from 'react';
+import Form, {ErrorMessage, Field, FormHeader, FormSection, HelperMessage} from '@atlaskit/form';
 import TextField from '@atlaskit/textfield';
-import Button, { ButtonGroup } from '@atlaskit/button';
+import Button, {ButtonGroup} from '@atlaskit/button';
 import Spinner from '@atlaskit/spinner';
-import { OptionType } from '@atlaskit/select';
-import { I18n } from '@atlassian/wrm-react-i18n';
+import {OptionType} from '@atlaskit/select';
+import {I18n} from '@atlassian/wrm-react-i18n';
 import styled from 'styled-components';
 import Panel from '@atlaskit/panel';
-import { Redirect } from 'react-router-dom';
+import {Redirect} from 'react-router-dom';
 
-import { yamlParse } from 'yaml-cfn';
-import { createQuickstartFormField } from './quickstartToAtlaskit';
-import { QuickstartParameterGroup, QuickstartTemplateForm } from './QuickStartTypes';
-
-import { callAppRest, RestApiPathConstants } from '../../../utils/api';
-import { quickstartStatusPath } from '../../../utils/RoutePaths';
-import { CancelButton } from '../../shared/CancelButton';
-import { DeploymentMode } from './QuickstartRoutes';
-import { provisioning } from '../../../api/provisioning';
-import { ErrorFlag } from '../../shared/ErrorFlag';
+import {yamlParse} from 'yaml-cfn';
+import {createQuickstartFormField} from './quickstartToAtlaskit';
+import {QuickstartParameterGroup, QuickstartTemplateForm} from './QuickStartTypes';
+import {quickstartStatusPath} from '../../../utils/RoutePaths';
+import {CancelButton} from '../../shared/CancelButton';
+import {DeploymentMode} from './QuickstartRoutes';
+import {provisioning} from '../../../api/provisioning';
+import {ErrorFlag} from '../../shared/ErrorFlag';
 
 const STACK_NAME_FIELD_NAME = 'stackName';
 
@@ -117,6 +115,8 @@ const QuickstartForm: FunctionComponent<QuickstartFormProps> = ({
                         const param = parameter;
                         if (ASIPrefixOverride && parameter.paramKey === 'ExportPrefix') {
                             param.paramProperties.Default = ASIPrefixOverride;
+                        } else if (parameter.paramKey === 'JiraVersion') {
+                            param.paramProperties.Default = '8.5.3';
                         }
                         return createQuickstartFormField(param);
                     })}

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/quickstartToAtlaskit.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/quickstartToAtlaskit.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import React, {ReactElement} from 'react';
-import Select, {AsyncSelect, OptionType} from '@atlaskit/select';
+import React, { ReactElement } from 'react';
+import Select, { AsyncSelect, OptionType } from '@atlaskit/select';
 import Toggle from '@atlaskit/toggle';
 import TextField from '@atlaskit/textfield';
-import {ErrorMessage, Field, HelperMessage} from '@atlaskit/form';
-import {I18n} from '@atlassian/wrm-react-i18n';
-import {QuickstartParameter} from './QuickStartTypes';
-import {callAppRest, RestApiPathConstants} from '../../../utils/api';
+import { ErrorMessage, Field, HelperMessage } from '@atlaskit/form';
+import { I18n } from '@atlassian/wrm-react-i18n';
+import { QuickstartParameter } from './QuickStartTypes';
+import { callAppRest, RestApiPathConstants } from '../../../utils/api';
 
 type FormElementGenerator = (
     defaultProps: DefaultFieldProps,

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/quickstartToAtlaskit.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/quickstartToAtlaskit.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from 'react';
-import Select, { AsyncSelect, OptionType } from '@atlaskit/select';
+import React, {ReactElement} from 'react';
+import Select, {AsyncSelect, OptionType} from '@atlaskit/select';
 import Toggle from '@atlaskit/toggle';
 import TextField from '@atlaskit/textfield';
-import { ErrorMessage, Field, HelperMessage } from '@atlaskit/form';
-import { I18n } from '@atlassian/wrm-react-i18n';
-import { QuickstartParameter } from './QuickStartTypes';
-import { callAppRest, RestApiPathConstants } from '../../../utils/api';
+import {ErrorMessage, Field, HelperMessage} from '@atlaskit/form';
+import {I18n} from '@atlassian/wrm-react-i18n';
+import {QuickstartParameter} from './QuickStartTypes';
+import {callAppRest, RestApiPathConstants} from '../../../utils/api';
 
 type FormElementGenerator = (
     defaultProps: DefaultFieldProps,
@@ -165,6 +165,13 @@ const createStringInputFromQuickstartParam: FormElementGenerator = (defaultField
     let overrideFieldProps: Record<string, string | number | boolean | Function> = {
         defaultValue: (Default as string) || '',
     };
+
+    if (param.paramKey === 'JiraVersion') {
+        overrideInputProps = {
+            isDisabled: true,
+            ...overrideInputProps,
+        };
+    }
 
     if (MaxLength) {
         overrideInputProps = {

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -20,6 +20,7 @@ import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.jira.config.util.JiraHome;
 import com.atlassian.jira.issue.attachment.AttachmentStore;
+import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.JiraConfiguration;
 import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
@@ -198,8 +199,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public JiraConfiguration jiraConfiguration(JiraHome jiraHome, PluginAccessor pluginAccessor) {
-        return new JiraConfiguration(jiraHome, pluginAccessor);
+    public JiraConfiguration jiraConfiguration(JiraHome jiraHome, PluginAccessor pluginAccessor, BuildUtilsInfo buildUtilsInfo) {
+        return new JiraConfiguration(jiraHome, pluginAccessor, buildUtilsInfo);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantOsgiImportConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantOsgiImportConfiguration.java
@@ -20,6 +20,7 @@ import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.jira.config.util.JiraHome;
 import com.atlassian.jira.issue.attachment.AttachmentStore;
+import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.plugin.PluginAccessor;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.permission.PermissionEnforcer;
@@ -79,6 +80,11 @@ public class MigrationAssistantOsgiImportConfiguration {
     @Bean
     public EventPublisher eventPublisher() {
         return importOsgiService(EventPublisher.class);
+    }
+
+    @Bean
+    public BuildUtilsInfo buildUtilsInfo() {
+        return importOsgiService(BuildUtilsInfo.class);
     }
 
     @Bean


### PR DESCRIPTION
* added `GET` `/application/properties` endpoint - currently returning just the application version (already in Postman)
* set the version as a default for the `JiraVersion` field
* make the field `disabled` so customers will always deploy the same version as they are currently running