### PR TITLE
Chet 558 stage specific error

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -41,7 +41,6 @@ import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsE
 import net.java.ao.Query;
 import net.swiftzer.semver.SemVer;
 import org.apache.commons.lang3.SystemUtils;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -217,12 +216,6 @@ public abstract class AWSMigrationService implements MigrationService {
             log.error("Expected one Migration, found multiple.");
             throw new RuntimeException("Invalid State - should only be 1 migration");
         }
-    }
-
-
-    @Override
-    public void stageSpecificError(@NotNull MigrationStage stage, @NotNull Throwable e) {
-        throw new UnsupportedOperationException("Implementation coming soon");
     }
 
     private List<Migration> findNonFinishedMigrations() {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -28,8 +28,6 @@ import com.atlassian.migration.datacenter.analytics.events.MigrationTransitionFa
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.DatabaseConfiguration;
 import com.atlassian.migration.datacenter.core.db.DatabaseClientTools;
-import com.atlassian.migration.datacenter.core.db.DatabaseExtractor;
-import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.core.db.PostgresClientTooling;
 import com.atlassian.migration.datacenter.core.proxy.ReadOnlyEntityInvocationHandler;
 import com.atlassian.migration.datacenter.dto.Migration;
@@ -42,11 +40,11 @@ import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageEr
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException;
 import net.swiftzer.semver.SemVer;
 import org.apache.commons.lang3.SystemUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Proxy;
-import java.nio.file.Path;
 
 import static com.atlassian.migration.datacenter.spi.MigrationStage.ERROR;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.NOT_STARTED;
@@ -59,8 +57,6 @@ public class AWSMigrationService implements MigrationService {
     private static final Logger log = LoggerFactory.getLogger(AWSMigrationService.class);
     private ActiveObjects ao;
     private ApplicationConfiguration applicationConfiguration;
-    private DatabaseExtractorFactory databaseExtractorFactory;
-    private Path localHome;
     private EventPublisher eventPublisher;
 
     /**
@@ -68,13 +64,9 @@ public class AWSMigrationService implements MigrationService {
      */
     public AWSMigrationService(ActiveObjects ao,
                                ApplicationConfiguration applicationConfiguration,
-                               DatabaseExtractorFactory databaseExtractorFactory,
-                               Path jiraHome,
                                EventPublisher eventPublisher) {
         this.ao = requireNonNull(ao);
         this.applicationConfiguration = applicationConfiguration;
-        this.databaseExtractorFactory = databaseExtractorFactory;
-        this.localHome = jiraHome;
         this.eventPublisher = eventPublisher;
     }
 
@@ -241,6 +233,11 @@ public class AWSMigrationService implements MigrationService {
             log.error("Expected one Migration, found multiple.");
             throw new RuntimeException("Invalid State - should only be 1 migration");
         }
+    }
+
+    @Override
+    public void stageSpecificError(@NotNull MigrationStage stage, @NotNull Throwable e) {
+        throw new UnsupportedOperationException("Implementation coming soon");
     }
 }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
