### PR TITLE
CHET-558/568: Call FS Stub retry endpoint from FS UI

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
 import java.util.stream.Collectors
 import javax.ws.rs.*
 import javax.ws.rs.core.MediaType
@@ -34,6 +35,11 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
                                   private val attachmentSyncManager: AttachmentSyncManager,
                                   private val reportManager: FileSystemMigrationReportManager)
 {
+
+    companion object {
+        val log = LoggerFactory.getLogger(FileSystemMigrationEndpoint::class.java)
+    }
+
     private val mapper: ObjectMapper = ObjectMapper()
 
     @PUT
@@ -112,6 +118,15 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
                 .entity(mapOf("error" to "filesystem migration is not in progress"))
                 .build()
         }
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/retry")
+    fun retryFileSystemMigration(): Response {
+        log.trace("Retrying file system migration")
+
+        return Response.accepted().build()
     }
 
     init {

--- a/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
@@ -21,6 +21,7 @@ enum RestApiPathConstants {
     fsStatusRestPath = `migration/fs/report`,
     fsStartRestPath = `migration/fs/start`,
     fsFinalSyncPath = `migration/fs/final-sync`,
+    fsRetryPath = `migration/fs/retry`,
 }
 
 type FailedFile = {
@@ -82,4 +83,8 @@ export const fs = {
         const capturedFiles = (await result.json()) as GetFinalSyncResponse;
         return capturedFiles.files || [];
     },
+
+    retryFsMigration: async (): Promise<void> => {
+        return callAppRest('PUT', RestApiPathConstants.fsRetryPath).then(Promise.resolve)
+    }
 };

--- a/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/api/fs.ts
@@ -85,6 +85,6 @@ export const fs = {
     },
 
     retryFsMigration: async (): Promise<void> => {
-        return callAppRest('PUT', RestApiPathConstants.fsRetryPath).then(Promise.resolve)
-    }
+        return callAppRest('PUT', RestApiPathConstants.fsRetryPath).then(Promise.resolve);
+    },
 };

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -94,7 +94,7 @@ const getPhaseFromStatus = (result: FileSystemMigrationStatusResponse): string =
 const getFsMigrationProgress: ProgressCallback = async () => {
     const retryProps: RetryProperties = {
         retryText: I18n.getText('atlassian.migration.datacenter.fs.retry'),
-        onRetry: () => Promise.reject(Error('Not implemented')),
+        onRetry: () => fs.retryFsMigration(),
     };
     return fs
         .getFsMigrationStatus()


### PR DESCRIPTION
## Summary

* Create a stub FS retry endpoint which will log the retry has been attempted
* Wire up the endpoint to the frontend