### PR TITLE
CHE-600: Prevent making calls to CFn API with null or empty stackname…

### DIFF
--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -137,7 +137,7 @@ public abstract class AWSMigrationService implements MigrationService {
                                                                       currentStage, to));
             throw InvalidMigrationStageError.errorWithMessage(currentStage, to);
         }
-        log.error("Stage transition: {} to {}", currentStage, to);
+        log.info("Stage transition: {} to {}", currentStage, to);
         setCurrentStage(migration, to);
         eventPublisher.publish(new MigrationTransitionEvent(applicationConfiguration.getPluginVersion(),
                                                             currentStage, to));
@@ -196,6 +196,7 @@ public abstract class AWSMigrationService implements MigrationService {
     }
 
     protected synchronized void setCurrentStage(Migration migration, MigrationStage stage) {
+        log.debug("Setting stage to {}", stage);
         migration.setStage(stage);
         migration.save();
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/CfnApi.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/CfnApi.java
@@ -21,6 +21,7 @@ import com.atlassian.migration.datacenter.core.util.LogUtils;
 import com.atlassian.migration.datacenter.spi.exceptions.InfrastructureProvisioningError;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentError;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentState;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,6 +136,9 @@ public class CfnApi {
      * @return an optional containing the error message for the first stack deployment failure event.
      */
     public Optional<String> getStackErrorRootCause(String stackName) {
+        if (StringUtils.isBlank(stackName)){
+            return Optional.empty();
+        }
         try {
             List<StackEvent> events = this.getClient()
                     .describeStackEvents(DescribeStackEventsRequest.builder().stackName(stackName).build())

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -85,6 +85,7 @@ public abstract class CloudformationDeploymentService {
         CompletableFuture<String> stackCompleteFuture = new CompletableFuture<>();
 
         final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
         deploymentWatcher = scheduledExecutorService.scheduleAtFixedRate(() -> {
             final InfrastructureDeploymentState status = cfnApi.getStatus(stackName);
             if (status.equals(InfrastructureDeploymentState.CREATE_COMPLETE)) {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -128,11 +128,11 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     }
 
     private void deployQuickstart(@NotNull String deploymentId, String templateUrl, @NotNull Map<String, String> params, MigrationContext context) throws InvalidMigrationStageError, InfrastructureDeploymentError {
-        // This is a safeguard against CHET-600 (https://aws-partner.atlassian.net/browse/CHET-600) where the statemachine is not transitioned to `PROVISION_APPLICATION` after a retry operation is invoked.
-        // The real cause of why this happens not fully known at the time of this commit. This temporary will transition from `PROVISIONING_ERROR` to  `PROVISIONING_APPLICATION` before deploying the stack
-        // Additionally, we may need to clear persisted stack details here.
+        // This is a safeguard against CHET-600 (https://aws-partner.atlassian.net/browse/CHET-600) which is caused as the statemachine transition to `PROVISIONING_ERROR` is dependent on the scheduled task to complete. If a provisioning operation is retried before the `handleFailedDeployment` task is run, the migration stage transition check would prevent the provisioning from completing successfully.
+        // See https://github.com/atlassian-labs/dc-migration-assistant/pull/375#issuecomment-655894553 for a detailed explanation of why error case is required.
+        // Also, see https://aws-partner.atlassian.net/browse/CHET-608 that tracks this bug.
         if(migrationService.getCurrentStage().equals(MigrationStage.PROVISIONING_ERROR)){
-            migrationService.transition(MigrationStage.PROVISION_APPLICATION_WAIT);
+            migrationService.transition(MigrationStage.PROVISION_APPLICATION);
         }
 
         migrationService.transition(MigrationStage.PROVISION_APPLICATION_WAIT);

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -132,6 +132,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         // See https://github.com/atlassian-labs/dc-migration-assistant/pull/375#issuecomment-655894553 for a detailed explanation of why error case is required.
         // Also, see https://aws-partner.atlassian.net/browse/CHET-608 that tracks this bug.
         if(migrationService.getCurrentStage().equals(MigrationStage.PROVISIONING_ERROR)){
+            logger.info("Forcing a transition to {} to ensure that we can provision a stack", MigrationStage.PROVISION_APPLICATION);
             migrationService.transition(MigrationStage.PROVISION_APPLICATION);
         }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -128,6 +128,13 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     }
 
     private void deployQuickstart(@NotNull String deploymentId, String templateUrl, @NotNull Map<String, String> params, MigrationContext context) throws InvalidMigrationStageError, InfrastructureDeploymentError {
+        // This is a safeguard against CHET-600 (https://aws-partner.atlassian.net/browse/CHET-600) where the statemachine is not transitioned to `PROVISION_APPLICATION` after a retry operation is invoked.
+        // The real cause of why this happens not fully known at the time of this commit. This temporary will transition from `PROVISIONING_ERROR` to  `PROVISIONING_APPLICATION` before deploying the stack
+        // Additionally, we may need to clear persisted stack details here.
+        if(migrationService.getCurrentStage().equals(MigrationStage.PROVISIONING_ERROR)){
+            migrationService.transition(MigrationStage.PROVISION_APPLICATION_WAIT);
+        }
+
         migrationService.transition(MigrationStage.PROVISION_APPLICATION_WAIT);
 
         logger.info("deploying application stack");

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -131,6 +131,19 @@ class QuickstartDeploymentServiceTest {
                 STACK_NAME, STACK_PARAMS);
     }
 
+
+    @Test
+    void shouldDeployQuickStartWhenStateIsTransitionedToError() throws InvalidMigrationStageError, InfrastructureDeploymentError {
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISIONING_ERROR);
+        deploySimpleStack();
+
+        verify(mockMigrationService).transition(MigrationStage.PROVISION_APPLICATION);
+        verify(mockMigrationService).transition(MigrationStage.PROVISION_APPLICATION_WAIT);
+        verify(mockCfnApi).provisionStack(
+                "https://aws-quickstart.s3.amazonaws.com/quickstart-atlassian-jira/templates/quickstart-jira-dc.template.yaml",
+                STACK_NAME, STACK_PARAMS);
+    }
+
     @Test
     void shouldDeployQuickStartWithVpc() throws InvalidMigrationStageError, InfrastructureDeploymentError {
         deployWithVpcStack();

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -108,6 +108,7 @@ class QuickstartDeploymentServiceTest {
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
         when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 
         lenient().when(mockCfnApi.getStack(STACK_NAME)).thenReturn(Optional.of(Stack.builder().stackName(STACK_NAME).outputs(MOCK_OUTPUTS).build()));
 

--- a/core/src/test/kotlin/com/atlassian/migration/datacenter/core/aws/CfnApiTest.kt
+++ b/core/src/test/kotlin/com/atlassian/migration/datacenter/core/aws/CfnApiTest.kt
@@ -91,6 +91,12 @@ internal class CfnApiTest {
     }
 
     @Test
+    fun shouldReturnEmptyWhenNoStackIdIsNullOrEmpty() {
+        assertEquals(Optional.empty<String>(), sut.getStackErrorRootCause(""))
+        assertEquals(Optional.empty<String>(), sut.getStackErrorRootCause(null))
+    }
+
+    @Test
     fun shouldFollowEventsForFailuresInNestedStacks() {
         val earliestError = "Dashboard 'tcat-per-jira-37c49438-dashboard' already exists"
         val nestedStackId = "arn:aws:cloudformation:us-east-1:887764444972:stack/tcat-per-jira-37c49438-CloudWatchDashboard-12CC4TVSVEFF7/39c6ec60-aab2-11ea-840e-0a05dbc7583b"


### PR DESCRIPTION
1. Check if stack name is null before calling `cfn.getStatus`
2. Before provisioning an application stack if current state is provision_error, force the transition to provision_error