@@ -30,10 +30,8 @@ import java.nio.file.Path;
 public class AllowAnyTransitionMigrationServiceFacade extends AWSMigrationService implements MigrationService {
     public AllowAnyTransitionMigrationServiceFacade(ActiveObjects activeObjects,
                                                     ApplicationConfiguration applicationConfiguration,
-                                                    DatabaseExtractorFactory databaseExtractorFactory,
-                                                    Path home,
                                                     EventPublisher eventPublisher) {
-        super(activeObjects, applicationConfiguration, databaseExtractorFactory, home, eventPublisher);
+        super(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Override

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
@@ -27,7 +27,7 @@ import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageEr
 
 import java.nio.file.Path;
 
-public class AllowAnyTransitionMigrationServiceFacade extends AWSMigrationService implements MigrationService {
+public class AllowAnyTransitionMigrationServiceFacade extends AwsMigrationServiceWrapper implements MigrationService {
     public AllowAnyTransitionMigrationServiceFacade(ActiveObjects activeObjects,
                                                     ApplicationConfiguration applicationConfiguration,
                                                     EventPublisher eventPublisher) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -143,7 +143,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
         report.setStatus(FAILED);
         bulkCopy.abortCopy();
 
-        migrationService.error("File system migration was aborted");
+        migrationService.stageSpecificError(FS_MIGRATION_ERROR,"File system migration was aborted");
     }
 
     private JobId getScheduledJobIdForMigration(int migrationId) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -33,7 +33,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.core.env.Environment;
 
+import static com.atlassian.migration.datacenter.spi.MigrationStage.*;
 import static com.atlassian.migration.datacenter.spi.MigrationStage.FS_MIGRATION_COPY;
+import static com.atlassian.migration.datacenter.spi.MigrationStage.FS_MIGRATION_ERROR;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DONE;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.DOWNLOADING;
 import static com.atlassian.migration.datacenter.spi.fs.reporting.FilesystemMigrationStatus.FAILED;
@@ -69,7 +71,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
 
     @Override
     public boolean isRunning() {
-        return this.migrationService.getCurrentStage().equals(MigrationStage.FS_MIGRATION_COPY_WAIT);
+        return this.migrationService.getCurrentStage().equals(FS_MIGRATION_COPY_WAIT);
     }
 
     @Override
@@ -82,7 +84,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
         boolean result = migrationRunner.runMigration(jobId, jobRunner);
 
         if (!result) {
-            migrationService.stageSpecificError(MigrationStage.FS_MIGRATION_ERROR, "Error starting filesystem migration job.");
+            migrationService.stageSpecificError(FS_MIGRATION_ERROR, "Error starting filesystem migration job.");
         }
         return result;
     }
@@ -98,7 +100,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
             return;
         }
 
-        migrationService.transition(MigrationStage.FS_MIGRATION_COPY_WAIT);
+        migrationService.transition(FS_MIGRATION_COPY_WAIT);
 
         logger.info("Enabling file listener to listen to attachment updates while migration is in progress");
         attachmentListener.start();
@@ -116,11 +118,11 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
             report.setStatus(DONE);
 
             logger.info("Completed file system migration. Transitioning to next stage.");
-            migrationService.transition(MigrationStage.OFFLINE_WARNING);
+            migrationService.transition(OFFLINE_WARNING);
         } catch (FileSystemMigrationFailure e) {
             logger.error("Encountered critical error during file system migration");
             report.setStatus(FAILED);
-            migrationService.error(e.getMessage());
+            migrationService.stageSpecificError(FS_MIGRATION_ERROR, e.getMessage());
         }
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -84,7 +84,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
         boolean result = migrationRunner.runMigration(jobId, jobRunner);
 
         if (!result) {
-            migrationService.stageSpecificError(FS_MIGRATION_ERROR, "Error starting filesystem migration job.");
+            migrationService.error("Error starting filesystem migration job.");
         }
         return result;
     }
@@ -122,7 +122,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
         } catch (FileSystemMigrationFailure e) {
             logger.error("Encountered critical error during file system migration");
             report.setStatus(FAILED);
-            migrationService.stageSpecificError(FS_MIGRATION_ERROR, e.getMessage());
+            migrationService.error(e);
         }
     }
 
@@ -143,7 +143,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
         report.setStatus(FAILED);
         bulkCopy.abortCopy();
 
-        migrationService.stageSpecificError(FS_MIGRATION_ERROR,"File system migration was aborted");
+        migrationService.error("File system migration was aborted");
     }
 
     private JobId getScheduledJobIdForMigration(int migrationId) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -82,7 +82,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
         boolean result = migrationRunner.runMigration(jobId, jobRunner);
 
         if (!result) {
-            migrationService.error("Error starting filesystem migration job.");
+            migrationService.stageSpecificError(MigrationStage.FS_MIGRATION_ERROR, "Error starting filesystem migration job.");
         }
         return result;
     }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
