### PR TITLE
None: Fix loading correct i18n module and fix webpack build mode

### DIFF
--- a/frontend/config/webpack.loaders.js
+++ b/frontend/config/webpack.loaders.js
@@ -19,7 +19,7 @@ const PostCssIcssValuesPlugin = require('postcss-icss-values');
 
 const { MY_I18N_FILES } = require('./webpack.constants');
 
-function getLoaders({ isProductionEnv = false }) {
+function getLoaders( isProductionEnv = false ) {
     return [
         {
             test: /\.(tsx|ts)?$/,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -112,7 +112,7 @@
     "scripts": {
         "watch": "webpack --watch --display-modules --config ./config/webpack.config.js",
         "start": "mvn package -DskipTests -Pwatch-mode && yarn dev-server ",
-        "build": "webpack --config ./config/webpack.config.js",
+        "build": "webpack --config ./config/webpack.config.js --mode=production",
         "build:dev": "webpack --config ./config/webpack.config.js --mode=development",
         "dev-server": "webpack-dev-server --config ./config/webpack.config.js --mode=development --env=dev-server",
         "analyze": "yarn build --env.analyze",

--- a/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/aws/quickstart/asi/ASIConfiguration.tsx
@@ -20,7 +20,7 @@ import { Button } from '@atlaskit/button/dist/cjs/components/Button';
 import { Redirect } from 'react-router-dom';
 import SectionMessage from '@atlaskit/section-message';
 import { ExistingASIConfiguration, ASIDescription } from './ExistingASIConfiguration';
-import { I18n } from '../../../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { I18n } from '@atlassian/wrm-react-i18n';
 import { CancelButton } from '../../../shared/CancelButton';
 import { quickstartPath } from '../../../../utils/RoutePaths';
 import { provisioning } from '../../../../api/provisioning';

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/CancelButton.tsx
@@ -16,7 +16,7 @@
 
 import React, { FunctionComponent, useState } from 'react';
 import Button from '@atlaskit/button';
-import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { I18n } from '@atlassian/wrm-react-i18n';
 import { CancelModal } from './CancelModal';
 
 export const cancelButtonStyle = {

--- a/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/shared/MigrationErrorSection.tsx
@@ -19,7 +19,7 @@ import SectionMessage from '@atlaskit/section-message';
 import styled from 'styled-components';
 
 import { CommandDetails as CommandResult } from '../../api/final-sync';
-import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { I18n } from '@atlassian/wrm-react-i18n';
 
 const ErrorFragment = styled.div`
     margin-top: 0px;

--- a/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
+++ b/frontend/src/main/dc-migration-assistant-fe/components/warning/WarningStage.tsx
@@ -21,7 +21,7 @@ import Button from '@atlaskit/button';
 import styled from 'styled-components';
 import { Redirect } from 'react-router-dom';
 import { finalSyncPath } from '../../utils/RoutePaths';
-import { I18n } from '../../atlassian/mocks/@atlassian/wrm-react-i18n';
+import { I18n } from '@atlassian/wrm-react-i18n';
 import { CancelButton } from '../shared/CancelButton';
 
 const Paragraph = styled.p`


### PR DESCRIPTION
While helping Ben I've found two problems:
 - the `@atlassian/wrm-react-i18n` module was imported from the mocs directory
 - The production mode passed to the `getLoaders` function is a boolean value. Additionally, the webpack build mode wasn't specified explicitly.
