### PR TITLE
CHET-580: Update landing page

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -141,17 +141,17 @@ export const ReadyStatus: FunctionComponent<ReadyProps> = ({ ready }) => {
                     {readyString(ready?.pgDumpAvailable)}
                 </li>
                 <li>
-                    <strong>pg_dump</strong> utility is compatible with the server version &nbsp;{' '}
+                    <strong>pg_dump</strong> utility is compatible with the server version &nbsp;
                     &nbsp; {readyString(ready?.pgDumpCompatible)}
                 </li>
                 <li>
-                    is using a <strong>Data Center license</strong> &nbsp;{' '}
+                    is using a &nbsp;
                     <a
                         target="_blank"
                         rel="noreferrer noopener"
                         href="https://confluence.atlassian.com/jirakb/how-to-use-the-data-center-migration-app-to-migrate-jira-to-an-aws-cluster-1005781495.html#HowtousetheDataCenterMigrationapptomigrateJiratoanAWScluster-dclicense"
                     >
-                        {I18n.getText('atlassian.migration.datacenter.common.learn_more')}
+                        Data Center license
                     </a>
                 </li>
             </ul>

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -145,8 +145,14 @@ export const ReadyStatus: FunctionComponent<ReadyProps> = ({ ready }) => {
                     &nbsp; {readyString(ready?.pgDumpCompatible)}
                 </li>
                 <li>
-                    has a home directory <strong>under 400GB</strong> &nbsp;{' '}
-                    <Lozenge appearance="moved">User should check</Lozenge>
+                    is using a <strong>Data Center license</strong> &nbsp;{' '}
+                    <a
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        href="https://confluence.atlassian.com/jirakb/how-to-use-the-data-center-migration-app-to-migrate-jira-to-an-aws-cluster-1005781495.html#HowtousetheDataCenterMigrationapptomigrateJiratoanAWScluster-dclicense"
+                    >
+                        {I18n.getText('atlassian.migration.datacenter.common.learn_more')}
+                    </a>
                 </li>
             </ul>
         </SectionMessage>

--- a/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/Home.tsx
@@ -145,7 +145,7 @@ export const ReadyStatus: FunctionComponent<ReadyProps> = ({ ready }) => {
                     &nbsp; {readyString(ready?.pgDumpCompatible)}
                 </li>
                 <li>
-                    is using a &nbsp;
+                    is using a&nbsp;
                     <a
                         target="_blank"
                         rel="noreferrer noopener"


### PR DESCRIPTION
Create a DC-license requirement to the per-requisites before a customer starts a migration. This will be done as a static text.

![image](https://user-images.githubusercontent.com/409063/86855415-9eb2d380-c0fd-11ea-8340-c8060a488e1b.png)

