### PR TITLE
Chet 558 inject non facade AWS migration service bean

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -28,8 +28,6 @@ import com.atlassian.migration.datacenter.analytics.events.MigrationTransitionFa
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
 import com.atlassian.migration.datacenter.core.db.DatabaseClientTools;
-import com.atlassian.migration.datacenter.core.db.DatabaseExtractor;
-import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.core.db.PostgresClientTooling;
 import com.atlassian.migration.datacenter.core.proxy.ReadOnlyEntityInvocationHandler;
 import com.atlassian.migration.datacenter.dto.Migration;
@@ -42,11 +40,11 @@ import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageEr
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException;
 import net.swiftzer.semver.SemVer;
 import org.apache.commons.lang3.SystemUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Proxy;
-import java.nio.file.Path;
 
 import static com.atlassian.migration.datacenter.spi.MigrationStage.ERROR;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.NOT_STARTED;
@@ -59,8 +57,6 @@ public class AWSMigrationService implements MigrationService {
     private static final Logger log = LoggerFactory.getLogger(AWSMigrationService.class);
     private ActiveObjects ao;
     private ApplicationConfiguration applicationConfiguration;
-    private DatabaseExtractorFactory databaseExtractorFactory;
-    private Path localHome;
     private EventPublisher eventPublisher;
 
     /**
@@ -68,13 +64,9 @@ public class AWSMigrationService implements MigrationService {
      */
     public AWSMigrationService(ActiveObjects ao,
                                ApplicationConfiguration applicationConfiguration,
-                               DatabaseExtractorFactory databaseExtractorFactory,
-                               Path jiraHome,
                                EventPublisher eventPublisher) {
         this.ao = requireNonNull(ao);
         this.applicationConfiguration = applicationConfiguration;
-        this.databaseExtractorFactory = databaseExtractorFactory;
-        this.localHome = jiraHome;
         this.eventPublisher = eventPublisher;
     }
 
@@ -241,6 +233,11 @@ public class AWSMigrationService implements MigrationService {
             log.error("Expected one Migration, found multiple.");
             throw new RuntimeException("Invalid State - should only be 1 migration");
         }
+    }
+
+    @Override
+    public void stageSpecificError(@NotNull MigrationStage stage, @NotNull Throwable e) {
+        throw new UnsupportedOperationException("Implementation coming soon");
     }
 }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
@@ -30,10 +30,8 @@ import java.nio.file.Path;
 public class AllowAnyTransitionMigrationServiceFacade extends AWSMigrationService implements MigrationService {
     public AllowAnyTransitionMigrationServiceFacade(ActiveObjects activeObjects,
                                                     ApplicationConfiguration applicationConfiguration,
-                                                    DatabaseExtractorFactory databaseExtractorFactory,
-                                                    Path home,
                                                     EventPublisher eventPublisher) {
-        super(activeObjects, applicationConfiguration, databaseExtractorFactory, home, eventPublisher);
+        super(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Override

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.nio.file.Paths;
 import java.util.Arrays;
 
 import static com.atlassian.migration.datacenter.spi.MigrationStage.AUTHENTICATION;
@@ -88,7 +87,7 @@ public class AWSMigrationServiceTest {
     public void setup() {
         assertNotNull(entityManager);
         ao = new TestActiveObjects(entityManager);
-        sut = new AWSMigrationService(ao, applicationConfiguration, databaseExtractorFactory, Paths.get("."), eventPublisher);
+        sut = new AWSMigrationService(ao, applicationConfiguration, eventPublisher);
         setupEntities();
         when(applicationConfiguration.getPluginVersion()).thenReturn("DUMMY");
         when(databaseExtractorFactory.getExtractor()).thenReturn(databaseExtractor);

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -23,7 +23,7 @@ import com.atlassian.jira.issue.attachment.AttachmentStore;
 import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.JiraConfiguration;
-import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
+import com.atlassian.migration.datacenter.core.aws.AWSMigrationService;
 import com.atlassian.migration.datacenter.core.aws.CancellableMigrationServiceHandler;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.aws.GlobalInfrastructure;
@@ -264,8 +264,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, DatabaseExtractorFactory databaseExtractorFactory, JiraHome jiraHome, EventPublisher eventPublisher) {
-        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, databaseExtractorFactory, jiraHome.getHome().toPath(), eventPublisher);
+    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new AWSMigrationService(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
@@ -18,27 +18,20 @@ package com.atlassian.migration.datacenter.configuration;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.event.api.EventPublisher;
-import com.atlassian.jira.config.util.JiraHome;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
-import com.atlassian.migration.datacenter.core.aws.SqsApi;
-import com.atlassian.migration.datacenter.core.aws.SqsApiImpl;
-import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-
-import java.util.function.Supplier;
 
 @Configuration
 public class MigrationAssistantProfileSpecificConfiguration {
     @Bean
     @Profile("allowAnyTransition")
     @Primary
-    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, DatabaseExtractorFactory databaseExtractorFactory, JiraHome jiraHome, EventPublisher eventPublisher) {
-        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, databaseExtractorFactory, jiraHome.getHome().toPath(), eventPublisher);
+    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher);
     }
 }

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
@@ -98,6 +98,13 @@ interface MigrationService {
     fun error(e: Throwable)
 
     /**
+     * Moves the migration into a stage specific error stage, storing the cause.
+     *
+     * @see MigrationStage.ERROR
+     */
+    fun stageSpecificError(stage: MigrationStage, e: Throwable)
+
+    /**
      * Moves the migration to the final state (if valid) and performs any cleanup.
      *
      * @see MigrationStage.FINISHED


### PR DESCRIPTION
Return AWS migration service from the bean configuration.

Remove a few unused parameters from the service