@@ -29,6 +29,8 @@ open class AwsMigrationServiceWrapper(ao: ActiveObjects?, applicationConfigurati
         when {
             PROVISIONING_ERROR.validAncestorStages.contains(preErrorTransitionStage) -> setCurrentStage(migration, PROVISIONING_ERROR)
             FS_MIGRATION_ERROR.validAncestorStages.contains(preErrorTransitionStage) -> setCurrentStage(migration, FS_MIGRATION_ERROR)
+            FINAL_SYNC_ERROR.validAncestorStages.contains(preErrorTransitionStage) ->
+                setCurrentStage(migration, FINAL_SYNC_ERROR)
             else -> setCurrentStage(migration, ERROR)
         }
 

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
@@ -1,0 +1,49 @@
+package com.atlassian.migration.datacenter.core.aws
+
+import com.atlassian.activeobjects.external.ActiveObjects
+import com.atlassian.event.api.EventPublisher
+import com.atlassian.migration.datacenter.analytics.events.MigrationFailedEvent
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.atlassian.migration.datacenter.dto.MigrationContext
+import com.atlassian.migration.datacenter.spi.MigrationService
+import com.atlassian.migration.datacenter.spi.MigrationStage
+import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
+import kotlin.math.min
+
+
+open class AwsMigrationServiceWrapper(ao: ActiveObjects?, applicationConfiguration: ApplicationConfiguration?, eventPublisher: EventPublisher?) : AWSMigrationService(ao, applicationConfiguration, eventPublisher), MigrationService {
+
+    override fun stageSpecificError(errorStage: MigrationStage, message: String) {
+        if (!errorStage.isErrorStage()) {
+            throw InvalidMigrationStageError("Stage $errorStage is not a valid error stage")
+        }
+
+        val migration = findFirstOrCreateMigration()
+        val context: MigrationContext = this.currentContext
+        val now = System.currentTimeMillis() / 1000L
+
+        val failStage = context.migration.stage
+
+
+        setCurrentStage(migration, errorStage)
+        // We must truncate the error message to 450 characters so that it fits in the varchar(450) column
+        // We must truncate the error message to 450 characters so that it fits in the varchar(450) column
+        context.setErrorMessage(message.substring(0, min(450, message.length)))
+        context.endEpoch = now
+        context.save()
+
+        this.eventPublisher.publish(MigrationFailedEvent(this.applicationConfiguration.pluginVersion,
+                failStage, now - context.startEpoch))
+    }
+
+    override fun error(message: String) {
+        this.stageSpecificError(MigrationStage.ERROR, message);
+    }
+
+    override fun error(e: Throwable) {
+        stageSpecificError(MigrationStage.ERROR, e.message!!)
+        findFirstOrCreateMigration().stage.exception = e
+    }
+
+
+}

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.nio.file.Paths;
 import java.util.Arrays;
 
 import static com.atlassian.migration.datacenter.spi.MigrationStage.AUTHENTICATION;
@@ -88,7 +87,7 @@ public class AWSMigrationServiceTest {
     public void setup() {
         assertNotNull(entityManager);
         ao = new TestActiveObjects(entityManager);
-        sut = new AWSMigrationService(ao, applicationConfiguration, databaseExtractorFactory, Paths.get("."), eventPublisher);
+        sut = new AWSMigrationService(ao, applicationConfiguration, eventPublisher);
         setupEntities();
         when(applicationConfiguration.getPluginVersion()).thenReturn("DUMMY");
         when(databaseExtractorFactory.getExtractor()).thenReturn(databaseExtractor);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -332,7 +332,7 @@ public class AWSMigrationServiceTest {
         initializeAndCreateSingleMigrationWithStage(PROVISION_APPLICATION);
 
         String errorMessage = "provisioning error";
-        sut.stageSpecificError(PROVISIONING_ERROR, errorMessage);
+        sut.error(errorMessage);
 
         Migration actualMigration = sut.getCurrentMigration();
         assertEquals(PROVISIONING_ERROR, actualMigration.getStage());
@@ -341,17 +341,17 @@ public class AWSMigrationServiceTest {
     }
 
     @Test
-    public void shouldNotTransitionToStageSpecificErrorWhenStageIsNotAnErrorStage() {
-        initializeAndCreateSingleMigrationWithStage(PROVISION_APPLICATION);
+    public void shouldTransitionToGenericErrorWhenCurrentStageDoesNotHaveASpecificErrorStage() {
+        initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
 
         String errorMessage = "provisioning error";
 
-        assertThrows(InvalidMigrationStageError.class, () -> sut.stageSpecificError(PROVISION_APPLICATION_WAIT, errorMessage));
+        sut.error( errorMessage);
 
         Migration actualMigration = sut.getCurrentMigration();
-        assertEquals(PROVISION_APPLICATION, actualMigration.getStage());
-        assertNull(actualMigration.getContext().getErrorMessage());
-        verify(eventPublisher, never()).publish(any(MigrationFailedEvent.class));
+        assertEquals(ERROR, actualMigration.getStage());
+        assertEquals(errorMessage, actualMigration.getContext().getErrorMessage());
+        verify(eventPublisher).publish(any(MigrationFailedEvent.class));
     }
 
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -58,12 +58,10 @@ import static com.atlassian.migration.datacenter.spi.MigrationStage.PROVISION_AP
 import static com.atlassian.migration.datacenter.spi.MigrationStage.PROVISION_APPLICATION_WAIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -168,12 +166,25 @@ public class AWSMigrationServiceTest {
 
     @Test
     public void shouldSetCurrentStageToErrorOnError() {
-        initializeAndCreateSingleMigrationWithStage(PROVISION_APPLICATION);
+        initializeAndCreateSingleMigrationWithStage(AUTHENTICATION);
 
         final String errorMessage = "failure";
         sut.error(errorMessage);
 
         assertEquals(ERROR, sut.getCurrentStage());
+
+        MigrationContext context = sut.getCurrentContext();
+        assertEquals(errorMessage, context.getErrorMessage());
+    }
+
+    @Test
+    public void shouldSetCurrentStageToSpecificErrorStageOnError() {
+        initializeAndCreateSingleMigrationWithStage(PROVISION_APPLICATION);
+
+        final String errorMessage = "failure";
+        sut.error(errorMessage);
+
+        assertEquals(PROVISIONING_ERROR, sut.getCurrentStage());
 
         MigrationContext context = sut.getCurrentContext();
         assertEquals(errorMessage, context.getErrorMessage());

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceTest.java
@@ -39,9 +39,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -144,6 +146,18 @@ class S3FilesystemMigrationServiceTest {
         Boolean isScheduled = fsService.scheduleMigration();
         assertTrue(isScheduled);
         verify(migrationService).assertCurrentStage(MigrationStage.FS_MIGRATION_COPY);
+    }
+
+    @Test
+    void shouldTransitionToStageSpecificErrorWhenUnableToScheduleAMigration() throws Exception {
+        createStubMigration();
+
+        when(migrationRunner.runMigration(any(), any())).thenReturn(false);
+
+        boolean isScheduled = fsService.scheduleMigration();
+        assertFalse(isScheduled);
+
+        verify(migrationService).stageSpecificError(argThat(x -> x == MigrationStage.FS_MIGRATION_ERROR), anyString());
     }
 
     @Test

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationServiceTest.java
@@ -167,7 +167,7 @@ class S3FilesystemMigrationServiceTest {
 
         fsService.abortMigration();
 
-        verify(migrationService).error("File system migration was aborted");
+        verify(migrationService).stageSpecificError(FS_MIGRATION_ERROR, "File system migration was aborted");
         FileSystemMigrationReport report = reportManager.getCurrentReport(ReportType.Filesystem);
         assertEquals(report.getStatus(), FilesystemMigrationStatus.FAILED);
     }

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -24,6 +24,7 @@ import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.JiraConfiguration;
 import com.atlassian.migration.datacenter.core.aws.AWSMigrationService;
+import com.atlassian.migration.datacenter.core.aws.AwsMigrationServiceWrapper;
 import com.atlassian.migration.datacenter.core.aws.CancellableMigrationServiceHandler;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.aws.GlobalInfrastructure;
@@ -265,7 +266,7 @@ public class MigrationAssistantBeanConfiguration {
 
     @Bean
     public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
-        return new AWSMigrationService(activeObjects, applicationConfiguration, eventPublisher);
+        return new AwsMigrationServiceWrapper(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -23,7 +23,7 @@ import com.atlassian.jira.issue.attachment.AttachmentStore;
 import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.JiraConfiguration;
-import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
+import com.atlassian.migration.datacenter.core.aws.AWSMigrationService;
 import com.atlassian.migration.datacenter.core.aws.CancellableMigrationServiceHandler;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
 import com.atlassian.migration.datacenter.core.aws.GlobalInfrastructure;
@@ -264,8 +264,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, DatabaseExtractorFactory databaseExtractorFactory, JiraHome jiraHome, EventPublisher eventPublisher) {
-        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, databaseExtractorFactory, jiraHome.getHome().toPath(), eventPublisher);
+    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new AWSMigrationService(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
@@ -18,27 +18,20 @@ package com.atlassian.migration.datacenter.configuration;
 
 import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.event.api.EventPublisher;
-import com.atlassian.jira.config.util.JiraHome;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
-import com.atlassian.migration.datacenter.core.aws.SqsApi;
-import com.atlassian.migration.datacenter.core.aws.SqsApiImpl;
-import com.atlassian.migration.datacenter.core.db.DatabaseExtractorFactory;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-
-import java.util.function.Supplier;
 
 @Configuration
 public class MigrationAssistantProfileSpecificConfiguration {
     @Bean
     @Profile("allowAnyTransition")
     @Primary
-    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, DatabaseExtractorFactory databaseExtractorFactory, JiraHome jiraHome, EventPublisher eventPublisher) {
-        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, databaseExtractorFactory, jiraHome.getHome().toPath(), eventPublisher);
+    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher);
     }
 }

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
@@ -98,13 +98,6 @@ interface MigrationService {
     fun error(e: Throwable)
 
     /**
-     * Moves the migration into a stage specific error stage, storing the cause.
-     *
-     * @see MigrationStage.ERROR
-     */
-    fun stageSpecificError(stage: MigrationStage, message: String)
-
-    /**
      * Moves the migration to the final state (if valid) and performs any cleanup.
      *
      * @see MigrationStage.FINISHED

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
@@ -102,7 +102,7 @@ interface MigrationService {
      *
      * @see MigrationStage.ERROR
      */
-    fun stageSpecificError(stage: MigrationStage, e: Throwable)
+    fun stageSpecificError(stage: MigrationStage, message: String)
 
     /**
      * Moves the migration to the final state (if valid) and performs any cleanup.

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
@@ -98,6 +98,13 @@ interface MigrationService {
     fun error(e: Throwable)
 
     /**
+     * Moves the migration into a stage specific error stage, storing the cause.
+     *
+     * @see MigrationStage.ERROR
+     */
+    fun stageSpecificError(stage: MigrationStage, e: Throwable)
+
+    /**
      * Moves the migration to the final state (if valid) and performs any cleanup.
      *
      * @see MigrationStage.FINISHED


### PR DESCRIPTION
Create a kotlin wrapper implementation for AWS migration service.

Implement a method to transition to any error stage, not just the generic `ERROR` stage

Transitions error stage transition from file system migration service to `FS_MIGRATION_ERROR`