### PR TITLE
CHET-560: Allow users to continue with migration despite failed file uploads

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -20,7 +20,12 @@ import { I18n } from '@atlassian/wrm-react-i18n';
 import moment from 'moment';
 import Panel from '@atlaskit/panel';
 import { MigrationTransferProps, MigrationTransferPage } from '../shared/MigrationTransferPage';
-import { ProgressBuilder, ProgressCallback, RetryProperties } from '../shared/Progress';
+import {
+    IgnoreAndContinueProperties,
+    ProgressBuilder,
+    ProgressCallback,
+    RetryProperties,
+} from '../shared/Progress';
 import { fs, FileSystemMigrationStatusResponse } from '../../api/fs';
 import { MigrationStage } from '../../api/migration';
 import { warningPath } from '../../utils/RoutePaths';
@@ -95,6 +100,10 @@ const getFsMigrationProgress: ProgressCallback = async () => {
         retryText: I18n.getText('atlassian.migration.datacenter.fs.retry'),
         onRetry: () => fs.retryFsMigration(),
     };
+    const ignoreAndContinueProps: IgnoreAndContinueProperties = {
+        continueText: I18n.getText('atlassian.migration.datacenter.fs.ignore.and.continue'),
+        onContinue: () => fs.retryFsMigration(),
+    };
     return fs
         .getFsMigrationStatus()
         .then(result => {
@@ -106,6 +115,7 @@ const getFsMigrationProgress: ProgressCallback = async () => {
             builder.setElapsedSeconds(result.elapsedTime.seconds);
             builder.setFailed(result.status === 'FAILED');
             builder.setRetryProps(retryProps);
+            builder.setIgnoreAndContinueProps(ignoreAndContinueProps);
 
             if (result.status === 'DONE') {
                 builder.setCompleteMessage(

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -102,7 +102,6 @@ const getFsMigrationProgress: ProgressCallback = async () => {
     };
     const ignoreAndContinueProps: IgnoreAndContinueProperties = {
         continueText: I18n.getText('atlassian.migration.datacenter.fs.ignore.and.continue'),
-        onContinue: () => fs.retryFsMigration(),
     };
     return fs
         .getFsMigrationStatus()

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -79,7 +79,6 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
 }) => {
     const [retryEnabled, setRetryEnabled] = useState<boolean>(false);
     const [shouldRedirectToStart, setShouldRedirectToStart] = useState<boolean>(false);
-    const [shouldIgnoreAndContinue, setShouldIgnoreAndContinue] = useState<boolean>(false);
 
     const failed = (progress.errorMessage && true) || progress.failed;
     const { onRetryRoute, retryText, onRetry } = progress?.retryProps;
@@ -101,10 +100,6 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
 
     if (shouldRedirectToStart) {
         return <Redirect to={onRetryRoute} push />;
-    }
-
-    if (shouldIgnoreAndContinue) {
-        return <Redirect to={warningPath} push />;
     }
 
     return (
@@ -167,10 +162,8 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                             {retryText || 'retry'}
                         </Button>
                         <Button
+                            href={warningPath}
                             style={{ marginTop: '10px', marginLeft: '10px' }}
-                            onClick={(): void => {
-                                setShouldIgnoreAndContinue(true);
-                            }}
                         >
                             {continueText || 'continue'}
                         </Button>

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -77,10 +77,13 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     startedMoment,
 }) => {
     const [retryEnabled, setRetryEnabled] = useState<boolean>(false);
+    const [continueEnabled, setContinueEnabled] = useState<boolean>(false);
     const [shouldRedirectToStart, setShouldRedirectToStart] = useState<boolean>(false);
+    const [shouldIgnoreAndContinue, setShouldIgnoreAndContinue] = useState<boolean>(false);
 
     const failed = (progress.errorMessage && true) || progress.failed;
     const { onRetryRoute, retryText, onRetry } = progress?.retryProps;
+    const { onContinueRoute, continueText, onContinue } = progress?.ignoreAndContinueProps;
 
     if (loading) {
         return (
@@ -98,6 +101,10 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
 
     if (shouldRedirectToStart) {
         return <Redirect to={onRetryRoute} push />;
+    }
+
+    if (shouldIgnoreAndContinue) {
+        return <Redirect to={onContinueRoute} push />;
     }
 
     return (
@@ -139,11 +146,25 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                         <CheckboxContainer>
                             <Checkbox
                                 value="true"
+                                isDisabled={continueEnabled}
                                 label={I18n.getText(
-                                    'atlassian.migration.datacenter.common.aws.retry.checkbox.text'
+                                    'atlassian.migration.datacenter.common.aws.retry.checkbox.restart.copy'
                                 )}
                                 onChange={(event: any): void => {
                                     setRetryEnabled(event.target.checked);
+                                }}
+                                name="retryAgree"
+                            />
+                        </CheckboxContainer>
+                        <CheckboxContainer>
+                            <Checkbox
+                                value="true"
+                                isDisabled={retryEnabled}
+                                label={I18n.getText(
+                                    'atlassian.migration.datacenter.common.aws.retry.checkbox.continue'
+                                )}
+                                onChange={(event: any): void => {
+                                    setContinueEnabled(event.target.checked);
                                 }}
                                 name="retryAgree"
                             />
@@ -158,6 +179,17 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                             }}
                         >
                             {retryText || 'retry'}
+                        </Button>
+                        <Button
+                            style={{ marginTop: '10px', marginLeft: '10px' }}
+                            isDisabled={!continueEnabled}
+                            onClick={(): void => {
+                                onContinue().then(() =>
+                                    setShouldIgnoreAndContinue(onContinueRoute && true)
+                                );
+                            }}
+                        >
+                            {continueText || 'continue'}
                         </Button>
                     </div>
                 ) : (

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -24,6 +24,7 @@ import Button from '@atlaskit/button';
 import styled from 'styled-components';
 import { Checkbox } from '@atlaskit/checkbox';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { warningPath } from '../../utils/RoutePaths';
 
 import { Progress } from './Progress';
 import {
@@ -83,7 +84,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
 
     const failed = (progress.errorMessage && true) || progress.failed;
     const { onRetryRoute, retryText, onRetry } = progress?.retryProps;
-    const { onContinueRoute, continueText, onContinue } = progress?.ignoreAndContinueProps;
+    const { continueText } = progress?.ignoreAndContinueProps;
 
     if (loading) {
         return (
@@ -104,7 +105,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     }
 
     if (shouldIgnoreAndContinue) {
-        return <Redirect to={onContinueRoute} push />;
+        return <Redirect to={warningPath} push />;
     }
 
     return (
@@ -184,9 +185,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                             style={{ marginTop: '10px', marginLeft: '10px' }}
                             isDisabled={!continueEnabled}
                             onClick={(): void => {
-                                onContinue().then(() =>
-                                    setShouldIgnoreAndContinue(onContinueRoute && true)
-                                );
+                                setShouldIgnoreAndContinue(true);
                             }}
                         >
                             {continueText || 'continue'}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -78,7 +78,6 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     startedMoment,
 }) => {
     const [retryEnabled, setRetryEnabled] = useState<boolean>(false);
-    const [continueEnabled, setContinueEnabled] = useState<boolean>(false);
     const [shouldRedirectToStart, setShouldRedirectToStart] = useState<boolean>(false);
     const [shouldIgnoreAndContinue, setShouldIgnoreAndContinue] = useState<boolean>(false);
 
@@ -147,25 +146,11 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                         <CheckboxContainer>
                             <Checkbox
                                 value="true"
-                                isDisabled={continueEnabled}
                                 label={I18n.getText(
                                     'atlassian.migration.datacenter.common.aws.retry.checkbox.restart.copy'
                                 )}
                                 onChange={(event: any): void => {
                                     setRetryEnabled(event.target.checked);
-                                }}
-                                name="retryAgree"
-                            />
-                        </CheckboxContainer>
-                        <CheckboxContainer>
-                            <Checkbox
-                                value="true"
-                                isDisabled={retryEnabled}
-                                label={I18n.getText(
-                                    'atlassian.migration.datacenter.common.aws.retry.checkbox.continue'
-                                )}
-                                onChange={(event: any): void => {
-                                    setContinueEnabled(event.target.checked);
                                 }}
                                 name="retryAgree"
                             />
@@ -183,7 +168,6 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                         </Button>
                         <Button
                             style={{ marginTop: '10px', marginLeft: '10px' }}
-                            isDisabled={!continueEnabled}
                             onClick={(): void => {
                                 setShouldIgnoreAndContinue(true);
                             }}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -31,10 +31,6 @@ export interface RetryCallback {
     (): Promise<void>;
 }
 
-export interface ContinueCallback {
-    (): Promise<void>;
-}
-
 export type RetryProperties = {
     /**
      * Text to display on the retry button
@@ -55,14 +51,6 @@ export type IgnoreAndContinueProperties = {
      * Text to display on the continue button
      */
     continueText: string;
-    /**
-     * A route to redirect the user to when
-     */
-    onContinue: ContinueCallback;
-    /**
-     * A route to redirect the user to when
-     */
-    onContinueRoute?: string;
 };
 
 /**

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -31,6 +31,10 @@ export interface RetryCallback {
     (): Promise<void>;
 }
 
+export interface ContinueCallback {
+    (): Promise<void>;
+}
+
 export type RetryProperties = {
     /**
      * Text to display on the retry button
@@ -44,6 +48,21 @@ export type RetryProperties = {
      * A route to redirect the user to when
      */
     onRetryRoute?: string;
+};
+
+export type IgnoreAndContinueProperties = {
+    /**
+     * Text to display on the continue button
+     */
+    continueText: string;
+    /**
+     * A route to redirect the user to when
+     */
+    onContinue: ContinueCallback;
+    /**
+     * A route to redirect the user to when
+     */
+    onContinueRoute?: string;
 };
 
 /**
@@ -65,6 +84,7 @@ export type Progress = {
     completeMessage?: CompleteMessage;
     failed?: boolean;
     retryProps: RetryProperties;
+    ignoreAndContinueProps?: IgnoreAndContinueProperties;
 };
 
 /**
@@ -84,6 +104,8 @@ export class ProgressBuilder {
     private failed: boolean;
 
     private retryProps: RetryProperties;
+
+    private ignoreAndContinueProps: IgnoreAndContinueProperties;
 
     setElapsedSeconds(seconds: number): ProgressBuilder {
         this.elapsedSeconds = seconds;
@@ -125,6 +147,12 @@ export class ProgressBuilder {
         return this;
     }
 
+    setIgnoreAndContinueProps(ignoreAndContinueProps: IgnoreAndContinueProperties) {
+        this.ignoreAndContinueProps = ignoreAndContinueProps;
+
+        return this;
+    }
+
     build(): Progress {
         if (!(this.phase && this.retryProps)) {
             throw new Error('must include phase and retry props in progress object');
@@ -138,10 +166,12 @@ export class ProgressBuilder {
             elapsedSeconds,
             failed,
             retryProps,
+            ignoreAndContinueProps,
         } = this;
 
         return {
             retryProps,
+            ignoreAndContinueProps,
             phase,
             completeMessage,
             completeness,

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -105,7 +105,7 @@ atlassian.migration.datacenter.fs.completeMessage.boldPrefix={0} of {1} files
 atlassian.migration.datacenter.fs.completeMessage.message=were successfully migrated
 atlassian.migration.datacenter.fs.error.failedFiles=Files that failed to upload:
 atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 100 file failures, more may have occured.
-atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and restart the content copy. You also have the option to ignore any errors and continue.
+atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and restart the content copy. You also have the option to ignore any errors and continue with the migration.
 atlassian.migration.datacenter.fs.retry=Restart content copy
 atlassian.migration.datacenter.fs.ignore.and.continue=Continue
 

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -32,7 +32,6 @@ atlassian.migration.datacenter.common.progress.mins_elapsed={0} hours, {1} minut
 atlassian.migration.datacenter.common.learn_more=Learn more
 atlassian.migration.datacenter.common.estimating=Estimating
 atlassian.migration.datacenter.common.aws.retry.checkbox.restart.copy=Everything looks good, let's restart content copy
-atlassian.migration.datacenter.common.aws.retry.checkbox.continue=Ignore failed uploads and rock on! 🤘
 atlassian.migration.datacenter.common.aws.status=AWS status
 
 # Migration Home page

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -31,7 +31,8 @@ atlassian.migration.datacenter.common.progress.started=Started at {0}
 atlassian.migration.datacenter.common.progress.mins_elapsed={0} hours, {1} minutes elapsed
 atlassian.migration.datacenter.common.learn_more=Learn more
 atlassian.migration.datacenter.common.estimating=Estimating
-atlassian.migration.datacenter.common.aws.retry.checkbox.text=Everything looks good, let's try again
+atlassian.migration.datacenter.common.aws.retry.checkbox.restart.copy=Everything looks good, let's restart content copy
+atlassian.migration.datacenter.common.aws.retry.checkbox.continue=Ignore failed uploads and rock on! 🤘
 atlassian.migration.datacenter.common.aws.status=AWS status
 
 # Migration Home page
@@ -104,8 +105,9 @@ atlassian.migration.datacenter.fs.completeMessage.boldPrefix={0} of {1} files
 atlassian.migration.datacenter.fs.completeMessage.message=were successfully migrated
 atlassian.migration.datacenter.fs.error.failedFiles=Files that failed to upload:
 atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 100 file failures, more may have occured.
-atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and retry the content copy.
-atlassian.migration.datacenter.fs.retry=Retry content copy
+atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and restart the content copy. You also have the option to ignore any errors and continue.
+atlassian.migration.datacenter.fs.retry=Restart content copy
+atlassian.migration.datacenter.fs.ignore.and.continue=Continue
 
 # Warning page
 atlassian.migration.datacenter.warning.title=Step 5 of 8: Block user access


### PR DESCRIPTION
Changes in green boxes:

- Introduce a new `Continue` button 
- Update resolution text 

![image](https://user-images.githubusercontent.com/409063/86317666-53b73d00-bc73-11ea-9e87-ab7a8af6995b.png)

When `Continue` is selected the user is taken to the next page in the migration flow...

![image](https://user-images.githubusercontent.com/409063/86317728-82cdae80-bc73-11ea-9948-a308523d354d.png)
