### PR TITLE
CHET-596: include warning about slow jira start time in validation page

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/stage/Validation.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/stage/Validation.tsx
@@ -129,6 +129,8 @@ const ValidationSummary: FunctionComponent = () => {
                 {I18n.getText('atlassian.migration.datacenter.validation.message')}
                 <br />
                 <a href={targetUrl}>{targetUrl}</a>
+                <br />
+                {I18n.getText('atlassian.migration.datacenter.validation.slow.start.message')}
             </p>
             <SectionMessageContainer>
                 <SectionMessage

--- a/frontend/src/main/resources/i18n/dc-migration-assistant.properties
+++ b/frontend/src/main/resources/i18n/dc-migration-assistant.properties
@@ -154,6 +154,7 @@ atlassian.migration.datacenter.step.validation.incorrect.stage.error.title=You h
 atlassian.migration.datacenter.step.validation.incorrect.stage.error.description=You may have arrived at this page by clicking on a direct link. \
   Please check the server logs and ensure that you complete the previous migration steps
 atlassian.migration.datacenter.validation.message=We finished migrating your data to AWS. Here's the base URL of your new deployment:
+atlassian.migration.datacenter.validation.slow.start.message=If you get an HTTP Error 503 response when you access the base URL, it usually means that Jira is still loading. This is expected, and you should wait 2-3 minutes before trying again. Use this time to familiarise yourself with the following steps.
 atlassian.migration.datacenter.validation.summary.phrase.instanceUrl=AWS Jira Instance
 atlassian.migration.datacenter.validation.summary.phrase.migrationDuration=Migration Duration
 atlassian.migration.datacenter.validation.summary.phrase.databaseSize=Database size transferred


### PR DESCRIPTION
This is intended to prepare users so they don't panic when following the link to Jira and seeing a 502 or 503 error