### PR TITLE
CHET-560: Allow users to continue with migration

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -47,6 +47,7 @@ const getDeploymentProgress: ProgressCallback = async () => {
                 onRetry: provisioning.retry,
                 retryText: I18n.getText('atlassian.migration.datacenter.provision.aws.retry.text'),
                 onRetryRoute: asiConfigurationPath,
+                canContinueWhenFailure: false,
             });
             switch (result.status) {
                 case ProvisioningStatus.Complete:

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/ProvisioningStatusPage.tsx
@@ -47,7 +47,7 @@ const getDeploymentProgress: ProgressCallback = async () => {
                 onRetry: provisioning.retry,
                 retryText: I18n.getText('atlassian.migration.datacenter.provision.aws.retry.text'),
                 onRetryRoute: asiConfigurationPath,
-                canContinueWhenFailure: false,
+                canContinueOnFailure: false,
             });
             switch (result.status) {
                 case ProvisioningStatus.Complete:

--- a/frontend/src/main/dc-migration-assistant-fe/components/final-sync/FinalSync.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/final-sync/FinalSync.tsx
@@ -57,7 +57,7 @@ const dbStatusToProgress = (status: DatabaseMigrationStatusResult): Progress => 
     builder.setRetryProps({
         retryText: I18n.getText('atlassian.migration.datacenter.sync.db.retry'),
         onRetry: finalSync.retryDbMigration,
-        canContinueWhenFailure: false,
+        canContinueOnFailure: false,
     });
 
     if (status.status === DBMigrationStatus.DONE) {
@@ -88,7 +88,7 @@ const fsSyncStatusToProgress = (status: FinalSyncStatus): Progress => {
     builder.setRetryProps({
         retryText: I18n.getText('atlassian.migration.datacenter.sync.fs.retry'),
         onRetry: finalSync.retryFsSync,
-        canContinueWhenFailure: false,
+        canContinueOnFailure: false,
     });
 
     if (downloaded === uploaded) {

--- a/frontend/src/main/dc-migration-assistant-fe/components/final-sync/FinalSync.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/final-sync/FinalSync.tsx
@@ -57,6 +57,7 @@ const dbStatusToProgress = (status: DatabaseMigrationStatusResult): Progress => 
     builder.setRetryProps({
         retryText: I18n.getText('atlassian.migration.datacenter.sync.db.retry'),
         onRetry: finalSync.retryDbMigration,
+        canContinueWhenFailure: false,
     });
 
     if (status.status === DBMigrationStatus.DONE) {
@@ -87,6 +88,7 @@ const fsSyncStatusToProgress = (status: FinalSyncStatus): Progress => {
     builder.setRetryProps({
         retryText: I18n.getText('atlassian.migration.datacenter.sync.fs.retry'),
         onRetry: finalSync.retryFsSync,
+        canContinueWhenFailure: false,
     });
 
     if (downloaded === uploaded) {

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -95,7 +95,7 @@ const getFsMigrationProgress: ProgressCallback = async () => {
         onRetryRoute: fsPath,
         retryText: I18n.getText('atlassian.migration.datacenter.fs.retry'),
         onRetry: () => fs.retryFsMigration(),
-        canContinueWhenFailure: true,
+        canContinueOnFailure: true,
     };
     return fs
         .getFsMigrationStatus()

--- a/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/fs/FileSystemTransfer.tsx
@@ -95,6 +95,7 @@ const getFsMigrationProgress: ProgressCallback = async () => {
         onRetryRoute: fsPath,
         retryText: I18n.getText('atlassian.migration.datacenter.fs.retry'),
         onRetry: () => fs.retryFsMigration(),
+        canContinueWhenFailure: true,
     };
     return fs
         .getFsMigrationStatus()

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
@@ -43,7 +43,7 @@ const props: MigrationTransferProps = {
                         retryProps: {
                             retryText: 'Retry',
                             onRetry: (): Promise<void> => Promise.resolve(),
-                            canContinueWhenFailure: false,
+                            canContinueOnFailure: false,
                         },
                     },
                 ]);

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferPage.test.tsx
@@ -43,6 +43,7 @@ const props: MigrationTransferProps = {
                         retryProps: {
                             retryText: 'Retry',
                             onRetry: (): Promise<void> => Promise.resolve(),
+                            canContinueWhenFailure: false,
                         },
                     },
                 ]);

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -76,7 +76,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     const [shouldRedirectToStart, setShouldRedirectToStart] = useState<boolean>(false);
 
     const failed = (progress.errorMessage && true) || progress.failed;
-    const { onRetryRoute, retryText, onRetry, canContinueWhenFailure } = progress?.retryProps;
+    const { onRetryRoute, retryText, onRetry, canContinueOnFailure } = progress?.retryProps;
 
     if (loading) {
         return (
@@ -153,7 +153,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                         >
                             {retryText || 'retry'}
                         </Button>
-                        {canContinueWhenFailure && (
+                        {canContinueOnFailure && (
                             <Button
                                 appearance="subtle-link"
                                 href={warningPath}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -24,7 +24,7 @@ import Button from '@atlaskit/button';
 import styled from 'styled-components';
 import { Checkbox } from '@atlaskit/checkbox';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
-import { warningPath } from '../../utils/RoutePaths';
+import { warningPath, validationPath } from '../../utils/RoutePaths';
 
 import { Progress } from './Progress';
 import {
@@ -154,7 +154,12 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                             {retryText || 'retry'}
                         </Button>
                         <Button
-                            href={warningPath}
+                            href={
+                                retryText ===
+                                I18n.getText('atlassian.migration.datacenter.fs.retry')
+                                    ? warningPath
+                                    : validationPath
+                            }
                             style={{ marginTop: '10px', marginLeft: '10px' }}
                         >
                             {I18n.getText('atlassian.migration.datacenter.fs.continue')}

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -155,6 +155,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                         </Button>
                         {canContinueWhenFailure && (
                             <Button
+                                appearance="subtle-link"
                                 href={warningPath}
                                 style={{ marginTop: '10px', marginLeft: '10px' }}
                             >

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -24,7 +24,7 @@ import Button from '@atlaskit/button';
 import styled from 'styled-components';
 import { Checkbox } from '@atlaskit/checkbox';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
-import { warningPath, validationPath } from '../../utils/RoutePaths';
+import { warningPath } from '../../utils/RoutePaths';
 
 import { Progress } from './Progress';
 import {
@@ -76,7 +76,7 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
     const [shouldRedirectToStart, setShouldRedirectToStart] = useState<boolean>(false);
 
     const failed = (progress.errorMessage && true) || progress.failed;
-    const { onRetryRoute, retryText, onRetry } = progress?.retryProps;
+    const { onRetryRoute, retryText, onRetry, canContinueWhenFailure } = progress?.retryProps;
 
     if (loading) {
         return (
@@ -153,17 +153,14 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                         >
                             {retryText || 'retry'}
                         </Button>
-                        <Button
-                            href={
-                                retryText ===
-                                I18n.getText('atlassian.migration.datacenter.fs.retry')
-                                    ? warningPath
-                                    : validationPath
-                            }
-                            style={{ marginTop: '10px', marginLeft: '10px' }}
-                        >
-                            {I18n.getText('atlassian.migration.datacenter.fs.continue')}
-                        </Button>
+                        {canContinueWhenFailure && (
+                            <Button
+                                href={warningPath}
+                                style={{ marginTop: '10px', marginLeft: '10px' }}
+                            >
+                                {I18n.getText('atlassian.migration.datacenter.fs.continue')}
+                            </Button>
+                        )}
                     </div>
                 ) : (
                     // If operation has not failed, render timing information - start time and duration

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationTransferProgress.tsx
@@ -24,6 +24,7 @@ import Button from '@atlaskit/button';
 import styled from 'styled-components';
 import { Checkbox } from '@atlaskit/checkbox';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { warningPath } from '../../utils/RoutePaths';
 
 import { Progress } from './Progress';
 import {
@@ -151,6 +152,12 @@ export const MigrationProgress: FunctionComponent<MigrationProgressProps> = ({
                             }}
                         >
                             {retryText || 'retry'}
+                        </Button>
+                        <Button
+                            href={warningPath}
+                            style={{ marginTop: '10px', marginLeft: '10px' }}
+                        >
+                            {I18n.getText('atlassian.migration.datacenter.fs.continue')}
                         </Button>
                     </div>
                 ) : (

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -44,6 +44,11 @@ export type RetryProperties = {
      * A route to redirect the user to when
      */
     onRetryRoute?: string;
+    /**
+     * A boolean to dictate whether or not failures
+     * can be ignored and the migration continued
+     */
+    canContinueWhenFailure: boolean;
 };
 
 /**

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/Progress.ts
@@ -48,7 +48,7 @@ export type RetryProperties = {
      * A boolean to dictate whether or not failures
      * can be ignored and the migration continued
      */
-    canContinueWhenFailure: boolean;
+    canContinueOnFailure: boolean;
 };
 
 /**

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -106,6 +106,7 @@ atlassian.migration.datacenter.fs.error.failedFiles=Files that failed to upload:
 atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 100 file failures, more may have occured.
 atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and retry the content copy.
 atlassian.migration.datacenter.fs.retry=Retry content copy
+atlassian.migration.datacenter.fs.continue=Continue to next step
 
 # Warning page
 atlassian.migration.datacenter.warning.title=Step 5 of 8: Block user access

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -106,7 +106,7 @@ atlassian.migration.datacenter.fs.error.failedFiles=Files that failed to upload:
 atlassian.migration.datacenter.fs.error.maxFailedFiles=We only track the first 100 file failures, more may have occured.
 atlassian.migration.datacenter.fs.error.resolutionAction=If you want to continue your migration, you can manually copy these files to the Jira application in AWS. Otherwise, we recommend you resolve the underlying error(s) and retry the content copy.
 atlassian.migration.datacenter.fs.retry=Retry content copy
-atlassian.migration.datacenter.fs.continue=Continue to next step
+atlassian.migration.datacenter.fs.continue=Ignore and continue
 
 # Warning page
 atlassian.migration.datacenter.warning.title=Step 5 of 7: Block user access


### PR DESCRIPTION
Use conditional rendering to determine whether the `Ignore and continue` button is rendered for a failed migration stage. For the puproses of this PR this button will only be rendered if there is an assets file upload failure i.e `Step 4 of 7: Copy Content`

![image](https://user-images.githubusercontent.com/409063/86556388-7eb4d000-bf96-11ea-834e-0545b775189c.png)

- When the `Ignore and continue` button is selected the user is taken to `Step 5 of 8`...

![image](https://user-images.githubusercontent.com/409063/86432288-8b3cec80-bd3a-11ea-94be-9e7642542619.png)
