### PR TITLE
allow all stage specific error states to be transitioned to from generic error stages

### DIFF
--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
@@ -38,7 +38,8 @@ enum class MigrationStage {
         override val validAncestorStages = setOf(PROVISION_MIGRATION_STACK)
     },
     PROVISIONING_ERROR {
-        override val validAncestorStages = setOf(PROVISION_APPLICATION, PROVISION_APPLICATION_WAIT, PROVISION_MIGRATION_STACK, PROVISION_MIGRATION_STACK_WAIT)
+        override val validAncestorStages
+            get() = setOf(PROVISION_APPLICATION, PROVISION_APPLICATION_WAIT, PROVISION_MIGRATION_STACK, PROVISION_MIGRATION_STACK_WAIT, ERROR)
     },
     FS_MIGRATION_COPY {
         override val validAncestorStages = setOf(PROVISION_MIGRATION_STACK_WAIT)
@@ -47,7 +48,8 @@ enum class MigrationStage {
         override val validAncestorStages = setOf(FS_MIGRATION_COPY)
     },
     FS_MIGRATION_ERROR {
-        override val validAncestorStages = setOf(FS_MIGRATION_COPY, FS_MIGRATION_COPY_WAIT)
+        override val validAncestorStages
+            get() = setOf(FS_MIGRATION_COPY, FS_MIGRATION_COPY_WAIT, ERROR)
     },
     OFFLINE_WARNING {
         override val validAncestorStages = setOf(FS_MIGRATION_COPY_WAIT)
@@ -77,7 +79,8 @@ enum class MigrationStage {
             get() = setOf(DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_ERROR)
     },
     FINAL_SYNC_ERROR {
-        override val validAncestorStages = setOf(DB_MIGRATION_EXPORT, DB_MIGRATION_EXPORT_WAIT, DB_MIGRATION_UPLOAD, DB_MIGRATION_UPLOAD_WAIT, DATA_MIGRATION_IMPORT, DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_WAIT)
+        override val validAncestorStages
+            get() = setOf(DB_MIGRATION_EXPORT, DB_MIGRATION_EXPORT_WAIT, DB_MIGRATION_UPLOAD, DB_MIGRATION_UPLOAD_WAIT, DATA_MIGRATION_IMPORT, DATA_MIGRATION_IMPORT_WAIT, FINAL_SYNC_WAIT, ERROR)
     },
     VALIDATE {
         override val validAncestorStages = setOf(FINAL_SYNC_WAIT)


### PR DESCRIPTION
I was going to implement CHET-557 and create the retry transition for fs bulk copy, but it was already implemented. I then noticed that we don't actually use the stage-specific migration stages except for when aborting the migration, which means that retrying would not work in many cases because the process would be in the generic error state and not the specific error state. I've added this transition as a bit of a band-aid. When retrying, we always abort the process first, which will transition to the stage-specific error state. This will allow the retry to work.

Ideally, we would refactor how error handling works across the board and remove this semantic coupling but I think that's too risky given release is next week.
