### PR TITLE
no-issue: Fix self-redirect when moving from offline warning to final sync

### DIFF
--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -22,6 +22,7 @@ import styled from 'styled-components';
 import { finalSyncPath } from '../../utils/RoutePaths';
 import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
 import { CancelButton } from '../shared/CancelButton';
+import { Redirect } from 'react-router-dom';
 
 const Paragraph = styled.p`
     margin-bottom: '20px';
@@ -81,14 +82,19 @@ const LearnMore: FunctionComponent = () => {
 
 export const WarningStagePage: FunctionComponent = () => {
     const [agreed, setAgreed] = useState<boolean>(false);
+    const [redirectToNext, setRedirectToNext] = useState<boolean>(false);
 
     const agreeOnClick = (event: any): void => {
         setAgreed(event.target.checked);
     };
 
+    if (redirectToNext) {
+        return <Redirect to={finalSyncPath} push />;
+    }
+
     const NextButton = (
         <Button
-            href={finalSyncPath}
+            onClick={(): void => setRedirectToNext(true)}
             isDisabled={!agreed}
             appearance="primary"
             style={nextButtonStyle}


### PR DESCRIPTION
## Context

When clicking "Next" on the offline warning page it would cause a full-page reload and thus redirect back to itself. This is because when the page is loaded fresh, it tries to send you to the "current" page for where you are in the migration. Because there is no state transition when doing this "next", we are in the same state and thus load the same page.

## Solution

We get around this by using a client-side redirect instead of a full-page reload. The ASI configuration -> deploy cluster has the same anomaly in that there are two pages for the same state but it was already using a client-side redirect instead of a full-page reload so never fell victim to this behaviour.