### PR TITLE
CHET-548: Ignore the export folder when running initial sync to S3

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawler.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 public class DirectoryStreamCrawler implements Crawler {
     private static final Logger logger = LoggerFactory.getLogger(DirectoryStreamCrawler.class);
 
-    private static final String ignorePattern = "^(dbconfig\\.xml|caches|import|plugins/.bundled_plugins|plugins/.osgi-plugins)";
+    private static final String ignorePattern = "^(dbconfig\\.xml|caches|import|export|plugins/.bundled_plugins|plugins/.osgi-plugins)";
     private static final Pattern defaultIgnoreList = Pattern.compile(ignorePattern);
 
     private FileSystemMigrationReport report;

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/DirectoryStreamCrawlerTest.java
@@ -63,9 +63,11 @@ class DirectoryStreamCrawlerTest {
 
         final Path ignored1 = Files.createDirectory(tempDir.resolve("import"));
         final Path ignored2 = Files.createDirectories(tempDir.resolve("plugins/.osgi-plugins"));
+        final Path ignored3 = Files.createDirectories(tempDir.resolve("export"));
         ignoredPaths.add(Files.write(tempDir.resolve("dbconfig.xml"), "subfile".getBytes()));
         ignoredPaths.add(Files.write(ignored1.resolve("ignore1.txt"), "subfile".getBytes()));
         ignoredPaths.add(Files.write(ignored2.resolve("ignore2.txt"), "subfile".getBytes()));
+        ignoredPaths.add(Files.write(ignored3.resolve("export-file.zip"), "subfile".getBytes()));
 
     }
 


### PR DESCRIPTION
The `export` folder can contain a huge amount of data - by default there is a scheduled daily job that saves XML export from the database. On a large instance, it means 7.5 GB daily.