### PR TITLE
CHET-516: Fix Multipart uploader

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3FilesystemMigrationService.java
@@ -118,7 +118,7 @@ public class S3FilesystemMigrationService implements FilesystemMigrationService,
             logger.info("Completed file system migration. Transitioning to next stage.");
             migrationService.transition(MigrationStage.OFFLINE_WARNING);
         } catch (FileSystemMigrationFailure e) {
-            logger.error("Encountered critical error during file system migration");
+            logger.error("Encountered critical error during file system migration", e);
             report.setStatus(FAILED);
             migrationService.error(e.getMessage());
         }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3MultiPartUploader.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3MultiPartUploader.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ExecutionException;
  * All files larger than 5MB (hard AWS limit) are required to be uploaded via this method.
  * <p>
  * https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html
+ * https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
  */
 public class S3MultiPartUploader {
     private final static Logger logger = LoggerFactory.getLogger(S3MultiPartUploader.class);
@@ -56,7 +57,7 @@ public class S3MultiPartUploader {
     private final File file;
     private final String key;
 
-    private int sizeToUpload = 100 * 1024 * 1024; // 100 MB
+    private int sizeToUpload = 25 * 1024 * 1024; // 25 MB
     private List<CompletedPart> completedParts = new ArrayList<>();
     private ByteBuffer buffer;
     private int uploadPartNumber = 1;

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3MultiPartUploader.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/fs/S3MultiPartUploader.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ExecutionException;
  * 2. Split the file into same sized parts (except the last one) and upload them to S3
  * 3. Confirm the upload has finished with all the required parts
  * <p>
- * All files larger than 5GB (hard AWS limit) are required to be uploaded via this method.
+ * All files larger than 5MB (hard AWS limit) are required to be uploaded via this method.
  * <p>
  * https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html
  */


### PR DESCRIPTION
* Smaller chunk size to avoid write timeout
* Fix Java 11 and 8 interoperability (the problem is API change for `ByteBuffer` in Java 9 https://jira.mongodb.org/browse/JAVA-2559)