### PR TITLE
CHET-559: Minor updates to error message panel

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, useState, useEffect, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 
 import { I18n } from '@atlassian/wrm-react-i18n';
 import moment from 'moment';
-import Spinner from '@atlaskit/spinner';
 import Panel from '@atlaskit/panel';
 import { MigrationTransferProps, MigrationTransferPage } from '../shared/MigrationTransferPage';
 import { ProgressBuilder, ProgressCallback, RetryProperties } from '../shared/Progress';
 import { fs, FileSystemMigrationStatusResponse } from '../../api/fs';
-import { migration, MigrationStage } from '../../api/migration';
+import { MigrationStage } from '../../api/migration';
 import { warningPath } from '../../utils/RoutePaths';
 
 const dummyStarted = moment();
@@ -34,14 +33,14 @@ dummyStarted.subtract(23, 'minutes');
 const getErrorFromResult = (result: FileSystemMigrationStatusResponse): ReactNode | undefined => {
     if (result?.failedFiles.length > 0) {
         const failedFilesCount = result.failedFiles.length;
-
         return (
             <>
                 <strong>{failedFilesCount} files</strong> failed to upload.{' '}
                 {failedFilesCount === 100 &&
                     I18n.getText('atlassian.migration.datacenter.fs.error.maxFailedFiles')}
+                <p />
+                {I18n.getText('atlassian.migration.datacenter.fs.error.resolutionAction')}
                 <Panel header={I18n.getText('atlassian.migration.datacenter.fs.error.failedFiles')}>
-                    {I18n.getText('atlassian.migration.datacenter.fs.error.resolutionAction')}
                     <ul>
                         {result.failedFiles.map(({ filePath, reason }) => (
                             <li key={filePath}>

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -31,7 +31,7 @@ atlassian.migration.datacenter.common.progress.started=Started at {0}
 atlassian.migration.datacenter.common.progress.mins_elapsed={0} hours, {1} minutes elapsed
 atlassian.migration.datacenter.common.learn_more=Learn more
 atlassian.migration.datacenter.common.estimating=Estimating
-atlassian.migration.datacenter.common.aws.retry.checkbox.text=Everything looks good, Let's try again
+atlassian.migration.datacenter.common.aws.retry.checkbox.text=Everything looks good, let's try again
 atlassian.migration.datacenter.common.aws.status=AWS status
 
 # Migration Home page
@@ -102,9 +102,9 @@ atlassian.migration.datacenter.fs.phase.download=Loading files into target appli
 atlassian.migration.datacenter.fs.phase.complete=Files are copied
 atlassian.migration.datacenter.fs.completeMessage.boldPrefix={0} of {1} files
 atlassian.migration.datacenter.fs.completeMessage.message=were successfully migrated
-atlassian.migration.datacenter.fs.error.failedFiles=These files failed to upload
+atlassian.migration.datacenter.fs.error.failedFiles=Files that failed to upload:
 atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 100 file failures, more may have occured.
-atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and restart the migration.
+atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and retry the content copy.
 atlassian.migration.datacenter.fs.retry=Retry content copy
 
 # Warning page


### PR DESCRIPTION
Error message now reflect image below. Green boxes indicate a wording change. The resolution text description has also been lifted out from the collapsible panel, meaning it will always be shown.

![image](https://user-images.githubusercontent.com/409063/86303896-9287cb80-bc50-11ea-9e69-220b2a898a57.png)