### PR TITLE
CHET-606: Skip websudo for status endpoints

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -23,6 +23,7 @@ import com.atlassian.migration.datacenter.core.fs.captor.S3FinalSyncService
 import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
+import com.atlassian.sal.api.websudo.WebSudoNotRequired
 import com.atlassian.sal.api.websudo.WebSudoRequired
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.PropertyAccessor
@@ -112,9 +113,10 @@ class FinalSyncEndpoint(
         }
     }
 
+    @GET
     @Path("/status")
     @Produces(MediaType.APPLICATION_JSON)
-    @GET
+    @WebSudoNotRequired // Avoids tripping the websudo redirect until advancing to the next stage. The status should not contain any sensitive information.
     fun getMigrationStatus(): Response {
         val elapsed = databaseMigrationService.elapsedTime
                 .orElse(Duration.ZERO)

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/aws/CloudFormationEndpoint.kt
@@ -25,6 +25,7 @@ import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeplo
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentState
 import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureDeploymentService
 import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig
+import com.atlassian.sal.api.websudo.WebSudoNotRequired
 import com.atlassian.sal.api.websudo.WebSudoRequired
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.PropertyAccessor
@@ -94,6 +95,7 @@ class CloudFormationEndpoint(
     @Path("/status")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @WebSudoNotRequired // Avoids tripping the websudo redirect until advancing to the next stage. The status should not contain any sensitive information.
     fun infrastructureStatus(): Response {
         return when (val currentMigrationStage = migrationService.currentStage) {
             MigrationStage.NOT_STARTED, MigrationStage.AUTHENTICATION, MigrationStage.PROVISION_APPLICATION -> handleInvalidStage()

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
@@ -22,6 +22,7 @@ import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService
+import com.atlassian.sal.api.websudo.WebSudoNotRequired
 import com.atlassian.sal.api.websudo.WebSudoRequired
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.PropertyAccessor
@@ -95,9 +96,10 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
                 .build()
     }
 
+    @GET
     @Path("/report")
     @Produces(MediaType.APPLICATION_JSON)
-    @GET
+    @WebSudoNotRequired // Avoids tripping the websudo redirect until advancing to the next stage. The report should not contain any sensitive information.
     fun getFilesystemMigrationStatus(): Response {
         val report = reportManager.getCurrentReport(ReportType.Filesystem)
             ?: return Response


### PR DESCRIPTION
Skip websudo for status endpoints, which avoids the sudo redirect during migration. The status endpoints should never return anything sensitive. With this in place the admin will only be prompted a password after the transition to the next stage.