### PR TITLE
CHET-608: consistent deployment state

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/FinalSyncEndpoint.kt
@@ -125,7 +125,7 @@ class FinalSyncEndpoint(
                 stageToStatus(currentStage),
                 elapsed
         )
-        val isCurrentStageAfterFinalSync = currentStage.isAfter(MigrationStage.FINAL_SYNC_WAIT)
+        val isCurrentStageAfterFinalSync = currentStage.isAfterWithoutRetries(MigrationStage.FINAL_SYNC_WAIT)
         val fsSyncStatus = finalSyncService.getFinalSyncStatus()
 
         val fs = FSSyncStatus(fsSyncStatus.uploadedFileCount, fsSyncStatus.uploadedFileCount - fsSyncStatus.enqueuedFileCount - fsSyncStatus.failedFileCount, fsSyncStatus.failedFileCount, isCurrentStageAfterFinalSync)

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -210,7 +210,7 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
     public InfrastructureDeploymentState getDeploymentStatus() {
         if (isHelperStackDeploymentStage()) {
             return super.getDeploymentStatus();
-        } else if (migrationService.getCurrentStage().isAfter(MigrationStage.PROVISION_MIGRATION_STACK_WAIT)) {
+        } else if (migrationService.getCurrentStage().isAfterWithoutRetries(MigrationStage.PROVISION_MIGRATION_STACK_WAIT)) {
             return InfrastructureDeploymentState.CREATE_COMPLETE;
         }
         return InfrastructureDeploymentState.NOT_DEPLOYING;

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -64,7 +64,7 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
     }
 
     AWSMigrationHelperDeploymentService(CfnApi cfnApi, Supplier<AutoScalingClient> autoScalingClientFactory, MigrationService migrationService, int pollIntervalSeconds) {
-        super(cfnApi, pollIntervalSeconds);
+        super(cfnApi, pollIntervalSeconds, migrationService);
         this.migrationService = migrationService;
         this.cfnApi = cfnApi;
         this.autoScalingClientFactory = autoScalingClientFactory;

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -208,7 +208,15 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
 
     @Override
     public InfrastructureDeploymentState getDeploymentStatus() {
-        return super.getDeploymentStatus(migrationService.getCurrentContext().getHelperStackDeploymentId());
+        if (isHelperStackDeploymentStage()) {
+            return super.getDeploymentStatus();
+        }
+        return InfrastructureDeploymentState.NOT_DEPLOYING;
+    }
+
+    private boolean isHelperStackDeploymentStage() {
+        MigrationStage stage = migrationService.getCurrentStage();
+        return stage == MigrationStage.PROVISION_MIGRATION_STACK || stage == MigrationStage.PROVISION_MIGRATION_STACK_WAIT || stage == MigrationStage.PROVISIONING_ERROR;
     }
 
     private String constructMigrationStackDeploymentIdentifier() {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentService.java
@@ -210,6 +210,8 @@ public class AWSMigrationHelperDeploymentService extends CloudformationDeploymen
     public InfrastructureDeploymentState getDeploymentStatus() {
         if (isHelperStackDeploymentStage()) {
             return super.getDeploymentStatus();
+        } else if (migrationService.getCurrentStage().isAfter(MigrationStage.PROVISION_MIGRATION_STACK_WAIT)) {
+            return InfrastructureDeploymentState.CREATE_COMPLETE;
         }
         return InfrastructureDeploymentState.NOT_DEPLOYING;
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -80,7 +80,7 @@ public abstract class CloudformationDeploymentService {
         beginWatchingDeployment(stackName);
     }
 
-    protected InfrastructureDeploymentState getDeploymentStatus(String stackName) {
+    protected InfrastructureDeploymentState getDeploymentStatus() {
         return migrationService.getCurrentContext().getDeploymentState();
     }
 

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentService.java
@@ -17,6 +17,8 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
+import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentError;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentState;
 import org.slf4j.Logger;
@@ -41,14 +43,16 @@ public abstract class CloudformationDeploymentService {
 
     private final CfnApi cfnApi;
     private final int deployStatusPollIntervalSeconds;
+    private final MigrationService migrationService;
     private ScheduledFuture<?> deploymentWatcher;
 
-    CloudformationDeploymentService(CfnApi cfnApi) {
-        this(cfnApi, 30);
+    CloudformationDeploymentService(CfnApi cfnApi, MigrationService migrationService) {
+        this(cfnApi, 30, migrationService);
     }
 
-    CloudformationDeploymentService(CfnApi cfnApi, int deployStatusPollIntervalSeconds) {
+    CloudformationDeploymentService(CfnApi cfnApi, int deployStatusPollIntervalSeconds, MigrationService migrationService) {
         this.cfnApi = cfnApi;
+        this.migrationService = migrationService;
         this.deployStatusPollIntervalSeconds = deployStatusPollIntervalSeconds;
     }
 
@@ -77,8 +81,7 @@ public abstract class CloudformationDeploymentService {
     }
 
     protected InfrastructureDeploymentState getDeploymentStatus(String stackName) {
-        requireNonNull(stackName);
-        return cfnApi.getStatus(stackName);
+        return migrationService.getCurrentContext().getDeploymentState();
     }
 
     private void beginWatchingDeployment(String stackName) {
@@ -88,6 +91,9 @@ public abstract class CloudformationDeploymentService {
 
         deploymentWatcher = scheduledExecutorService.scheduleAtFixedRate(() -> {
             final InfrastructureDeploymentState status = cfnApi.getStatus(stackName);
+            MigrationContext context = migrationService.getCurrentContext();
+            context.setDeploymentState(status);
+            context.save();
             if (status.equals(InfrastructureDeploymentState.CREATE_COMPLETE)) {
                 logger.info("stack {} creation succeeded", stackName);
                 handleSuccessfulDeployment();

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -131,7 +131,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         // This is a safeguard against CHET-600 (https://aws-partner.atlassian.net/browse/CHET-600) which is caused as the statemachine transition to `PROVISIONING_ERROR` is dependent on the scheduled task to complete. If a provisioning operation is retried before the `handleFailedDeployment` task is run, the migration stage transition check would prevent the provisioning from completing successfully.
         // See https://github.com/atlassian-labs/dc-migration-assistant/pull/375#issuecomment-655894553 for a detailed explanation of why error case is required.
         // Also, see https://aws-partner.atlassian.net/browse/CHET-608 that tracks this bug.
-        if(migrationService.getCurrentStage().equals(MigrationStage.PROVISIONING_ERROR)){
+        if (migrationService.getCurrentStage().equals(MigrationStage.PROVISIONING_ERROR)) {
             logger.info("Forcing a transition to {} to ensure that we can provision a stack", MigrationStage.PROVISION_APPLICATION);
             migrationService.transition(MigrationStage.PROVISION_APPLICATION);
         }
@@ -206,10 +206,13 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
         context.save();
     }
 
+    @NotNull
     @Override
     public InfrastructureDeploymentState getDeploymentStatus() {
         if (isAppDeploymentState()) {
             return super.getDeploymentStatus();
+        } else if (migrationService.getCurrentStage().isAfter(MigrationStage.PROVISION_APPLICATION_WAIT)) {
+            return InfrastructureDeploymentState.CREATE_COMPLETE;
         }
         return InfrastructureDeploymentState.NOT_DEPLOYING;
     }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -208,7 +208,15 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
 
     @Override
     public InfrastructureDeploymentState getDeploymentStatus() {
-        return super.getDeploymentStatus(migrationService.getCurrentContext().getApplicationDeploymentId());
+        if (isAppDeploymentState()) {
+            return super.getDeploymentStatus();
+        }
+        return InfrastructureDeploymentState.NOT_DEPLOYING;
+    }
+
+    private boolean isAppDeploymentState() {
+        MigrationStage stage = migrationService.getCurrentStage();
+        return stage == MigrationStage.PROVISION_APPLICATION || stage == MigrationStage.PROVISION_APPLICATION_WAIT || stage == MigrationStage.PROVISIONING_ERROR;
     }
 
     @Override

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -211,7 +211,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
     public InfrastructureDeploymentState getDeploymentStatus() {
         if (isAppDeploymentState()) {
             return super.getDeploymentStatus();
-        } else if (migrationService.getCurrentStage().isAfter(MigrationStage.PROVISION_APPLICATION_WAIT)) {
+        } else if (migrationService.getCurrentStage().isAfterWithoutRetries(MigrationStage.PROVISION_APPLICATION_WAIT)) {
             return InfrastructureDeploymentState.CREATE_COMPLETE;
         }
         return InfrastructureDeploymentState.NOT_DEPLOYING;

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java
@@ -62,7 +62,7 @@ public class QuickstartDeploymentService extends CloudformationDeploymentService
             TargetDbCredentialsStorageService dbCredentialsStorageService,
             AWSMigrationHelperDeploymentService migrationHelperDeploymentService,
             MigrationStackInputGatheringStrategyFactory strategyFactory) {
-        super(cfnApi);
+        super(cfnApi, migrationService);
 
         this.cfnApi = cfnApi;
         this.migrationService = migrationService;

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
@@ -171,6 +171,19 @@ class AWSMigrationHelperDeploymentServiceTest {
         assertEquals(InfrastructureDeploymentState.NOT_DEPLOYING, sut.getDeploymentStatus());
     }
 
+    @Test
+    void shouldReturnDeploymentCompleteWhenAfterApplicationDeploymentAndNoError() {
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.FS_MIGRATION_COPY);
+        assertEquals(InfrastructureDeploymentState.CREATE_COMPLETE, sut.getDeploymentStatus());
+    }
+
+    @Test
+    void shouldReturnDeploymentFailedWhenProvisioningError() {
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISIONING_ERROR);
+        when(mockContext.getDeploymentState()).thenReturn(InfrastructureDeploymentState.CREATE_FAILED);
+        assertEquals(InfrastructureDeploymentState.CREATE_FAILED, sut.getDeploymentStatus());
+    }
+
     private void assertGettingStackOutputsThrowsError() {
         ArrayList<Executable> outputGetters = new ArrayList<>();
         outputGetters.add(sut::getMigrationS3BucketName);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/AWSMigrationHelperDeploymentServiceTest.java
@@ -66,7 +66,6 @@ class AWSMigrationHelperDeploymentServiceTest {
     static final String MIGRATION_ASG = "migration-asg";
     static final String MIGRATION_BUCKET = "migration-bucket";
     static final String MIGRATION_HOST_INSTANCE_ID = "i-12345";
-    public static final String DEPLOYMENT_FAILURE_MESSAGE = "it broke";
     public static final String QUEUE_PHYSICAL_RESOURCE_ID = "https://sqs.someRegion.amazonaws.com/accountId/queue-name";
     public static final String DEAD_LETTER_QUEUE_PHYSICAL_RESOURCE_ID = "https://sqs.someRegion.amazonaws.com/accountId/dead-letter-queue-name";
 
@@ -89,13 +88,8 @@ class AWSMigrationHelperDeploymentServiceTest {
     @BeforeEach
     void setUp() {
         when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
-        when(mockContext.getApplicationDeploymentId()).thenReturn(APPLICATION_DEPLOYMENT);
 
         deploymentId = new AtomicReference<>();
-        doAnswer(invocation -> {
-            deploymentId.set(invocation.getArgument(0));
-            return null;
-        }).when(mockContext).setHelperStackDeploymentId(anyString());
 
         lenient().when(mockContext.getHelperStackDeploymentId()).thenReturn(deploymentId.get());
 
@@ -104,6 +98,11 @@ class AWSMigrationHelperDeploymentServiceTest {
 
     @Test
     void shouldNameMigrationStackAfterApplicationStackWithSuffixAndStoreInContext() throws InfrastructureDeploymentError {
+        when(mockContext.getApplicationDeploymentId()).thenReturn(APPLICATION_DEPLOYMENT);
+        doAnswer(invocation -> {
+            deploymentId.set(invocation.getArgument(0));
+            return null;
+        }).when(mockContext).setHelperStackDeploymentId(anyString());
         givenMigrationStackHasStartedDeploying();
 
         assertEquals(DEPLOYMENT_ID, deploymentId.get());
@@ -111,25 +110,22 @@ class AWSMigrationHelperDeploymentServiceTest {
 
     @Test
     void shouldProvisionCloudFormationStack() throws InfrastructureDeploymentError {
+        when(mockContext.getApplicationDeploymentId()).thenReturn(APPLICATION_DEPLOYMENT);
         givenMigrationStackHasStartedDeploying();
 
         verify(mockCfn).provisionStack("https://trebuchet-public-resources.s3.amazonaws.com/migration-helper.yml", DEPLOYMENT_ID, Collections.emptyMap());
     }
 
     @Test
-    void shouldReturnInProgressWhileCloudformationDeploymentIsOngoing() throws InfrastructureDeploymentError {
-        givenMigrationStackDeploymentWillBeInProgress();
-        givenMigrationStackHasStartedDeploying();
-        givenMigrationStackNameHasBeenStoredInContext();
+    void shouldReturnInProgressWhileCloudformationDeploymentIsOngoing() {
+        when(mockContext.getDeploymentState()).thenReturn(InfrastructureDeploymentState.CREATE_IN_PROGRESS);
 
         assertEquals(InfrastructureDeploymentState.CREATE_IN_PROGRESS, sut.getDeploymentStatus());
     }
 
     @Test
     void shouldReturnCompleteWhenCloudFormationDeploymentSucceeds() throws InterruptedException, InfrastructureDeploymentError {
-        givenMigrationStackDeploymentWillCompleteSuccessfully();
-        givenMigrationStackHasStartedDeploying();
-        givenMigrationStackNameHasBeenStoredInContext();
+        when(mockContext.getDeploymentState()).thenReturn(InfrastructureDeploymentState.CREATE_COMPLETE);
 
         Thread.sleep(100);
 
@@ -138,11 +134,7 @@ class AWSMigrationHelperDeploymentServiceTest {
 
     @Test
     void shouldReturnErrorWhenCloudFormationDeploymentFails() throws InterruptedException, InfrastructureDeploymentError {
-        givenMigrationStackDeploymentWillFail();
-        givenMigrationStackHasStartedDeploying();
-        givenMigrationStackNameHasBeenStoredInContext();
-
-        Thread.sleep(100);
+        when(mockContext.getDeploymentState()).thenReturn(InfrastructureDeploymentState.CREATE_FAILED);
 
         InfrastructureDeploymentState state = sut.getDeploymentStatus();
         assertEquals(InfrastructureDeploymentState.CREATE_FAILED, state);
@@ -198,15 +190,6 @@ class AWSMigrationHelperDeploymentServiceTest {
         } catch (InvalidMigrationStageError invalidMigrationStageError) {
             fail("invalid migration stage error thrown while deploying migration helper", invalidMigrationStageError);
         }
-    }
-
-    private void givenMigrationStackNameHasBeenStoredInContext() {
-        when(mockContext.getHelperStackDeploymentId()).thenReturn(DEPLOYMENT_ID);
-    }
-
-    private void givenMigrationStackDeploymentWillBeInProgress() {
-        givenContextContainsMigrationHelperStackId();
-        when(mockCfn.getStatus(DEPLOYMENT_ID)).thenReturn(InfrastructureDeploymentState.CREATE_IN_PROGRESS);
     }
 
     private void givenMigrationStackDeploymentWillCompleteSuccessfully() {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
@@ -88,7 +88,7 @@ class CloudformationDeploymentServiceTest {
         givenDeploymentStateIs(InfrastructureDeploymentState.CREATE_IN_PROGRESS);
         deploySimpleStack();
 
-        InfrastructureDeploymentState state = sut.getDeploymentStatus(STACK_NAME);
+        InfrastructureDeploymentState state = sut.getDeploymentStatus();
         assertEquals(InfrastructureDeploymentState.CREATE_IN_PROGRESS, state);
     }
 
@@ -111,7 +111,7 @@ class CloudformationDeploymentServiceTest {
     void shouldBeFailedWhenStatusIsDeleted() throws InterruptedException, InfrastructureDeploymentError {
         givenDeploymentStateIs(InfrastructureDeploymentState.CREATE_FAILED);
 
-        InfrastructureDeploymentState state = sut.getDeploymentStatus(STACK_NAME);
+        InfrastructureDeploymentState state = sut.getDeploymentStatus();
         assertEquals(InfrastructureDeploymentState.CREATE_FAILED, state);
     }
 

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
@@ -17,7 +17,8 @@
 package com.atlassian.migration.datacenter.core.aws.infrastructure;
 
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
-import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.dto.MigrationContext;
+import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentError;
 import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentState;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +48,12 @@ class CloudformationDeploymentServiceTest {
     @Mock
     CfnApi mockCfnApi;
 
+    @Mock
+    MigrationService migrationService;
+
+    @Mock
+    MigrationContext context;
+
     CloudformationDeploymentService sut;
 
     boolean deploymentFailed = false;
@@ -52,7 +61,9 @@ class CloudformationDeploymentServiceTest {
 
     @BeforeEach
     void setup() {
-        sut = new CloudformationDeploymentService(mockCfnApi) {
+        lenient().doNothing().when(context).save();
+        when(migrationService.getCurrentContext()).thenReturn(context);
+        sut = new CloudformationDeploymentService(mockCfnApi, migrationService) {
             @Override
             protected void handleFailedDeployment(String message) {
                 deploymentFailed = true;
@@ -74,8 +85,7 @@ class CloudformationDeploymentServiceTest {
 
     @Test
     void shouldReturnInProgressWhileDeploying() throws InfrastructureDeploymentError {
-        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(InfrastructureDeploymentState.CREATE_IN_PROGRESS);
-
+        givenDeploymentStateIs(InfrastructureDeploymentState.CREATE_IN_PROGRESS);
         deploySimpleStack();
 
         InfrastructureDeploymentState state = sut.getDeploymentStatus(STACK_NAME);
@@ -94,30 +104,19 @@ class CloudformationDeploymentServiceTest {
         assertTrue(deploymentFailed);
         assertFalse(deploymentSucceeded);
 
+        verify(context).setDeploymentState(InfrastructureDeploymentState.CREATE_FAILED);
+    }
+
+    @Test
+    void shouldBeFailedWhenStatusIsDeleted() throws InterruptedException, InfrastructureDeploymentError {
+        givenDeploymentStateIs(InfrastructureDeploymentState.CREATE_FAILED);
 
         InfrastructureDeploymentState state = sut.getDeploymentStatus(STACK_NAME);
         assertEquals(InfrastructureDeploymentState.CREATE_FAILED, state);
     }
 
     @Test
-    void shouldBeFailedWhenStatusIsDeleted() throws InterruptedException, InfrastructureDeploymentError {
-        final String badStatus = "it broke";
-        when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(InfrastructureDeploymentState.DELETE_IN_PROGRESS);
-
-        deploySimpleStack();
-
-        Thread.sleep(100);
-
-        assertTrue(deploymentFailed);
-        assertFalse(deploymentSucceeded);
-
-
-        InfrastructureDeploymentState state = sut.getDeploymentStatus(STACK_NAME);
-        assertEquals(InfrastructureDeploymentState.DELETE_IN_PROGRESS, state);
-    }
-
-    @Test
-    void shouldCallHandleSuccessfulDeploymentWhenDeploymentFails() throws InterruptedException, InfrastructureDeploymentError {
+    void shouldCallHandleSuccessfulDeploymentWhenDeploymentSucceeds() throws InterruptedException, InfrastructureDeploymentError {
         when(mockCfnApi.getStatus(STACK_NAME)).thenReturn(InfrastructureDeploymentState.CREATE_COMPLETE);
 
         deploySimpleStack();
@@ -130,6 +129,11 @@ class CloudformationDeploymentServiceTest {
 
     private void deploySimpleStack() throws InfrastructureDeploymentError {
         sut.deployCloudformationStack(TEMPLATE_URL, STACK_NAME, STACK_PARAMS);
+    }
+
+    private void givenDeploymentStateIs(InfrastructureDeploymentState state) {
+        when(migrationService.getCurrentContext()).thenReturn(context);
+        when(context.getDeploymentState()).thenReturn(state);
     }
 
 }

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/CloudformationDeploymentServiceTest.java
@@ -62,7 +62,7 @@ class CloudformationDeploymentServiceTest {
     @BeforeEach
     void setup() {
         lenient().doNothing().when(context).save();
-        when(migrationService.getCurrentContext()).thenReturn(context);
+        lenient().when(migrationService.getCurrentContext()).thenReturn(context);
         sut = new CloudformationDeploymentService(mockCfnApi, migrationService) {
             @Override
             protected void handleFailedDeployment(String message) {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -107,7 +107,7 @@ class QuickstartDeploymentServiceTest {
             properties.setProperty(passwordPropertyKey, invocation.getArgument(0));
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
-        when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
+        lenient().when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
         lenient().when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 
         lenient().when(mockCfnApi.getStack(STACK_NAME)).thenReturn(Optional.of(Stack.builder().stackName(STACK_NAME).outputs(MOCK_OUTPUTS).build()));
@@ -258,6 +258,13 @@ class QuickstartDeploymentServiceTest {
         }
 
         verify(mockContext).setDeploymentMode(mode);
+    }
+
+    @Test
+    void shouldReturnNotDeployingWhenMigrationPhaseIsNotProvisioningStage() {
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.AUTHENTICATION);
+
+        assertEquals(InfrastructureDeploymentState.NOT_DEPLOYING, deploymentService.getDeploymentStatus());
     }
 
     private void givenStackDeploymentWillBeInProgress() {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -48,6 +48,7 @@ import java.util.Properties;
 
 import static com.atlassian.migration.datacenter.core.aws.infrastructure.QuickstartDeploymentService.SERVICE_URL_STACK_OUTPUT_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -265,6 +266,19 @@ class QuickstartDeploymentServiceTest {
         when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.AUTHENTICATION);
 
         assertEquals(InfrastructureDeploymentState.NOT_DEPLOYING, deploymentService.getDeploymentStatus());
+    }
+
+    @Test
+    void shouldReturnDeploymentCompleteWhenAfterApplicationDeploymentAndNoError() {
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.FS_MIGRATION_COPY);
+        assertEquals(InfrastructureDeploymentState.CREATE_COMPLETE, deploymentService.getDeploymentStatus());
+    }
+
+    @Test
+    void shouldReturnDeploymentFailedWhenProvisioningError() {
+        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISIONING_ERROR);
+        when(mockContext.getDeploymentState()).thenReturn(InfrastructureDeploymentState.CREATE_FAILED);
+        assertEquals(InfrastructureDeploymentState.CREATE_FAILED, deploymentService.getDeploymentStatus());
     }
 
     private void givenStackDeploymentWillBeInProgress() {

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentServiceTest.java
@@ -103,12 +103,12 @@ class QuickstartDeploymentServiceTest {
     void setUp() {
         Properties properties = new Properties();
         final String passwordPropertyKey = "password";
-        doAnswer(invocation -> {
+        lenient().doAnswer(invocation -> {
             properties.setProperty(passwordPropertyKey, invocation.getArgument(0));
             return null;
         }).when(dbCredentialsStorageService).storeCredentials(anyString());
         when(mockMigrationService.getCurrentContext()).thenReturn(mockContext);
-        when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
+        lenient().when(mockMigrationService.getCurrentStage()).thenReturn(MigrationStage.PROVISION_APPLICATION);
 
         lenient().when(mockCfnApi.getStack(STACK_NAME)).thenReturn(Optional.of(Stack.builder().stackName(STACK_NAME).outputs(MOCK_OUTPUTS).build()));
 
@@ -163,10 +163,7 @@ class QuickstartDeploymentServiceTest {
 
     @Test
     void shouldReturnInProgressWhileDeploying() throws InvalidMigrationStageError, InfrastructureDeploymentError {
-        when(mockContext.getApplicationDeploymentId()).thenReturn(STACK_NAME);
-        givenStackDeploymentWillBeInProgress();
-
-        deploySimpleStack();
+        when(mockContext.getDeploymentState()).thenReturn(InfrastructureDeploymentState.CREATE_IN_PROGRESS);
 
         InfrastructureDeploymentState state = deploymentService.getDeploymentStatus();
         assertEquals(InfrastructureDeploymentState.CREATE_IN_PROGRESS, state);
@@ -248,7 +245,7 @@ class QuickstartDeploymentServiceTest {
         verify(mockContext).setServiceUrl(testServiceUrl);
         //Caters to the last save call in deployApplication com/atlassian/migration/datacenter/core/aws/infrastructure/QuickstartDeploymentService.java:106.
         // That call must be removed and each setter should save automatically, or the entire block needs to be run in a transaction
-        verify(mockContext, times(3)).save();
+        verify(mockContext, times(4)).save();
     }
 
     @ParameterizedTest

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/dto/MigrationContext.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/dto/MigrationContext.kt
@@ -15,6 +15,7 @@
  */
 package com.atlassian.migration.datacenter.dto
 
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentState
 import com.atlassian.migration.datacenter.spi.infrastructure.ProvisioningConfig
 import net.java.ao.Entity
 import net.java.ao.schema.StringLength
@@ -31,6 +32,7 @@ interface MigrationContext : Entity {
     fun getErrorMessage(): String
 
     var deploymentMode: ProvisioningConfig.DeploymentMode
+    var deploymentState: InfrastructureDeploymentState
 
     var startEpoch: Long
     var endEpoch: Long

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
@@ -105,12 +105,15 @@ enum class MigrationStage {
         }
     }
 
-
-    fun isAfter(stage: MigrationStage): Boolean {
-        return isAfter(stage, mutableSetOf())
+    /**
+     * @return true if this stage is after the provided stage along the happy path of a migration i.e. without passing
+     * through an error stage (retrying)
+     */
+    fun isAfterWithoutRetries(stage: MigrationStage): Boolean {
+        return isAfterWithoutRetries(stage, mutableSetOf())
     }
 
-    private fun isAfter(stage: MigrationStage, visited: MutableSet<MigrationStage>): Boolean {
+    private fun isAfterWithoutRetries(stage: MigrationStage, visited: MutableSet<MigrationStage>): Boolean {
         if (this == stage || this == NOT_STARTED) return false
         if (this == FINISHED || this == ERROR) return true
         // If we encounter a cycle and haven't found the stage return false
@@ -120,7 +123,7 @@ enum class MigrationStage {
             when (it) {
                 stage -> true
                 ERROR, PROVISIONING_ERROR, FS_MIGRATION_ERROR, FINAL_SYNC_ERROR -> false
-                else -> it.isAfter(stage, visited)
+                else -> it.isAfterWithoutRetries(stage, visited)
             }
         }
         return ancestorsValid.contains(true)

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationStage.kt
@@ -114,16 +114,16 @@ enum class MigrationStage {
         if (this == stage || this == NOT_STARTED) return false
         if (this == FINISHED || this == ERROR) return true
         // If we encounter a cycle and haven't found the stage return false
-        if (visited.contains(stage)) return false
-        return this.validAncestorStages.map {
+        if (visited.contains(this)) return false
+        visited.add(this)
+        val ancestorsValid = this.validAncestorStages.map {
             when (it) {
                 stage -> true
-                else -> {
-                    visited.add(it)
-                    return it.isAfter(stage, visited)
-                }
+                ERROR, PROVISIONING_ERROR, FS_MIGRATION_ERROR, FINAL_SYNC_ERROR -> false
+                else -> it.isAfter(stage, visited)
             }
-        }.contains(true)
+        }
+        return ancestorsValid.contains(true)
     }
 
     // Hacky, but OK for now.

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureDeploymentState.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/infrastructure/InfrastructureDeploymentState.kt
@@ -19,6 +19,7 @@ package com.atlassian.migration.datacenter.spi.infrastructure
  * Represents the status of the deployment of infrastructure
  */
 enum class InfrastructureDeploymentState {
+    NOT_DEPLOYING,
     CREATE_IN_PROGRESS,
     CREATE_COMPLETE,
     CREATE_FAILED,

--- a/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/MigrationStageTest.kt
+++ b/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/MigrationStageTest.kt
@@ -56,19 +56,19 @@ internal class MigrationStageTest {
 
     @Test
     fun testIsAfterStage(){
-        assertTrue(FINISHED.isAfter(NOT_STARTED))
-        assertTrue(VALIDATE.isAfter(FINAL_SYNC_WAIT))
-        assertTrue(FS_MIGRATION_COPY.isAfter(PROVISION_MIGRATION_STACK_WAIT))
-        assertTrue(VALIDATE.isAfter(PROVISION_APPLICATION))
-        assertTrue(PROVISION_MIGRATION_STACK_WAIT.isAfter(PROVISION_MIGRATION_STACK))
-        assertTrue(ERROR.isAfter(PROVISION_APPLICATION))
+        assertTrue(FINISHED.isAfterWithoutRetries(NOT_STARTED))
+        assertTrue(VALIDATE.isAfterWithoutRetries(FINAL_SYNC_WAIT))
+        assertTrue(FS_MIGRATION_COPY.isAfterWithoutRetries(PROVISION_MIGRATION_STACK_WAIT))
+        assertTrue(VALIDATE.isAfterWithoutRetries(PROVISION_APPLICATION))
+        assertTrue(PROVISION_MIGRATION_STACK_WAIT.isAfterWithoutRetries(PROVISION_MIGRATION_STACK))
+        assertTrue(ERROR.isAfterWithoutRetries(PROVISION_APPLICATION))
 
-        assertFalse(PROVISION_APPLICATION.isAfter(PROVISION_APPLICATION_WAIT))
-        assertFalse(NOT_STARTED.isAfter(FINISHED))
-        assertFalse(NOT_STARTED.isAfter(PROVISION_APPLICATION))
-        assertFalse(FS_MIGRATION_COPY.isAfter(FS_MIGRATION_COPY_WAIT))
-        assertFalse(FS_MIGRATION_COPY_WAIT.isAfter(FS_MIGRATION_COPY_WAIT))
-        assertFalse(DB_MIGRATION_EXPORT_WAIT.isAfter(FINAL_SYNC_WAIT))
+        assertFalse(PROVISION_APPLICATION.isAfterWithoutRetries(PROVISION_APPLICATION_WAIT))
+        assertFalse(NOT_STARTED.isAfterWithoutRetries(FINISHED))
+        assertFalse(NOT_STARTED.isAfterWithoutRetries(PROVISION_APPLICATION))
+        assertFalse(FS_MIGRATION_COPY.isAfterWithoutRetries(FS_MIGRATION_COPY_WAIT))
+        assertFalse(FS_MIGRATION_COPY_WAIT.isAfterWithoutRetries(FS_MIGRATION_COPY_WAIT))
+        assertFalse(DB_MIGRATION_EXPORT_WAIT.isAfterWithoutRetries(FINAL_SYNC_WAIT))
     }
 
     @Test

--- a/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/MigrationStageTest.kt
+++ b/spi/src/test/kotlin/com/atlassian/migration/datacenter/spi/MigrationStageTest.kt
@@ -58,15 +58,17 @@ internal class MigrationStageTest {
     fun testIsAfterStage(){
         assertTrue(FINISHED.isAfter(NOT_STARTED))
         assertTrue(VALIDATE.isAfter(FINAL_SYNC_WAIT))
+        assertTrue(FS_MIGRATION_COPY.isAfter(PROVISION_MIGRATION_STACK_WAIT))
         assertTrue(VALIDATE.isAfter(PROVISION_APPLICATION))
         assertTrue(PROVISION_MIGRATION_STACK_WAIT.isAfter(PROVISION_MIGRATION_STACK))
         assertTrue(ERROR.isAfter(PROVISION_APPLICATION))
 
+        assertFalse(PROVISION_APPLICATION.isAfter(PROVISION_APPLICATION_WAIT))
         assertFalse(NOT_STARTED.isAfter(FINISHED))
-        assertFalse(DB_MIGRATION_EXPORT_WAIT.isAfter(FINAL_SYNC_WAIT))
         assertFalse(NOT_STARTED.isAfter(PROVISION_APPLICATION))
         assertFalse(FS_MIGRATION_COPY.isAfter(FS_MIGRATION_COPY_WAIT))
         assertFalse(FS_MIGRATION_COPY_WAIT.isAfter(FS_MIGRATION_COPY_WAIT))
+        assertFalse(DB_MIGRATION_EXPORT_WAIT.isAfter(FINAL_SYNC_WAIT))
     }
 
     @Test


### PR DESCRIPTION
# Summary

* Refactor deployment status API result to come from DB
* Refactor backend polling of cloudformation deployment status to commit result to db
* Refactor migration stage `isAfter` logic to exclude retry paths
  * This was necessary because we use the current migration stage to determine how to respond to a query for deployment status. e.g. if we check the migration stack deployment status from the `FS_MIGRATION_COPY` stage (or any stage in the future), we return `CREATE_COMPLETE` because to get to that stage you need a successful migration stack deployment