### PR TITLE
CHET-557: Auto cleanup migration infrastructure when finishing migration

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/ErrorFlag.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/ErrorFlag.tsx
@@ -37,7 +37,7 @@ type ErrorFlagProps = {
     /**
      * Text that appears below the flag. Should be a call to action on how to resolve the error
      */
-    description: string;
+    description: React.ReactNode;
     /**
      * Unique identifier for the error
      */

--- a/frontend/src/main/dc-migration-assistant-fe/components/stage/Validation.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/stage/Validation.tsx
@@ -170,7 +170,9 @@ const ValidationSummary: FunctionComponent = () => {
                 showError={finishMigrationApiErrorMessage && finishMigrationApiErrorMessage !== ''}
                 dismissErrorFunc={(): void => setFinishMigrationApiErrorMessage('')}
                 title={I18n.getText('atlassian.migration.datacenter.validation.finish.api.error')}
-                description="This only impacts the source instance. Please check the logs for the exact cause."
+                description={I18n.getText(
+                    'atlassian.migration.datacenter.validation.finish.api.error.description'
+                )}
                 id="finish-api-error"
             />
             <h3>{I18n.getText('atlassian.migration.datacenter.step.validation.phrase')}</h3>

--- a/frontend/src/main/dc-migration-assistant-fe/components/stage/Validation.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/stage/Validation.tsx
@@ -167,7 +167,7 @@ const ValidationSummary: FunctionComponent = () => {
     return (
         <>
             <ErrorFlag
-                showError={finishMigrationApiErrorMessage !== ''}
+                showError={finishMigrationApiErrorMessage && finishMigrationApiErrorMessage !== ''}
                 dismissErrorFunc={(): void => setFinishMigrationApiErrorMessage('')}
                 title={I18n.getText('atlassian.migration.datacenter.validation.finish.api.error')}
                 description="This only impacts the source instance. Please check the logs for the exact cause."
@@ -189,25 +189,16 @@ const ValidationSummary: FunctionComponent = () => {
                     marginTop: '15px',
                 }}
                 onClick={(): void => {
-                    migration
-                        .finishMigration()
-                        .then(() => setIsFinishMigrationSuccess(true))
+                    Promise.all([migration.finishMigration(), provisioning.cleanupInfrastructure()])
+                        .then(() => {
+                            setIsFinishMigrationSuccess(true);
+                        })
                         .catch(response => {
                             setFinishMigrationApiErrorMessage(response.message);
                         });
                 }}
             >
                 {I18n.getText('atlassian.migration.datacenter.validation.next.button')}
-            </Button>
-            <Button
-                appearance="warning"
-                onClick={(): any => provisioning.cleanupInfrastructure()}
-                style={{
-                    marginTop: '15px',
-                    marginLeft: '5px',
-                }}
-            >
-                Cleanup migration infrastructure
             </Button>
         </>
     );

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -162,6 +162,7 @@ atlassian.migration.datacenter.validation.post.action.aws.test=Test your new AWS
 atlassian.migration.datacenter.validation.post.action.redirect.dns=Redirect your DNS
 atlassian.migration.datacenter.validation.next.button=OK, got it
 atlassian.migration.datacenter.validation.finish.api.error=Error while completing the migration
+atlassian.migration.datacenter.validation.finish.api.error.description=Something went wrong completing the migration. Check your network connection, then try clicking again. If the problem persists, check the Jira logs for the exact cause.
 
 # Cancel Modal
 atlassian.migration.datacenter.cancellation.modal.progress.warning=If you cancel the migration, you will lose all progress.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21027663/86303096-1b513800-bc4e-11ea-9215-901880a2c7a1.png)
Above screenshot shows both requests from one button click (Failing because Jira not running).

One concern that I have is that the migration cleanup will fail and we have no way to report that to the user. However, since the cleanup is a long-running task, we should not show that the cleanup failed here