### PR TITLE
no-issue: [frontend] fix typos in validation page

### DIFF
--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -150,7 +150,7 @@ atlassian.migration.datacenter.step.validation.redirect.home=Click here to visit
 atlassian.migration.datacenter.step.validation.incorrect.stage.error.title=You have reached this page out of a pre-defined order of migration steps
 atlassian.migration.datacenter.step.validation.incorrect.stage.error.description=You may have arrived at this page by clicking on a direct link. \
   Please check the server logs and ensure that you complete the previous migration steps
-atlassian.migration.datacenter.validation.message=We finished migrating your data to AWS. Here's the BASEURL of your new deployment:
+atlassian.migration.datacenter.validation.message=We finished migrating your data to AWS. Here's the base URL of your new deployment:
 atlassian.migration.datacenter.validation.summary.phrase.instanceUrl=AWS Jira Instance
 atlassian.migration.datacenter.validation.summary.phrase.migrationDuration=Migration Duration
 atlassian.migration.datacenter.validation.summary.phrase.databaseSize=Database size transferred

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -159,10 +159,10 @@ atlassian.migration.datacenter.validation.actions.required=To complete the setup
 atlassian.migration.datacenter.validation.post.action.aws.login=Ensure you can access your new Jira instance
 atlassian.migration.datacenter.validation.post.action.reconnect.external.services=Re-integrate all external services
 atlassian.migration.datacenter.validation.post.action.aws.verify=Verify that all your data was migrated
-atlassian.migration.datacenter.validation.post.action.index=Performa a full Jira reindex
+atlassian.migration.datacenter.validation.post.action.index=Perform a full Jira reindex
 atlassian.migration.datacenter.validation.post.action.redirect.dns=Redirect your DNS
 atlassian.migration.datacenter.validation.next.checkbox=I'll take care of it!
-atlassian.migration.datacenter.validation.next.button=OK, got it
+atlassian.migration.datacenter.validation.next.button=Close the migration app
 atlassian.migration.datacenter.validation.finish.api.error=Error while completing the migration
 atlassian.migration.datacenter.validation.finish.api.error.description=Something went wrong completing the migration. Check your network connection, then try clicking again. If the problem persists, check the Jira logs for the exact cause.
 


### PR DESCRIPTION
> The blue button should say "Close the migration app" , though

> Also typo "Performa"