### PR TITLE
Don't render any user input in ASI config step if there are no ASI's in chosen region.

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -18,9 +18,8 @@ import styled from 'styled-components';
 import { ButtonGroup } from '@atlaskit/button';
 import { Button } from '@atlaskit/button/dist/cjs/components/Button';
 import { Redirect } from 'react-router-dom';
-import Spinner from '@atlaskit/spinner';
 import SectionMessage from '@atlaskit/section-message';
-import { ExistingASIConfiguration, ASISelector, ASIDescription } from './ExistingASIConfiguration';
+import { ExistingASIConfiguration, ASIDescription } from './ExistingASIConfiguration';
 import { I18n } from '../../../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { CancelButton } from '../../../shared/CancelButton';
 import { quickstartPath } from '../../../../utils/RoutePaths';
@@ -94,7 +93,9 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
                 onSelectDeploymentMode={onSelectDeploymentMode}
             />
         ) : (
-            <ASISelector existingASIs={[]} useExisting={false} handlePrefixUpdated={updatePRefix} />
+            <SectionMessage>
+                <p>{I18n.getText('atlassian.migration.datacenter.provision.aws.asi.none')}</p>
+            </SectionMessage>
         );
     };
 
@@ -128,7 +129,7 @@ export const ASIConfiguration: FunctionComponent<ASIConfigurationProps> = ({
                         onClick={handleSubmit}
                         type="submit"
                         appearance="primary"
-                        isDisabled={prefix?.length === 0}
+                        isDisabled={existingASIPrefixes?.length !== 0 && prefix?.length === 0}
                         data-test="asi-submit"
                         isLoading={loadingPrefixes}
                     >

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -61,6 +61,7 @@ atlassian.migration.datacenter.provision.aws.asi.description=The Atlassian Stand
 atlassian.migration.datacenter.provision.aws.asi.found=We found an existing ASI in your region. You can deploy to this ASI, or create a new one
 atlassian.migration.datacenter.provision.aws.asi.chooseDeploymentMethod.label=Deploy to
 atlassian.migration.datacenter.provision.aws.asi.details=Identifier used in all variables (VPCID, SubnetIDs, KeyName) exported from this deployment's Atlassian Standard Infrastructure. Use different identifiers if you're deploying multiple Atlassian Standard Infrastructures in the same AWS region. Format is 3 upper case letters followed by ”-“.
+atlassian.migration.datacenter.provision.aws.asi.none=We didn't find an ASI in your chosen region, so we'll help you create one in the next step
 atlassian.migration.datacenter.provision.aws.asi.option.existing=Existing ASI
 atlassian.migration.datacenter.provision.aws.asi.option.new=New ASI
 atlassian.migration.datacenter.provision.aws.asi.prefix=ASI identifier


### PR DESCRIPTION
## Summary

* Don't render text input when no ASI's
* Show text explaining why
* Allow transition to next page

## No ASIs in region

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/21027663/85974559-22433500-ba19-11ea-9ca9-9c28b0ab67eb.png">


## ASIs in region

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/21027663/85974470-dee8c680-ba18-11ea-92bd-86b6ad5c81c2.png">
