### PR TITLE
updating CLA links to use new CLA system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Atlassian requires contributors to sign a Contributor License Agreement, known a
 
 Prior to accepting your contributions we ask that you please follow the appropriate link below to digitally sign the CLA. The Corporate CLA is for those who are contributing as a member of an organization and the individual CLA is for those contributing as an individual.
 
-* [CLA for corporate contributors](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=e1c17c66-ca4d-4aab-a953-2c231af4a20b)
-* [CLA for individuals](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=3f94fbdc-2fbe-46ac-b14c-5d152700ae5d)
+* [CLA for corporate contributors](https://opensource.atlassian.com/corporate)
+* [CLA for individuals](https://opensource.atlassian.com/individual)
 
 # Intellij Idea settings
 


### PR DESCRIPTION
updating these to reflect our new CLA system as we've moved away from DocuSign 🙂