### PR TITLE
CHET-556: Decouple pg_dump availability check logic

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -27,8 +27,10 @@ import com.atlassian.migration.datacenter.analytics.events.MigrationTransitionEv
 import com.atlassian.migration.datacenter.analytics.events.MigrationTransitionFailedEvent;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
+import com.atlassian.migration.datacenter.core.db.DatabaseClientTools;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractor;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
+import com.atlassian.migration.datacenter.core.db.PostgresClientTooling;
 import com.atlassian.migration.datacenter.core.proxy.ReadOnlyEntityInvocationHandler;
 import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.dto.MigrationContext;
@@ -138,12 +140,16 @@ public class AWSMigrationService implements MigrationService {
     @Override
     public MigrationReadyStatus getReadyStatus()
     {
-        DatabaseExtractor databaseExtractor = databaseExtractorFactory.getExtractor();
+        /*
+         * TODO: For now we only support Postgres. Once support for database types is 
+         * expanded introduce a factory here that will return the correct implementation
+         */
+        DatabaseClientTools dbClientTooling = new PostgresClientTooling(applicationConfiguration);
 
         Boolean db = applicationConfiguration.getDatabaseConfiguration().getType() == DatabaseConfiguration.DBType.POSTGRESQL;
         Boolean os = SystemUtils.IS_OS_LINUX;
-        SemVer pgDumpVer = databaseExtractor.getClientVersion();
-        SemVer pgServerVer = databaseExtractor.getServerVersion();
+        SemVer pgDumpVer = dbClientTooling.getDatabaseDumpClientVersion();
+        SemVer pgServerVer = dbClientTooling.getDatabaseServerVersion();
         Boolean pgDumpAvail = pgDumpVer != null;
 
        // From the pg_dump manpage: "pg_dump cannot dump from PostgreSQL servers newer than its own

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/DatabaseClientTools.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/DatabaseClientTools.kt
@@ -15,16 +15,12 @@
  */
 package com.atlassian.migration.datacenter.core.db
 
-import com.atlassian.migration.datacenter.spi.exceptions.DatabaseMigrationFailure
-import java.nio.file.Path
+import net.swiftzer.semver.SemVer
 
-interface DatabaseExtractor {
-    @Throws(DatabaseMigrationFailure::class)
-    fun startDatabaseDump(target: Path): Process?
+interface DatabaseClientTools {
+    fun getDatabaseDumpClientVersion(): SemVer?
+    
+    fun getDatabaseServerVersion(): SemVer?
 
-    @Throws(DatabaseMigrationFailure::class)
-    fun startDatabaseDump(target: Path, parallel: Boolean): Process
-
-    @Throws(DatabaseMigrationFailure::class)
-    fun dumpDatabase(to: Path)
+    fun getDatabaseDumpClientPath(): String?
 }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/DefaultDatabaseExtractorFactory.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/DefaultDatabaseExtractorFactory.kt
@@ -19,10 +19,10 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration.DBType
 import com.atlassian.migration.datacenter.spi.exceptions.DatabaseMigrationFailure
 
-class DefaultDatabaseExtractorFactory(val config: ApplicationConfiguration) : DatabaseExtractorFactory {
+class DefaultDatabaseExtractorFactory(val config: ApplicationConfiguration, val databaseClientTools: DatabaseClientTools) : DatabaseExtractorFactory {
     override val extractor: DatabaseExtractor by lazy {
         if (config.databaseConfiguration.type == DBType.POSTGRESQL) {
-            PostgresExtractor(config)
+            PostgresExtractor(config, databaseClientTools)
         } else {
             UnSupportedDatabaseExtractor()
         }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientTooling.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientTooling.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.atlassian.migration.datacenter.core.db
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.impossibl.postgres.jdbc.PGDriver
+import net.swiftzer.semver.SemVer
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.sql.SQLException
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class PostgresClientTooling(private val applicationConfiguration: ApplicationConfiguration) : DatabaseClientTools {
+    companion object {
+        private val log = LoggerFactory.getLogger(PostgresClientTooling::class.java)
+        private val pddumpPaths = arrayOf("/usr/bin/pg_dump", "/usr/local/bin/pg_dump")
+        private val versionPattern = Regex("^pg_dump\\s+\\([^\\)]+\\)\\s+(\\d[\\d\\.]+)[\\s$]")
+        
+        @JvmStatic
+        fun parsePgDumpVersion(text: String): SemVer? {
+            val match = versionPattern.find(text) ?: return null
+            return SemVer.parse(match.groupValues[1])
+        }
+    }
+
+    /**
+     * Get the the pg_dump version
+     *
+     * @return semantic version of the dump utility
+     */
+    override fun getDatabaseDumpClientVersion(): SemVer? {
+        val pgdump = pgdumpPath ?: return null
+
+        try {
+            val proc = ProcessBuilder(pgdump,
+                    "--version")
+                    .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                    .redirectError(ProcessBuilder.Redirect.PIPE)
+                    .start()
+
+            proc.waitFor(60, TimeUnit.SECONDS)
+
+            val message = proc.inputStream.bufferedReader().readText()
+
+            return parsePgDumpVersion(message)
+
+        } catch (e: Exception) {
+            log.error("Failed to get pg_dump version from command-line")
+            return null
+        }
+    }
+
+    /**
+     * Get the path of the pg_dump binary
+     *
+     * @return the path to the dump utility
+     */
+    override fun getDatabaseDumpClientPath(): String? {
+        for (path in pddumpPaths) {
+            val p = Paths.get(path)
+            if (Files.isReadable(p) && Files.isExecutable(p)) {
+                return path
+            }
+        }
+        return null
+    }
+
+    /**
+     * Get the semantic version of the postgres server
+     *
+     * @return the semantic version of postgres in use
+     */
+    override fun getDatabaseServerVersion(): SemVer? {
+        // NOTE: We use the NG Postgres driver here as the official
+        // one doesn't play well with OSGI.
+        val config = applicationConfiguration.databaseConfiguration
+        val url = "jdbc:pgsql://${config.host}:${config.port}/${config.name}"
+        val props = Properties().apply {
+            setProperty("user", config.username)
+            setProperty("password", config.password)
+        }
+
+        val conn = try {
+            PGDriver().connect(url, props)
+        } catch (e: SQLException) {
+            log.error("Exception opening DB connection for version", e)
+            null
+        } ?: return null
+
+        val meta = conn.metaData
+        conn.close()
+
+        return SemVer.parse(meta.databaseProductVersion)
+    }
+
+    private val pgdumpPath: String?
+        get() {
+            for (path in pddumpPaths) {
+                val p = Paths.get(path)
+                if (Files.isReadable(p) && Files.isExecutable(p)) {
+                    return path
+                }
+            }
+            return null
+        }
+}

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/UnSupportedDatabaseExtractor.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/db/UnSupportedDatabaseExtractor.kt
@@ -20,11 +20,6 @@ import net.swiftzer.semver.SemVer
 import java.nio.file.Path
 
 class UnSupportedDatabaseExtractor : DatabaseExtractor {
-    override val clientVersion: SemVer?
-        get() = null
-    override val serverVersion: SemVer?
-        get() = null
-
     @Throws(DatabaseMigrationFailure::class)
     override fun startDatabaseDump(target: Path): Process {
         throw UnsupportedOperationException("Not implemented")

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -24,6 +24,7 @@ import com.atlassian.migration.datacenter.core.aws.db.restore.SsmPsqlDatabaseRes
 import com.atlassian.migration.datacenter.core.aws.infrastructure.AWSMigrationHelperDeploymentService;
 import com.atlassian.migration.datacenter.core.aws.infrastructure.RemoteInstanceCommandRunnerService;
 import com.atlassian.migration.datacenter.core.aws.ssm.SSMApi;
+import com.atlassian.migration.datacenter.core.db.DatabaseClientTools;
 import com.atlassian.migration.datacenter.core.db.DefaultDatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.core.fs.DefaultFileSystemMigrationReportManager;
 import com.atlassian.migration.datacenter.core.fs.FileSystemMigrationReportManager;
@@ -85,6 +86,9 @@ class DatabaseMigrationServiceIT {
     @Mock(lenient = true)
     ApplicationConfiguration configuration;
 
+    @Mock(lenient = true)
+    DatabaseClientTools databaseClientTools;
+    
     FileSystemMigrationReportManager reportManager = new DefaultFileSystemMigrationReportManager();
 
     @Mock
@@ -133,7 +137,7 @@ class DatabaseMigrationServiceIT {
     @Test
     void testDatabaseMigration() throws ExecutionException, InterruptedException, InvalidMigrationStageError, S3SyncFileSystemDownloader.CannotLaunchCommandException {
         MigrationStageCallback archiveStageTransitionCallback = new DatabaseArchiveStageTransitionCallback(migrationService);
-        DatabaseArchivalService databaseArchivalService = new DatabaseArchivalService(new DefaultDatabaseExtractorFactory(configuration), archiveStageTransitionCallback);
+        DatabaseArchivalService databaseArchivalService = new DatabaseArchivalService(new DefaultDatabaseExtractorFactory(configuration, databaseClientTools), archiveStageTransitionCallback);
 
         MigrationStageCallback uploadStageTransitionCallback = new DatabaseUploadStageTransitionCallback(this.migrationService);
         DatabaseArtifactS3UploadService s3UploadService = new DatabaseArtifactS3UploadService(() -> s3client, uploadStageTransitionCallback, reportManager);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/db/DatabaseMigrationServiceIT.java
@@ -26,6 +26,7 @@ import com.atlassian.migration.datacenter.core.aws.infrastructure.RemoteInstance
 import com.atlassian.migration.datacenter.core.aws.ssm.SSMApi;
 import com.atlassian.migration.datacenter.core.db.DatabaseClientTools;
 import com.atlassian.migration.datacenter.core.db.DefaultDatabaseExtractorFactory;
+import com.atlassian.migration.datacenter.core.db.PostgresClientTooling;
 import com.atlassian.migration.datacenter.core.fs.DefaultFileSystemMigrationReportManager;
 import com.atlassian.migration.datacenter.core.fs.FileSystemMigrationReportManager;
 import com.atlassian.migration.datacenter.core.fs.download.s3sync.S3SyncFileSystemDownloader;
@@ -86,7 +87,6 @@ class DatabaseMigrationServiceIT {
     @Mock(lenient = true)
     ApplicationConfiguration configuration;
 
-    @Mock(lenient = true)
     DatabaseClientTools databaseClientTools;
     
     FileSystemMigrationReportManager reportManager = new DefaultFileSystemMigrationReportManager();
@@ -131,6 +131,7 @@ class DatabaseMigrationServiceIT {
                 .build();
         CreateBucketResponse resp = s3client.createBucket(req).get();
         assertTrue(resp.sdkHttpResponse().isSuccessful());
+        databaseClientTools = new PostgresClientTooling(configuration);
     }
 
 

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
@@ -1,71 +1,71 @@
-/*
- * Copyright 2020 Atlassian
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.atlassian.migration.datacenter.core.db
-
-import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
-import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
-import net.swiftzer.semver.SemVer
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.junit.jupiter.MockitoExtension
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.MountableFile
-import kotlin.test.assertEquals
-
-@Testcontainers
-@ExtendWith(MockitoExtension::class)
-internal class PostgresClientToolingIT {
-    companion object {
-        @Container
-        val postgres = PostgreSQLContainer<Nothing>("postgres:9.6.18").apply {
-            withDatabaseName("jira")
-            withCopyFileToContainer(MountableFile.forClasspathResource("db/jira.sql"), "/docker-entrypoint-initdb.d/jira.sql")
-        }
-    }
-
-    @Mock(lenient = true)
-    var configuration: ApplicationConfiguration? = null
-    
-    private lateinit var databaseClientTooling: PostgresClientTooling;
-
-    @BeforeEach
-    fun setUp() {
-        Mockito.`when`(configuration!!.databaseConfiguration)
-                .thenReturn(DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
-                        postgres.containerIpAddress,
-                        postgres.getMappedPort(5432),
-                        postgres.databaseName,
-                        postgres.username,
-                        postgres.password))
-
-        databaseClientTooling = PostgresClientTooling(configuration!!)
-    }
-
-    @AfterEach
-    fun tearDown() {
-    }
-
-    @Test
-    fun itShouldObtainThePostgresServerVersion() {
-        assertEquals(SemVer(9, 6, 18), databaseClientTooling.getDatabaseServerVersion())
-    }
-}
+///*
+// * Copyright 2020 Atlassian
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package com.atlassian.migration.datacenter.core.db
+//
+//import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+//import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
+//import net.swiftzer.semver.SemVer
+//import org.junit.jupiter.api.AfterEach
+//import org.junit.jupiter.api.BeforeEach
+//import org.junit.jupiter.api.Test
+//import org.junit.jupiter.api.extension.ExtendWith
+//import org.mockito.Mock
+//import org.mockito.Mockito
+//import org.mockito.junit.jupiter.MockitoExtension
+//import org.testcontainers.containers.PostgreSQLContainer
+//import org.testcontainers.junit.jupiter.Container
+//import org.testcontainers.junit.jupiter.Testcontainers
+//import org.testcontainers.utility.MountableFile
+//import kotlin.test.assertEquals
+//
+//@Testcontainers
+//@ExtendWith(MockitoExtension::class)
+//internal class PostgresClientToolingIT {
+//    companion object {
+//        @Container
+//        val postgres = PostgreSQLContainer<Nothing>("postgres:9.6.18").apply {
+//            withDatabaseName("jira")
+//            withCopyFileToContainer(MountableFile.forClasspathResource("db/jira.sql"), "/docker-entrypoint-initdb.d/jira.sql")
+//        }
+//    }
+//
+//    @Mock(lenient = true)
+//    var configuration: ApplicationConfiguration? = null
+//    
+//    private lateinit var databaseClientTooling: PostgresClientTooling;
+//
+//    @BeforeEach
+//    fun setUp() {
+//        Mockito.`when`(configuration!!.databaseConfiguration)
+//                .thenReturn(DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
+//                        postgres.containerIpAddress,
+//                        postgres.getMappedPort(5432),
+//                        postgres.databaseName,
+//                        postgres.username,
+//                        postgres.password))
+//
+//        databaseClientTooling = PostgresClientTooling(configuration!!)
+//    }
+//
+//    @AfterEach
+//    fun tearDown() {
+//    }
+//
+//    @Test
+//    fun itShouldObtainThePostgresServerVersion() {
+//        assertEquals(SemVer(9, 6, 18), databaseClientTooling.getDatabaseServerVersion())
+//    }
+//}

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.atlassian.migration.datacenter.core.db
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
+import junit.framework.Assert.assertFalse
+import junit.framework.Assert.assertTrue
+import net.swiftzer.semver.SemVer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils
+import org.testcontainers.utility.MountableFile
+import java.io.FileInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.file.Files
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.*
+import java.util.zip.GZIPInputStream
+import kotlin.test.assertEquals
+
+@Testcontainers
+@ExtendWith(MockitoExtension::class)
+internal class PostgresExtractorIT {
+    companion object {
+        @Container
+        val postgres = PostgreSQLContainer<Nothing>("postgres:9.6.18").apply {
+            withDatabaseName("jira")
+            withCopyFileToContainer(MountableFile.forClasspathResource("db/jira.sql"), "/docker-entrypoint-initdb.d/jira.sql")
+        }
+    }
+
+    @Mock(lenient = true)
+    var configuration: ApplicationConfiguration? = null
+    
+    private lateinit var clientTooling: PostgresClientTooling;
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.`when`(configuration!!.databaseConfiguration)
+                .thenReturn(DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
+                        postgres.containerIpAddress,
+                        postgres.getMappedPort(5432),
+                        postgres.databaseName,
+                        postgres.username,
+                        postgres.password))
+
+        clientTooling = PostgresClientTooling(configuration!!)
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Test
+    @Throws(SQLException::class)
+    fun testPsqlDataImported() {
+        val props = Properties()
+        props["user"] = postgres.username
+        props["password"] = postgres.password
+
+        val conn = DriverManager.getConnection(postgres.jdbcUrl, props)
+        val s = conn.createStatement()
+        val r = s.executeQuery("SELECT id, summary FROM jiraissue WHERE issuenum = 1;")
+        assertTrue(r.next())
+
+        val summary = r.getString(2)
+        assertTrue(summary.startsWith("As an Agile team, I'd like to learn about Scrum"))
+        assertFalse(r.next())
+
+        r.close()
+        s.close()
+        conn.close()
+    }
+
+    @Test
+    fun testServerVersion() {
+        val migration = PostgresExtractor(configuration!!, clientTooling!!)
+        assertEquals(SemVer(9, 6, 18), clientTooling?.getDatabaseServerVersion())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun testDatabaseDump() {
+        val migration = PostgresExtractor(configuration!!, clientTooling!!)
+        val tempDir = createTempDir().toPath()
+        val target = tempDir.resolve("database.dump")
+
+        migration.dumpDatabase(target)
+        assertTrue(target.toFile().exists())
+        assertTrue(target.toFile().isDirectory)
+
+        var found = false
+        for (p in Files.newDirectoryStream(target, "*.gz")) {
+            val stream: InputStream = GZIPInputStream(FileInputStream(p.toFile()))
+            for (line in IOUtils.readLines(stream, "UTF-8")) {
+                if (line.contains("As an Agile team, I'd like to learn about Scrum")) {
+                    found = true
+                    break
+                }
+            }
+        }
+
+        assertTrue(found)
+    }
+
+}

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
@@ -1,71 +1,71 @@
-///*
-// * Copyright 2020 Atlassian
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package com.atlassian.migration.datacenter.core.db
-//
-//import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
-//import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
-//import net.swiftzer.semver.SemVer
-//import org.junit.jupiter.api.AfterEach
-//import org.junit.jupiter.api.BeforeEach
-//import org.junit.jupiter.api.Test
-//import org.junit.jupiter.api.extension.ExtendWith
-//import org.mockito.Mock
-//import org.mockito.Mockito
-//import org.mockito.junit.jupiter.MockitoExtension
-//import org.testcontainers.containers.PostgreSQLContainer
-//import org.testcontainers.junit.jupiter.Container
-//import org.testcontainers.junit.jupiter.Testcontainers
-//import org.testcontainers.utility.MountableFile
-//import kotlin.test.assertEquals
-//
-//@Testcontainers
-//@ExtendWith(MockitoExtension::class)
-//internal class PostgresClientToolingIT {
-//    companion object {
-//        @Container
-//        val postgres = PostgreSQLContainer<Nothing>("postgres:9.6.18").apply {
-//            withDatabaseName("jira")
-//            withCopyFileToContainer(MountableFile.forClasspathResource("db/jira.sql"), "/docker-entrypoint-initdb.d/jira.sql")
-//        }
-//    }
-//
-//    @Mock(lenient = true)
-//    var configuration: ApplicationConfiguration? = null
-//    
-//    private lateinit var databaseClientTooling: PostgresClientTooling;
-//
-//    @BeforeEach
-//    fun setUp() {
-//        Mockito.`when`(configuration!!.databaseConfiguration)
-//                .thenReturn(DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
-//                        postgres.containerIpAddress,
-//                        postgres.getMappedPort(5432),
-//                        postgres.databaseName,
-//                        postgres.username,
-//                        postgres.password))
-//
-//        databaseClientTooling = PostgresClientTooling(configuration!!)
-//    }
-//
-//    @AfterEach
-//    fun tearDown() {
-//    }
-//
-//    @Test
-//    fun itShouldObtainThePostgresServerVersion() {
-//        assertEquals(SemVer(9, 6, 18), databaseClientTooling.getDatabaseServerVersion())
-//    }
-//}
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.atlassian.migration.datacenter.core.db
+
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
+import net.swiftzer.semver.SemVer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.MountableFile
+import kotlin.test.assertEquals
+
+@Testcontainers
+@ExtendWith(MockitoExtension::class)
+internal class PostgresClientToolingIT {
+    companion object {
+        @Container
+        val postgres = PostgreSQLContainer<Nothing>("postgres:9.6.18").apply {
+            withDatabaseName("jira")
+            withCopyFileToContainer(MountableFile.forClasspathResource("db/jira.sql"), "/docker-entrypoint-initdb.d/jira.sql")
+        }
+    }
+
+    @Mock(lenient = true)
+    var configuration: ApplicationConfiguration? = null
+    
+    private lateinit var databaseClientTooling: PostgresClientTooling;
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.`when`(configuration!!.databaseConfiguration)
+                .thenReturn(DatabaseConfiguration(DatabaseConfiguration.DBType.POSTGRESQL,
+                        postgres.containerIpAddress,
+                        postgres.getMappedPort(5432),
+                        postgres.databaseName,
+                        postgres.username,
+                        postgres.password))
+
+        databaseClientTooling = PostgresClientTooling(configuration!!)
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Test
+    fun itShouldObtainThePostgresServerVersion() {
+        assertEquals(SemVer(9, 6, 18), databaseClientTooling.getDatabaseServerVersion())
+    }
+}

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingIT.kt
@@ -17,8 +17,6 @@ package com.atlassian.migration.datacenter.core.db
 
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
 import net.swiftzer.semver.SemVer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -30,16 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils
 import org.testcontainers.utility.MountableFile
-import java.io.FileInputStream
-import java.io.IOException
-import java.io.InputStream
-import java.nio.file.Files
-import java.sql.DriverManager
-import java.sql.SQLException
-import java.util.*
-import java.util.zip.GZIPInputStream
 import kotlin.test.assertEquals
 
 @Testcontainers
@@ -56,7 +45,7 @@ internal class PostgresClientToolingIT {
     @Mock(lenient = true)
     var configuration: ApplicationConfiguration? = null
     
-    private lateinit var clientTooling: PostgresClientTooling;
+    private lateinit var databaseClientTooling: PostgresClientTooling;
 
     @BeforeEach
     fun setUp() {
@@ -68,7 +57,7 @@ internal class PostgresClientToolingIT {
                         postgres.username,
                         postgres.password))
 
-        clientTooling = PostgresClientTooling(configuration!!)
+        databaseClientTooling = PostgresClientTooling(configuration!!)
     }
 
     @AfterEach
@@ -77,6 +66,6 @@ internal class PostgresClientToolingIT {
 
     @Test
     fun itShouldObtainThePostgresServerVersion() {
-        assertEquals(SemVer(9, 6, 18), clientTooling.getDatabaseServerVersion())
+        assertEquals(SemVer(9, 6, 18), databaseClientTooling.getDatabaseServerVersion())
     }
 }

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
-internal class PostgresExtractorTest {
+internal class PostgresClientToolingTest {
 
     companion object {
         @JvmStatic
@@ -69,6 +69,4 @@ internal class PostgresExtractorTest {
     fun testWithKnownValues(param: Pair<String, SemVer>) {
         assertEquals(param.second, PostgresClientTooling.parsePgDumpVersion(param.first))
     }
-
-
 }

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingTest.kt
@@ -33,7 +33,7 @@ internal class PostgresClientToolingTest {
             Pair("pg_dump (PostgreSQL) 9.5.21\n", SemVer(9, 5, 21)),
 
             // Ubuntu bionic
-                Pair("pg_dump (PostgreSQL) 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)\n", SemVer(10, 12)),
+            Pair("pg_dump (PostgreSQL) 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)\n", SemVer(10, 12)),
 
             // Ubuntu eoan
             Pair("pg_dump (PostgreSQL) 11.7 (Ubuntu 11.7-0ubuntu0.19.10.1)\n", SemVer(11, 7)),

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresClientToolingTest.kt
@@ -33,7 +33,7 @@ internal class PostgresExtractorTest {
             Pair("pg_dump (PostgreSQL) 9.5.21\n", SemVer(9, 5, 21)),
 
             // Ubuntu bionic
-            Pair("pg_dump (PostgreSQL) 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)\n", SemVer(10, 12)),
+                Pair("pg_dump (PostgreSQL) 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)\n", SemVer(10, 12)),
 
             // Ubuntu eoan
             Pair("pg_dump (PostgreSQL) 11.7 (Ubuntu 11.7-0ubuntu0.19.10.1)\n", SemVer(11, 7)),

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.kt
@@ -55,6 +55,8 @@ internal class PostgresExtractorIT {
 
     @Mock(lenient = true)
     var configuration: ApplicationConfiguration? = null
+    
+    private lateinit var clientTooling: PostgresClientTooling;
 
     @BeforeEach
     fun setUp() {
@@ -65,6 +67,8 @@ internal class PostgresExtractorIT {
                         postgres.databaseName,
                         postgres.username,
                         postgres.password))
+
+        clientTooling = PostgresClientTooling(configuration!!)
     }
 
     @AfterEach
@@ -94,14 +98,14 @@ internal class PostgresExtractorIT {
 
     @Test
     fun testServerVersion() {
-        val migration = PostgresExtractor(configuration!!)
-        assertEquals(SemVer(9, 6, 18), migration.serverVersion)
+        val migration = PostgresExtractor(configuration!!, clientTooling!!)
+        assertEquals(SemVer(9, 6, 18), clientTooling?.getDatabaseServerVersion())
     }
 
     @Test
     @Throws(IOException::class)
     fun testDatabaseDump() {
-        val migration = PostgresExtractor(configuration!!)
+        val migration = PostgresExtractor(configuration!!, clientTooling!!)
         val tempDir = createTempDir().toPath()
         val target = tempDir.resolve("database.dump")
 

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresExtractorIT.kt
@@ -19,7 +19,6 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration
 import junit.framework.Assert.assertFalse
 import junit.framework.Assert.assertTrue
-import net.swiftzer.semver.SemVer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -40,7 +39,6 @@ import java.sql.DriverManager
 import java.sql.SQLException
 import java.util.*
 import java.util.zip.GZIPInputStream
-import kotlin.test.assertEquals
 
 @Testcontainers
 @ExtendWith(MockitoExtension::class)
@@ -56,7 +54,7 @@ internal class PostgresExtractorIT {
     @Mock(lenient = true)
     var configuration: ApplicationConfiguration? = null
     
-    private lateinit var clientTooling: PostgresClientTooling;
+    private lateinit var databaseClientTooling: PostgresClientTooling
 
     @BeforeEach
     fun setUp() {
@@ -68,7 +66,7 @@ internal class PostgresExtractorIT {
                         postgres.username,
                         postgres.password))
 
-        clientTooling = PostgresClientTooling(configuration!!)
+        databaseClientTooling = PostgresClientTooling(configuration!!)
     }
 
     @AfterEach
@@ -97,15 +95,9 @@ internal class PostgresExtractorIT {
     }
 
     @Test
-    fun testServerVersion() {
-        val migration = PostgresExtractor(configuration!!, clientTooling!!)
-        assertEquals(SemVer(9, 6, 18), clientTooling?.getDatabaseServerVersion())
-    }
-
-    @Test
     @Throws(IOException::class)
     fun testDatabaseDump() {
-        val migration = PostgresExtractor(configuration!!, clientTooling!!)
+        val migration = PostgresExtractor(configuration!!, databaseClientTooling)
         val tempDir = createTempDir().toPath()
         val target = tempDir.resolve("database.dump")
 

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresExtractorTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/db/PostgresExtractorTest.kt
@@ -67,7 +67,7 @@ internal class PostgresExtractorTest {
     @ParameterizedTest
     @MethodSource("versions")
     fun testWithKnownValues(param: Pair<String, SemVer>) {
-        assertEquals(param.second, PostgresExtractor.parsePgDumpVersion(param.first))
+        assertEquals(param.second, PostgresClientTooling.parsePgDumpVersion(param.first))
     }
 
 

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -141,7 +141,7 @@ export const ReadyStatus: FunctionComponent<ReadyProps> = ({ ready }) => {
                     {readyString(ready?.pgDumpAvailable)}
                 </li>
                 <li>
-                    the <strong>pg_dump</strong> utility is compatible with the server version
+                    <strong>pg_dump</strong> utility is compatible with the server version &nbsp;{' '}
                     &nbsp; {readyString(ready?.pgDumpCompatible)}
                 </li>
                 <li>

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -288,7 +288,7 @@ public class MigrationAssistantBeanConfiguration {
         return new DatabaseArchivalService(databaseExtractorFactory, archiveStageTransitionCallback);
     }
 
-    @Bean   
+    @Bean
     public S3SyncFileSystemDownloadManager s3SyncFileSystemDownloadManager(S3SyncFileSystemDownloader downloader) {
         return new S3SyncFileSystemDownloadManager(downloader);
     }

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -58,9 +58,10 @@ import com.atlassian.migration.datacenter.core.aws.region.AvailabilityZoneManage
 import com.atlassian.migration.datacenter.core.aws.region.PluginSettingsRegionManager;
 import com.atlassian.migration.datacenter.core.aws.region.RegionService;
 import com.atlassian.migration.datacenter.core.aws.ssm.SSMApi;
+import com.atlassian.migration.datacenter.core.db.DatabaseClientTools;
 import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.core.db.DefaultDatabaseExtractorFactory;
-import com.atlassian.migration.datacenter.core.exceptions.AwsQueueError;
+import com.atlassian.migration.datacenter.core.db.PostgresClientTooling;
 import com.atlassian.migration.datacenter.core.fs.DefaultFileSystemMigrationReportManager;
 import com.atlassian.migration.datacenter.core.fs.DefaultFilesystemUploaderFactory;
 import com.atlassian.migration.datacenter.core.fs.FileSystemMigrationReportManager;
@@ -160,6 +161,11 @@ public class MigrationAssistantBeanConfiguration {
                 .credentialsProvider(awsCredentialsProvider)
                 .region(Region.of(regionService.getRegion()))
                 .build();
+    }
+
+    @Bean
+    public DatabaseClientTools databaseClientTools(ApplicationConfiguration applicationConfiguration) {
+        return new PostgresClientTooling(applicationConfiguration);
     }
     
     @Bean
@@ -272,8 +278,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public DatabaseExtractorFactory databaseExtractorFactory(ApplicationConfiguration applicationConfiguration) {
-        return new DefaultDatabaseExtractorFactory(applicationConfiguration);
+    public DatabaseExtractorFactory databaseExtractorFactory(ApplicationConfiguration applicationConfiguration, DatabaseClientTools databaseClientTools) {
+        return new DefaultDatabaseExtractorFactory(applicationConfiguration, databaseClientTools);
     }
 
     @Bean
@@ -281,7 +287,7 @@ public class MigrationAssistantBeanConfiguration {
         return new DatabaseArchivalService(databaseExtractorFactory, archiveStageTransitionCallback);
     }
 
-    @Bean
+    @Bean   
     public S3SyncFileSystemDownloadManager s3SyncFileSystemDownloadManager(S3SyncFileSystemDownloader downloader) {
         return new S3SyncFileSystemDownloadManager(downloader);
     }


### PR DESCRIPTION
extract `pg_dump` availability and version checks so that they can be run independently. 