### PR TITLE
CHET-627: End to end test stabilisation && GitHub Actions

### DIFF
--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -58,6 +58,7 @@ jobs:
           CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
           CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
           CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
+          CYPRESS_TARGET_TESTSUITE: smoketest
         run: |
           mvn package -DskipTests
           mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
@@ -73,6 +74,7 @@ jobs:
           CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
           CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
           CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
+          CYPRESS_TARGET_TESTSUITE: e2e_full_migration
         run: |
           mvn package -DskipTests
           mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11 ]
-        profile: ['integration', '!integration', 'smoketest', 'functest', 'end2end']
+        profile: ['end2end']
 
     steps:
       - name: Checkout code
@@ -45,40 +45,40 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-#
-#      - name: Test with maven
-#        if: matrix.profile != 'smoketest' && matrix.profile != 'functest'
-#        run: mvn -B clean verify -P ${{ matrix.profile}}
 
-#      - name: Smoke-test with production image
-#        timeout-minutes: 20
-#        if: matrix.profile == 'smoketest'
-#        env:
-#          JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
-#          CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
-#          CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
-#          CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
-#        run: |
-#          mvn package -DskipTests
-#          mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
-#          cd jira-e2e-tests
-#          ./postgres/inject-license
-#          JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
+      - name: Test with maven
+        if: matrix.profile != 'smoketest' && matrix.profile != 'functest'
+        run: mvn -B clean verify -P ${{ matrix.profile}}
+
+      - name: Smoke-test with production image
+        timeout-minutes: 20
+        if: matrix.profile == 'smoketest'
+        env:
+          JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
+          CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
+          CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
+          CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
+        run: |
+          mvn package -DskipTests
+          mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
+          cd jira-e2e-tests
+          ./postgres/inject-license
+          JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
 
       - name: End to end test with production image
-          timeout-minutes: 20
-          if: matrix.profile == 'end2end'
-          env:
-            JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
-            CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
-            CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
-            CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
-          run: |
-            mvn package -DskipTests
-            mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
-            cd jira-e2e-tests
-            ./postgres/inject-license
-            JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
+        timeout-minutes: 20
+        if: matrix.profile == 'end2end'
+        env:
+          JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
+          CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
+          CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
+          CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
+        run: |
+          mvn package -DskipTests
+          mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
+          cd jira-e2e-tests
+          ./postgres/inject-license
+          JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
 
       - name: REST API tests with production image
         timeout-minutes: 20

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push]
 
+env:
+  MAIN_BRANCH_REF: ${{ secrets.MAIN_BRANCH_REF }}
+
 jobs:
   run_tests:
     name: Java${{ matrix.java }} ${{ matrix.profile }} test
@@ -10,7 +13,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11 ]
-        profile: ['end2end']
+        profile: ['integration', '!integration', 'smoketest', 'functest', 'end2end']
 
     steps:
       - name: Checkout code
@@ -46,12 +49,12 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Test with maven
-        if: matrix.profile != 'smoketest' && matrix.profile != 'functest'
+        if: matrix.profile != 'smoketest' && matrix.profile != 'functest' && matrix.profile != 'end2end'
         run: mvn -B clean verify -P ${{ matrix.profile}}
 
       - name: Smoke-test with production image
         timeout-minutes: 20
-        if: matrix.profile == 'smoketest'
+        if: matrix.profile == 'smoketest' && matrix.java == '11'
         env:
           JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
           CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
@@ -67,7 +70,7 @@ jobs:
 
       - name: End to end test with production image
         timeout-minutes: 120
-        if: ${{ matrix.profile == 'end2end' && matrix.java == '11' }}
+        if: ${{ matrix.profile == 'end2end' && matrix.java == '11' && github.ref == env.MAIN_BRANCH_REF }}
         env:
           JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
           CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11 ]
-        profile: ['integration', '!integration', 'smoketest', 'functest']
+        profile: ['integration', '!integration', 'smoketest', 'functest', 'end2end']
 
     steps:
       - name: Checkout code
@@ -45,25 +45,40 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+#
+#      - name: Test with maven
+#        if: matrix.profile != 'smoketest' && matrix.profile != 'functest'
+#        run: mvn -B clean verify -P ${{ matrix.profile}}
 
-      - name: Test with maven
-        if: matrix.profile != 'smoketest' && matrix.profile != 'functest'
-        run: mvn -B clean verify -P ${{ matrix.profile}}
+#      - name: Smoke-test with production image
+#        timeout-minutes: 20
+#        if: matrix.profile == 'smoketest'
+#        env:
+#          JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
+#          CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
+#          CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
+#          CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
+#        run: |
+#          mvn package -DskipTests
+#          mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
+#          cd jira-e2e-tests
+#          ./postgres/inject-license
+#          JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
 
-      - name: Smoke-test with production image
-        timeout-minutes: 20
-        if: matrix.profile == 'smoketest'
-        env:
-          JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
-          CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
-          CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
-          CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
-        run: |
-          mvn package -DskipTests
-          mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
-          cd jira-e2e-tests
-          ./postgres/inject-license
-          JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
+      - name: End to end test with production image
+          timeout-minutes: 20
+          if: matrix.profile == 'end2end'
+          env:
+            JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
+            CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}
+            CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPRESS_AWS_SECRET_ACCESS_KEY }}
+            CYPRESS_ADMIN_PASSWORD: ${{ secrets.CYPRESS_ADMIN_PASSWORD }}
+          run: |
+            mvn package -DskipTests
+            mv jira-plugin/target/jira-plugin-*.jar jira-e2e-tests/jira/
+            cd jira-e2e-tests
+            ./postgres/inject-license
+            JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
 
       - name: REST API tests with production image
         timeout-minutes: 20

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -81,6 +81,12 @@ jobs:
           ./postgres/inject-license
           JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
 
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-results
+          path: /opt/cypress/
+
       - name: REST API tests with production image
         timeout-minutes: 20
         if: matrix.profile == 'functest'

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -6,7 +6,7 @@ jobs:
   run_tests:
     name: Java${{ matrix.java }} ${{ matrix.profile }} test
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 120
 
     strategy:
       matrix:
@@ -66,7 +66,7 @@ jobs:
           JIRA_VERSION=latest docker-compose up --force-recreate --build --exit-code-from cypress --abort-on-container-exit postgresql jira cypress
 
       - name: End to end test with production image
-        timeout-minutes: 20
+        timeout-minutes: 120
         if: matrix.profile == 'end2end'
         env:
           JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -6,7 +6,6 @@ jobs:
   run_tests:
     name: Java${{ matrix.java }} ${{ matrix.profile }} test
     runs-on: ubuntu-latest
-    timeout-minutes: 120
 
     strategy:
       matrix:
@@ -68,7 +67,7 @@ jobs:
 
       - name: End to end test with production image
         timeout-minutes: 120
-        if: matrix.profile == 'end2end'
+        if: ${{ matrix.profile == 'end2end' && matrix.java == '11' }}
         env:
           JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
           CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -85,7 +85,7 @@ jobs:
         if: failure()
         with:
           name: cypress-results
-          path: /opt/cypress/
+          path: /tmp/cypress/ # this is coming from the docker-compose volume mounts
 
       - name: REST API tests with production image
         timeout-minutes: 20

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -35,7 +35,7 @@ import { showsBlockUserWarning, continueWithMigration } from '../support/pages/B
 import { runFinalSync, monitorFinalSync } from '../support/pages/FinalSync';
 import { showsValidationPage } from '../support/pages/ValidationPage';
 
-const shouldReset = true;
+const shouldReset = false;
 
 const getAwsTokens = (): AWSCredentials => {
     return {
@@ -92,10 +92,10 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
+        cy.visit(ctx.pluginFullUrl + '/fs'); // TODO remove if possible
         cy.jira_login(ctx);
-        cy.wait(60000);
         cy.visit(ctx.pluginFullUrl + '/fs');
-        cy.wait(60000);
+
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });
@@ -106,23 +106,16 @@ describe('Migration plugin', () => {
     });
 
     it('runs final database migration and final fs sync', () => {
-        cy.jira_login(ctx);
-        cy.wait(60000);
-        cy.visit(ctx.pluginFullUrl + '/final-s');
-        cy.wait(60000);
-
         runFinalSync();
         monitorFinalSync(ctx);
     });
 
     let serviceURL: string;
     it('shows validation page after migration finishes and close migration app', () => {
-        refreshLogin(); //we are usually logged out
-
         serviceURL = showsValidationPage();
     });
 
-    it('Validate issues with inline attachment', () => {
+    it.skip('Validate issues with inline attachment', () => {
         validate_issue(
             'TEST-17',
             ctx,
@@ -133,7 +126,7 @@ describe('Migration plugin', () => {
         );
     });
 
-    it('Validate issues with large attachment', () => {
+    it.skip('Validate issues with large attachment', () => {
         validate_issue(
             'TEST-18',
             ctx,
@@ -143,9 +136,4 @@ describe('Migration plugin', () => {
             null
         );
     });
-
-    const refreshLogin = () => {
-        cy.jira_login(ctx);
-        cy.visit(ctx.pluginHomePage);
-    };
 });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -87,10 +87,13 @@ describe('Migration plugin', () => {
         submitQuickstartForm();
     });
 
-   
+    it('waits for provisioning', () => {
+        waitForProvisioning(ctx);
+    });
 
     it('starts and monitor filesystem', () => {
-        waitForProvisioning(ctx);
+        cy.jira_login(ctx);
+        cy.visit(ctx.pluginFullUrl + '/fs');
 
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -92,8 +92,7 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
-        cy.jira_login(ctx);
-        cy.visit(ctx.pluginFullUrl + '/fs');
+        cy.jira_fill_websudo(ctx);
 
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -133,6 +133,15 @@ describe('Migration plugin', () => {
     });
 
     it('Validate issues with inline attachment', () => {
+        cy.log(serviceURL);
+
+        cy.wait(1000 * 60 * 5);
+
+        cy.request(serviceURL + '/status').then((resp) => {
+            cy.log(`status> ${resp.status.toString()}`);
+            cy.log(`body> ${resp.body}`);
+        });
+
         validate_issue(
             'TEST-17',
             ctx,

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -102,22 +102,22 @@ describe('Migration plugin', () => {
     });
 
     it('shows warning to block user access', () => {
-        cy.visit(ctx.pluginFullUrl + '/warning');
+        cy.visit(`${ctx.pluginFullUrl}/warning`);
 
         showsBlockUserWarning();
-        // continueWithMigration();
+        continueWithMigration();
     });
 
     it('runs final database migration and final fs sync', () => {
-        cy.visit(ctx.pluginFullUrl + '/final-sync');
-
         runFinalSync();
         monitorFinalSync(ctx);
     });
 
     let serviceURL: string;
     it('shows validation page after migration finishes and close migration app', () => {
+        cy.visit(`${ctx.pluginFullUrl}/validation`)
         serviceURL = showsValidationPage();
+        cy.log(serviceURL);
     });
 
     it.skip('Validate issues with inline attachment', () => {

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -49,6 +49,7 @@ describe('Migration plugin', () => {
     const region = 'ap-southeast-2';
     const testId = Math.random().toString(36).substring(2, 8);
     const credentials = getAwsTokens();
+    let serviceUrl;
 
     before(() => {
         cy.on('uncaught:exception', (err, runnable) => false);
@@ -96,7 +97,6 @@ describe('Migration plugin', () => {
 
         cy.visit(`${ctx.pluginFullUrl}/fs`);
 
-
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });
@@ -115,12 +115,24 @@ describe('Migration plugin', () => {
 
     let serviceURL: string;
     it('shows validation page after migration finishes and close migration app', () => {
-        cy.visit(`${ctx.pluginFullUrl}/validation`)
-        serviceURL = showsValidationPage();
+        cy.visit(`${ctx.pluginFullUrl}/validation`);
+
+        cy.get('#dc-migration-assistant-root p > a')
+            .contains('http://')
+            .then((href) => {
+                const _serviceURL = href.attr('href');
+                if (typeof _serviceURL === 'string') {
+                    serviceURL = _serviceURL;
+                } else {
+                    serviceURL = 'cannot fetch URL';
+                }
+            });
         cy.log(serviceURL);
+
+        showsValidationPage();
     });
 
-    it.skip('Validate issues with inline attachment', () => {
+    it('Validate issues with inline attachment', () => {
         validate_issue(
             'TEST-17',
             ctx,
@@ -131,7 +143,7 @@ describe('Migration plugin', () => {
         );
     });
 
-    it.skip('Validate issues with large attachment', () => {
+    it('Validate issues with large attachment', () => {
         validate_issue(
             'TEST-18',
             ctx,

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -125,7 +125,7 @@ describe('Migration plugin', () => {
         waitForProvisioning(ctx);
     });
 
-    it.skip('starts and monitor filesystem', () => {
+    it('starts and monitor filesystem', () => {
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -114,7 +114,7 @@ describe('Migration plugin', () => {
     it('shows validation page after migration finishes and close migration app', () => {
         refreshLogin(); //we are usually logged out
 
-        let serviceURL = showsValidationPage();
+        serviceURL = showsValidationPage();
     });
 
     it('Validate issues with inline attachment', () => {

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -16,7 +16,7 @@
 
 /// <reference types="Cypress" />
 
-import type { AWSCredentials } from '../support/common'
+import type { AWSCredentials } from '../support/common';
 
 import { waitForProvisioning } from '../support/pages/ProvisioningPage';
 import { getContext, validate_issue } from '../support/jira';
@@ -92,8 +92,10 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
-        refreshLogin(); //we are usually logged out
-
+        cy.jira_login(ctx);
+        cy.wait(60000);
+        cy.visit(ctx.pluginFullUrl + '/fs');
+        cy.wait(60000);
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });
@@ -104,7 +106,10 @@ describe('Migration plugin', () => {
     });
 
     it('runs final database migration and final fs sync', () => {
-        refreshLogin(); //we are usually logged out
+        cy.jira_login(ctx);
+        cy.wait(60000);
+        cy.visit(ctx.pluginFullUrl + '/final-s');
+        cy.wait(60000);
 
         runFinalSync();
         monitorFinalSync(ctx);

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -94,16 +94,23 @@ describe('Migration plugin', () => {
     it('starts and monitor filesystem', () => {
         cy.jira_fill_websudo(ctx);
 
+        cy.visit(`${ctx.pluginFullUrl}/fs`);
+
+
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });
 
     it('shows warning to block user access', () => {
+        cy.visit(ctx.pluginFullUrl + '/warning');
+
         showsBlockUserWarning();
-        continueWithMigration();
+        // continueWithMigration();
     });
 
     it('runs final database migration and final fs sync', () => {
+        cy.visit(ctx.pluginFullUrl + '/final-sync');
+
         runFinalSync();
         monitorFinalSync(ctx);
     });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -53,6 +53,7 @@ describe('Migration plugin', () => {
 
     before(() => {
         cy.on('uncaught:exception', (err, runnable) => false);
+        cy.viewport('macbook-15');
         expect(credentials.keyId, 'Set AWS_ACCESS_KEY_ID, see README.md').to.not.be.undefined;
 
         Cypress.Cookies.defaults({ whitelist: ['JSESSIONID', 'atlassian.xsrf.token'] });
@@ -158,8 +159,7 @@ describe('Migration plugin', () => {
             ctx,
             serviceURL,
             'random.bin',
-            'cdb8239c10b894beef502af29eaa3cf1',
-            null
+            'cdb8239c10b894beef502af29eaa3cf1'
         );
     });
 });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -87,13 +87,10 @@ describe('Migration plugin', () => {
         submitQuickstartForm();
     });
 
-    it('waits for provisioning', () => {
-        waitForProvisioning(ctx);
-    });
+   
 
     it('starts and monitor filesystem', () => {
-        cy.jira_login(ctx);
-        cy.visit(ctx.pluginFullUrl + '/fs');
+        waitForProvisioning(ctx);
 
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -92,8 +92,6 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
-        cy.jira_fill_websudo(ctx);
-
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -109,7 +109,6 @@ describe('Migration plugin', () => {
     });
 
     it('runs final database migration and final fs sync', () => {
-        cy.visit(`${ctx.pluginFullUrl}/final-sync`);
         runFinalSync();
         monitorFinalSync(ctx);
     });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -110,7 +110,7 @@ describe('Migration plugin', () => {
         monitorFinalSync(ctx);
     });
 
-    let serviceURL: string
+    let serviceURL: string;
     it('shows validation page after migration finishes and close migration app', () => {
         refreshLogin(); //we are usually logged out
 
@@ -118,11 +118,25 @@ describe('Migration plugin', () => {
     });
 
     it('Validate issues with inline attachment', () => {
-        validate_issue("TEST-17", ctx, serviceURL, "vbackground.png", "3393ce5431bcb31aea66541c3a1c6a56", "43ef675cf099a8d5108b1de45e221dac")
+        validate_issue(
+            'TEST-17',
+            ctx,
+            serviceURL,
+            'vbackground.png',
+            '3393ce5431bcb31aea66541c3a1c6a56',
+            '43ef675cf099a8d5108b1de45e221dac'
+        );
     });
 
     it('Validate issues with large attachment', () => {
-        validate_issue("TEST-18", ctx, serviceURL, "random.bin", "cdb8239c10b894beef502af29eaa3cf1", null)
+        validate_issue(
+            'TEST-18',
+            ctx,
+            serviceURL,
+            'random.bin',
+            'cdb8239c10b894beef502af29eaa3cf1',
+            null
+        );
     });
 
     const refreshLogin = () => {

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -153,7 +153,7 @@ describe('Migration plugin', () => {
         );
     });
 
-    it('Validate issues with large attachment', () => {
+    it.skip('Validate issues with large attachment', () => {
         validate_issue(
             'TEST-18',
             ctx,

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -35,7 +35,7 @@ import { showsBlockUserWarning, continueWithMigration } from '../support/pages/B
 import { runFinalSync, monitorFinalSync } from '../support/pages/FinalSync';
 import { showsValidationPage } from '../support/pages/ValidationPage';
 
-const shouldReset = false;
+const shouldReset = true;
 
 const getAwsTokens = (): AWSCredentials => {
     return {
@@ -92,7 +92,6 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
-        cy.visit(ctx.pluginFullUrl + '/fs'); // TODO remove if possible
         cy.jira_login(ctx);
         cy.visit(ctx.pluginFullUrl + '/fs');
 

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -92,6 +92,8 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
+        cy.jira_fill_websudo(ctx);
+
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -60,6 +60,7 @@ describe('Migration plugin', () => {
         if (shouldReset) {
             cy.reset_migration(ctx);
         }
+        cy.visit(ctx.pluginFullUrl);
     });
 
     beforeEach(() => {

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -63,44 +63,10 @@ describe('Migration plugin', () => {
         cy.visit(ctx.pluginFullUrl);
     });
 
-    beforeEach(() => {
-        // cy.visit(ctx.pluginFullUrl);
-    });
-
     afterEach(function () {
         if (this.currentTest.state === 'failed') {
             Cypress.runner.stop();
         }
-    });
-
-    it.skip('runs full migration', () => {
-        startMigration(ctx);
-
-        fillCrendetialsOnAuthPage(ctx, region, credentials);
-
-        selectPrefixOnASIPage(ctx);
-
-        configureQuickStartFormWithoutVPC(ctx, {
-            stackName: `teststack-${testId}`,
-            dbPassword: `XadD54^${testId}`,
-            dbMasterPassword: `YadD54^${testId}`,
-        });
-
-        submitQuickstartForm();
-
-        waitForProvisioning(ctx);
-
-        startFileSystemInitialMigration(ctx);
-
-        monitorFileSystemMigration(ctx);
-
-        showsBlockUserWarning();
-        continueWithMigration();
-
-        runFinalSync();
-        monitorFinalSync(ctx);
-
-        showsValidationPage();
     });
 
     it('starts migration', () => {
@@ -126,22 +92,28 @@ describe('Migration plugin', () => {
     });
 
     it('starts and monitor filesystem', () => {
+        refreshLogin(); //we are usually logged out
+
         startFileSystemInitialMigration(ctx);
         monitorFileSystemMigration(ctx);
     });
 
-    it('show warning to block access access', () => {
+    it('shows warning to block user access', () => {
         showsBlockUserWarning();
         continueWithMigration();
     });
 
-    it('runs final sync', () => {
+    it('runs final database migration and final fs sync', () => {
+        refreshLogin(); //we are usually logged out
+
         runFinalSync();
         monitorFinalSync(ctx);
     });
 
     let serviceURL: string
-    it('shows validation page after migration finishes', () => {
+    it('shows validation page after migration finishes and close migration app', () => {
+        refreshLogin(); //we are usually logged out
+
         let serviceURL = showsValidationPage();
     });
 
@@ -153,4 +125,8 @@ describe('Migration plugin', () => {
         validate_issue("TEST-18", ctx, serviceURL, "random.bin", "cdb8239c10b894beef502af29eaa3cf1", null)
     });
 
+    const refreshLogin = () => {
+        cy.jira_login(ctx);
+        cy.visit(ctx.pluginHomePage);
+    };
 });

--- a/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
+++ b/jira-e2e-tests/cypress/integration/e2e_full_migration.ts
@@ -109,6 +109,7 @@ describe('Migration plugin', () => {
     });
 
     it('runs final database migration and final fs sync', () => {
+        cy.visit(`${ctx.pluginFullUrl}/final-sync`);
         runFinalSync();
         monitorFinalSync(ctx);
     });

--- a/jira-e2e-tests/cypress/integration/landing_page.ts
+++ b/jira-e2e-tests/cypress/integration/landing_page.ts
@@ -21,13 +21,13 @@ import { getContext } from '../support/jira';
 describe('Landing page', () => {
     const ctx: AppContext = getContext();
 
-    beforeEach(() => {
+    before(() => {
         cy.server();
         cy.jira_login(ctx);
         cy.reset_migration(ctx);
     });
 
-    it('should display warning and disable button when not ready for migration', () => {
+    it.skip('should display warning and disable button when not ready for migration', () => {
         cy.route({
             method: 'GET',
             url: ctx.context + '/rest/dc-migration/1.0/migration/ready',
@@ -52,5 +52,19 @@ describe('Landing page', () => {
         });
 
         cy.get('button[data-test=start-migration]').should('be.disabled');
+    });
+
+    let serviceUrl;
+    it('test async wrapper', () => {
+        cy.get('#dc-migration-assistant-root a')
+            .first()
+            .invoke('text')
+            .then((value) => {
+                serviceUrl = value;
+            });
+    });
+
+    it('test async wrapper', () => {
+        cy.log(serviceUrl);
     });
 });

--- a/jira-e2e-tests/cypress/package.json
+++ b/jira-e2e-tests/cypress/package.json
@@ -7,14 +7,15 @@
         "@types/jest": "^25.2.1",
         "@types/node": "^13.13.4",
         "@types/typescript": "^2.0.0",
-        "cypress": "^4.10.0",
+        "cypress": "4.12.0",
         "jest": "^25.5.0",
         "ts-jest": "^25.4.0",
         "typescript": "^3.8.3"
     },
     "scripts": {
         "cypress": "cypress open",
-        "test": "cypress run"
+        "test": "cypress run",
+        "electron": "cypress open --browser electron"
     },
     "prettier": {
         "tabWidth": 4,

--- a/jira-e2e-tests/cypress/support/index.d.ts
+++ b/jira-e2e-tests/cypress/support/index.d.ts
@@ -1,3 +1,4 @@
+import { AppContext } from './common';
 /*
  * Copyright 2020 Atlassian
  *
@@ -19,6 +20,7 @@
 declare namespace Cypress {
     interface Chainable {
         jira_login(ctx: AppContext): Chainable<Element>;
+        jira_fill_websudo(ctx: AppContext): Chainable<Element>;
         jira_setup(): Chainable<Element>;
         reset_migration(ctx: AppContext): Chainable<Element>;
     }

--- a/jira-e2e-tests/cypress/support/index.d.ts
+++ b/jira-e2e-tests/cypress/support/index.d.ts
@@ -21,6 +21,5 @@ declare namespace Cypress {
         jira_login(ctx: AppContext): Chainable<Element>;
         jira_setup(): Chainable<Element>;
         reset_migration(ctx: AppContext): Chainable<Element>;
-        relogin(ctx: AppContext): Chainable<Element>;
     }
 }

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -30,8 +30,8 @@ Cypress.Commands.add('jira_login', (ctx) => {
 });
 
 Cypress.Commands.add('jira_fill_websudo', (ctx) => {
-  cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
-  cy.get('#login-form-submit').click();
+    cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
+    cy.get('#login-form-submit').click();
 });
 
 Cypress.Commands.add('jira_setup', () => {
@@ -53,5 +53,21 @@ Cypress.Commands.add('reset_migration', (ctx) => {
     cy.get('#dc-migration-assistant-root').should('exist');
     cy.window().then((window) => {
         window.AtlassianMigration.resetMigration();
+    });
+});
+
+Cypress.on('window:before:load', function (win) {
+    const original = win.EventTarget.prototype.addEventListener;
+
+    win.EventTarget.prototype.addEventListener = function () {
+        if (arguments && arguments[0] === 'beforeunload') {
+            return;
+        }
+        return original.apply(this, arguments);
+    };
+
+    Object.defineProperty(win, 'onbeforeunload', {
+        get: function () {},
+        set: function () {},
     });
 });

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -52,8 +52,3 @@ Cypress.Commands.add('reset_migration', (ctx) => {
         window.AtlassianMigration.resetMigration();
     });
 });
-
-Cypress.Commands.add('relogin', (ctx) => {
-    cy.jira_login(ctx);
-    cy.visit(ctx.pluginHomePage);
-});

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -22,14 +22,16 @@ Cypress.Commands.add('jira_login', (ctx) => {
     cy.get('#login-form-username').type(ctx.username);
     cy.get('#login-form-password').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
-    // Force wait for dashboard to avoid flakiness.
-    cy.wait(20000)
 
     // Ensure we have full admin access before doing anything
     cy.visit(ctx.sudoURL);
     cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
-    cy.wait(20000)
+});
+
+Cypress.Commands.add('jira_fill_websudo', (ctx) => {
+  cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
+  cy.get('#login-form-submit').click();
 });
 
 Cypress.Commands.add('jira_setup', () => {

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -30,6 +30,7 @@ Cypress.Commands.add('jira_login', (ctx) => {
 });
 
 Cypress.Commands.add('jira_fill_websudo', (ctx) => {
+    cy.visit(ctx.sudoURL);
     cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
 });
@@ -53,21 +54,5 @@ Cypress.Commands.add('reset_migration', (ctx) => {
     cy.get('#dc-migration-assistant-root').should('exist');
     cy.window().then((window) => {
         window.AtlassianMigration.resetMigration();
-    });
-});
-
-Cypress.on('window:before:load', function (win) {
-    const original = win.EventTarget.prototype.addEventListener;
-
-    win.EventTarget.prototype.addEventListener = function () {
-        if (arguments && arguments[0] === 'beforeunload') {
-            return;
-        }
-        return original.apply(this, arguments);
-    };
-
-    Object.defineProperty(win, 'onbeforeunload', {
-        get: function () {},
-        set: function () {},
     });
 });

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -23,12 +23,13 @@ Cypress.Commands.add('jira_login', (ctx) => {
     cy.get('#login-form-password').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
     // Force wait for dashboard to avoid flakiness.
-    //cy.get('[class=g-intro]').should('exist');
+    cy.wait(20000)
 
     // Ensure we have full admin access before doing anything
     cy.visit(ctx.sudoURL);
     cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
+    cy.wait(20000)
 });
 
 Cypress.Commands.add('jira_setup', () => {

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -27,7 +27,7 @@ Cypress.Commands.add('jira_login', (ctx) => {
 
     // Ensure we have full admin access before doing anything
     cy.visit(ctx.sudoURL);
-    cy.get('#login-form-authenticatePassword').type(ctx.password);
+    cy.get('#login-form-authenticatePassword').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
 });
 

--- a/jira-e2e-tests/cypress/support/index.js
+++ b/jira-e2e-tests/cypress/support/index.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('jira_login', (ctx) => {
     cy.visit(ctx.loginURL);
 
     cy.get('#login-form-username').type(ctx.username);
-    cy.get('#login-form-password').type(ctx.password);
+    cy.get('#login-form-password').type(ctx.password, { log: false });
     cy.get('#login-form-submit').click();
     // Force wait for dashboard to avoid flakiness.
     //cy.get('[class=g-intro]').should('exist');

--- a/jira-e2e-tests/cypress/support/jira.ts
+++ b/jira-e2e-tests/cypress/support/jira.ts
@@ -77,6 +77,7 @@ export const getContext = () => {
         case 'local': {
             return dockerLocalContext;
         }
+        case 'compose':
         default:
             return dockerComposeContext;
     }

--- a/jira-e2e-tests/cypress/support/jira.ts
+++ b/jira-e2e-tests/cypress/support/jira.ts
@@ -16,8 +16,8 @@
 
 /// <reference types="Cypress" />
 
-import type { AppContext } from './common'
-import * as common from './common'
+import type { AppContext } from './common';
+import * as common from './common';
 
 export const createAppContext = (
     base: string,
@@ -27,7 +27,7 @@ export const createAppContext = (
     const baseURL = base + contextPath;
     const pluginPathWithContext = contextPath + '/plugins/servlet/dc-migration-assistant';
     const pluginFullUrl = base + pluginPathWithContext;
-    const password = Cypress.env('ADMIN_PASSWORD')
+    const password = Cypress.env('ADMIN_PASSWORD');
     assert.isDefined(
         password,
         'You need to define admin password via `CYPRESS_ADMIN_PASSWORD env variable`'
@@ -83,50 +83,60 @@ export const getContext = () => {
     }
 };
 
-
 export const reindex = (issues: string[], ctx: AppContext, targetURL: string) => {
     cy.request({
-        url: targetURL+`/rest/api/2/reindex/issue?issueID=${issues.join(",")}`,
-        method: "POST",
-        headers: {"Origin": targetURL},
+        url: `${targetURL}/rest/api/2/reindex/issue?issueID=${issues.join(',')}`,
+        method: 'POST',
+        headers: { Origin: targetURL },
         auth: ctx.restAuth,
-    })
-}
+    });
+};
 
-export const validate_issue = (issueKey: string, ctx: AppContext, targetURL: string, attName: string?, attHash: string?, attThumbHash: string?) => {
-    cy.log(targetURL)
+export const validate_issue = (
+    issueKey: string,
+    ctx: AppContext,
+    targetURL: string,
+    attName?: string,
+    attHash?: string,
+    attThumbHash?: string
+) => {
     reindex([issueKey], ctx, targetURL);
 
     let req = {
-        url: `${ctx.restBaseURL}/issue/${issueKey}`,
+        url: `${targetURL}/rest/api/2/issue/${issueKey}`,
         auth: ctx.restAuth,
-    }
+    };
     cy.request(req)
         .its('body')
         .then((issue) => {
-            expect(issue).property('key').to.equal(issueKey)
-            expect(issue).property('fields').property('attachment').to.have.length(1)
+            expect(issue).property('key').to.equal(issueKey);
+            expect(issue).property('fields').property('attachment').to.have.length(1);
             if (attName != null && attName != undefined) {
-                expect(issue.fields.attachment[0]).property('filename').to.equal(attName)
+                expect(issue.fields.attachment[0]).property('filename').to.equal(attName);
                 let imgURL = issue.fields.attachment[0].content;
                 let thumbURL = issue.fields.attachment[0].thumbnail;
-                return [imgURL, thumbURL]
+                return [imgURL, thumbURL];
             } else {
-                return [null, null]
+                return [null, null];
             }
         })
         .then(([imgURL, thumbURL]) => {
-            if (imgURL != null) {
-                cy.request({url: imgURL, auth: ctx.restAuth, encoding: 'binary'})
-                    .then((resp) => {
-                        common.checksum(resp.body, attHash)
-                    })
+            if (attHash && imgURL != null) {
+                cy.request({
+                    url: imgURL,
+                    auth: ctx.restAuth,
+                    encoding: 'binary',
+                    timeout: 2 * 60 * 1000, // we might be downloading 10 MB binary
+                }).then((resp) => {
+                    common.checksum(resp.body, attHash);
+                });
             }
-            if (thumbURL != null) {
-                cy.request({url: thumbURL, auth: ctx.restAuth,encoding: 'binary'})
-                    .then((resp) => {
-                        common.checksum(resp.body, attThumbHash)
-                    })
+            if (attThumbHash && thumbURL != null) {
+                cy.request({ url: thumbURL, auth: ctx.restAuth, encoding: 'binary' }).then(
+                    (resp) => {
+                        common.checksum(resp.body, attThumbHash);
+                    }
+                );
             }
-        })
-}
+        });
+};

--- a/jira-e2e-tests/cypress/support/jira.ts
+++ b/jira-e2e-tests/cypress/support/jira.ts
@@ -94,6 +94,7 @@ export const reindex = (issues: string[], ctx: AppContext, targetURL: string) =>
 }
 
 export const validate_issue = (issueKey: string, ctx: AppContext, targetURL: string, attName: string?, attHash: string?, attThumbHash: string?) => {
+    cy.log(targetURL)
     reindex([issueKey], ctx, targetURL);
 
     let req = {

--- a/jira-e2e-tests/cypress/support/pages/AwsAuthPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/AwsAuthPage.ts
@@ -7,8 +7,8 @@ export const fillCrendetialsOnAuthPage = (
         expect(loc.pathname).to.eq(ctx.pluginPath + '/aws/auth');
     });
 
-    cy.get('[data-test=aws-auth-key]').type(credentials.keyId);
-    cy.get('[data-test=aws-auth-secret]').type(credentials.secretKey);
+    cy.get('[data-test=aws-auth-key]').type(credentials.keyId, { log: false });
+    cy.get('[data-test=aws-auth-secret]').type(credentials.secretKey, { log: false });
     // FIXME: This may be flaky; the AtlasKit AsyncSelect
     // component is hard to instrument.
     cy.get('#region-uid3').click();

--- a/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
+++ b/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
@@ -1,5 +1,5 @@
 import { waitForStatus, EndpointType } from '../waiters';
-import {AppContext} from "../common";
+import { AppContext } from '../common';
 
 const header = 'Step 4 of 7: Copy Content';
 
@@ -30,15 +30,9 @@ export const monitorFileSystemMigration = (ctx: AppContext) => {
 
     cy.get('#dc-migration-assistant-root').then(($section) => {
         if ($section.text().includes('Ignore and continue')) {
-            cy.get('a', { timeout: 20000 })
-                .contains('Ignore and continue')
-                .should('be.visible')
-                .click();
+            cy.get('a', { timeout: 20000 }).contains('Ignore and continue').click();
         } else {
-            cy.get('button[data-testid=button-next]', { timeout: 20000 })
-                .contains('Next')
-                .should('be.visible')
-                .click();
+            cy.get('button[data-testid=button-next]', { timeout: 20000 }).contains('Next').click();
         }
     });
 };

--- a/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
+++ b/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
@@ -4,7 +4,7 @@ import { AppContext } from '../common';
 const header = 'Step 4 of 7: Copy Content';
 
 export const startFileSystemInitialMigration = (ctx: AppContext) => {
-    cy.location().should((loc: Location) => {
+    cy.location({timeout: 20000}).should((loc: Location) => {
         expect(loc.pathname).to.eq(ctx.pluginPath + '/fs');
     });
     cy.get('#dc-migration-assistant-root h1').contains(header);

--- a/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
+++ b/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
@@ -20,18 +20,22 @@ export const monitorFileSystemMigration = (ctx: AppContext) => {
     cy.get('#dc-migration-assistant-root h1').contains(header);
     cy.get('button[data-testid=button-refresh]').should('be.visible');
 
-    cy.get('#dc-migration-assistant-root h4').contains('Counting and uploading your files to AWS');
-
     waitForStatus(
         ctx.context + '/rest/dc-migration/1.0/migration/fs/report',
         'DONE',
         EndpointType.FILESYSTEM_REPORT
     );
 
+    cy.log("let's wait for 20 seconds");
+    cy.wait(20000);
+
     cy.get('#dc-migration-assistant-root').then(($section) => {
+        cy.log($section.text());
         if ($section.text().includes('Ignore and continue')) {
+            cy.log('We had failing files, we will ignore and continue');
             cy.get('a', { timeout: 20000 }).contains('Ignore and continue').click();
         } else {
+            cy.log('All green, lets continue');
             cy.get('button[data-testid=button-next]', { timeout: 20000 }).contains('Next').click();
         }
     });

--- a/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
+++ b/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
@@ -26,9 +26,6 @@ export const monitorFileSystemMigration = (ctx: AppContext) => {
         EndpointType.FILESYSTEM_REPORT
     );
 
-    cy.log("let's wait for 20 seconds");
-    cy.wait(20000);
-
     cy.get('#dc-migration-assistant-root').then(($section) => {
         cy.log($section.text());
         if ($section.text().includes('Ignore and continue')) {

--- a/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
+++ b/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
@@ -1,4 +1,5 @@
 import { waitForStatus, EndpointType } from '../waiters';
+import {AppContext} from "../common";
 
 const header = 'Step 4 of 7: Copy Content';
 
@@ -27,8 +28,17 @@ export const monitorFileSystemMigration = (ctx: AppContext) => {
         EndpointType.FILESYSTEM_REPORT
     );
 
-    cy.get('button[data-testid=button-next]', { timeout: 20000 })
-        .contains('Next')
-        .should('be.visible')
-        .click();
+    cy.get('#dc-migration-assistant-root').then(($section) => {
+        if ($section.text().includes('Ignore and continue')) {
+            cy.get('a', { timeout: 20000 })
+                .contains('Ignore and continue')
+                .should('be.visible')
+                .click();
+        } else {
+            cy.get('button[data-testid=button-next]', { timeout: 20000 })
+                .contains('Next')
+                .should('be.visible')
+                .click();
+        }
+    });
 };

--- a/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
+++ b/jira-e2e-tests/cypress/support/pages/FileSystemMigration.ts
@@ -4,8 +4,8 @@ import { AppContext } from '../common';
 const header = 'Step 4 of 7: Copy Content';
 
 export const startFileSystemInitialMigration = (ctx: AppContext) => {
-    cy.location({timeout: 20000}).should((loc: Location) => {
-        expect(loc.pathname).to.eq(ctx.pluginPath + '/fs');
+    cy.location({ timeout: 20000 }).should((loc: Location) => {
+        expect(loc.pathname).to.eq(`${ctx.pluginPath}/fs`);
     });
     cy.get('#dc-migration-assistant-root h1').contains(header);
     cy.get('button[data-testid=button-cancel]').should('be.visible').and('not.be.disabled');
@@ -33,7 +33,7 @@ export const monitorFileSystemMigration = (ctx: AppContext) => {
             cy.get('a', { timeout: 20000 }).contains('Ignore and continue').click();
         } else {
             cy.log('All green, lets continue');
-            cy.get('button[data-testid=button-next]', { timeout: 20000 }).contains('Next').click();
+            cy.get('button[data-testid=button-next]', { timeout: 20000 }).contains('Next');
         }
     });
 };

--- a/jira-e2e-tests/cypress/support/pages/FinalSync.ts
+++ b/jira-e2e-tests/cypress/support/pages/FinalSync.ts
@@ -2,7 +2,7 @@ import { waitForStatus, EndpointType } from '../waiters';
 export const runFinalSync = () => {
     cy.get('#dc-migration-assistant-root h1').contains('Step 6 of 7: Final Sync');
     cy.get('#dc-migration-assistant-root p').contains(
-        'Now that youve blocked user access to the instance, we can copy its database and sync any new content changes. You can close this page and return anytime to check its progress.'
+        "Now that you've blocked user access to the instance, we can copy its database and sync any new content changes."
     );
 
     cy.get('button[data-testid=button-cancel').should('be.visible');

--- a/jira-e2e-tests/cypress/support/pages/FinalSync.ts
+++ b/jira-e2e-tests/cypress/support/pages/FinalSync.ts
@@ -19,16 +19,8 @@ export const monitorFinalSync = (ctx: AppContext) => {
 
     waitForStatus(
         `${ctx.context}/rest/dc-migration/1.0/migration`,
-        'DATA_MIGRATION_IMPORT',
+        'validation',
         EndpointType.STAGE
-    );
-
-    cy.get('#dc-migration-assistant-root h4').contains('Database import', { timeout: 20000 });
-
-    waitForStatus(
-        `${ctx.context}/rest/dc-migration/1.0/migration/final-sync/status`,
-        'DONE',
-        EndpointType.FINAL_SYNC
     );
 
     cy.get('button[data-testid=button-next').should('be.visible').click();

--- a/jira-e2e-tests/cypress/support/pages/FinalSync.ts
+++ b/jira-e2e-tests/cypress/support/pages/FinalSync.ts
@@ -19,5 +19,5 @@ export const monitorFinalSync = (ctx: AppContext) => {
 
     waitForStatus(`${ctx.context}/rest/dc-migration/1.0/migration`, 'validate', EndpointType.STAGE);
 
-    cy.get('button[data-testid=button-next').should('be.visible').click();
+    cy.get('button[data-testid=button-next').should('be.visible');
 };

--- a/jira-e2e-tests/cypress/support/pages/FinalSync.ts
+++ b/jira-e2e-tests/cypress/support/pages/FinalSync.ts
@@ -17,11 +17,7 @@ export const monitorFinalSync = (ctx: AppContext) => {
     cy.get('button[data-testid=button-cancel').should('be.visible');
     cy.get('button[data-testid=button-refresh').should('be.visible');
 
-    waitForStatus(
-        `${ctx.context}/rest/dc-migration/1.0/migration`,
-        'validation',
-        EndpointType.STAGE
-    );
+    waitForStatus(`${ctx.context}/rest/dc-migration/1.0/migration`, 'validate', EndpointType.STAGE);
 
     cy.get('button[data-testid=button-next').should('be.visible').click();
 };

--- a/jira-e2e-tests/cypress/support/pages/LandingPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/LandingPage.ts
@@ -2,5 +2,5 @@ export const startMigration = (ctx: AppContext) => {
     cy.location().should((loc: Location) => {
         expect(loc.pathname).to.eq(ctx.context + '/plugins/servlet/dc-migration-assistant/home');
     });
-    cy.get('[data-test=start-migration]').should('be.enabled').click({ timeout: 20000 });
+    cy.get('[data-test=start-migration]').should('be.enabled').click({ timeout: 60000 });
 };

--- a/jira-e2e-tests/cypress/support/pages/LandingPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/LandingPage.ts
@@ -2,5 +2,5 @@ export const startMigration = (ctx: AppContext) => {
     cy.location().should((loc: Location) => {
         expect(loc.pathname).to.eq(ctx.context + '/plugins/servlet/dc-migration-assistant/home');
     });
-    cy.get('[data-test=start-migration]').should('exist').click();
+    cy.get('[data-test=start-migration]').should('be.enabled').click({ timeout: 20000 });
 };

--- a/jira-e2e-tests/cypress/support/pages/ProvisioningPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/ProvisioningPage.ts
@@ -29,6 +29,4 @@ export const waitForProvisioning = (ctx: AppContext) => {
     cy.log('Provisioned migration stack stack');
 
     cy.get('button[data-testid=button-next]').contains('Next', { timeout: 60000 }).click();
-
-    cy.relogin(ctx);
 };

--- a/jira-e2e-tests/cypress/support/pages/ProvisioningPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/ProvisioningPage.ts
@@ -28,5 +28,5 @@ export const waitForProvisioning = (ctx: AppContext) => {
     );
     cy.log('Provisioned migration stack stack');
 
-    cy.get('button[data-testid=button-next]').contains('Next', { timeout: 60000 }).click();
+    cy.get('button[data-testid=button-next]').contains('Next', { timeout: 60000 });
 };

--- a/jira-e2e-tests/cypress/support/pages/ProvisioningPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/ProvisioningPage.ts
@@ -28,9 +28,7 @@ export const waitForProvisioning = (ctx: AppContext) => {
     );
     cy.log('Provisioned migration stack stack');
 
-    cy.get('#dc-migration-assistant-root h4').contains('Deployment Complete', { timeout: 60000 });
-
-    cy.get('button[data-testid=button-next]').contains('Next').click();
+    cy.get('button[data-testid=button-next]').contains('Next', { timeout: 60000 }).click();
 
     cy.relogin(ctx);
 };

--- a/jira-e2e-tests/cypress/support/pages/QuickstartForm.ts
+++ b/jira-e2e-tests/cypress/support/pages/QuickstartForm.ts
@@ -1,3 +1,5 @@
+import { AppContext, CloudFormationFormValues } from '../common';
+
 export const configureQuickStartFormWithoutVPC = (
     ctx: AppContext,
     values: CloudFormationFormValues

--- a/jira-e2e-tests/cypress/support/pages/SelectAsiPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/SelectAsiPage.ts
@@ -7,7 +7,7 @@ export const selectPrefixOnASIPage = (ctx: AppContext, prefix: string = 'ATL-') 
         "We're scanning your AWS account for existing ASIs. This may take a while."
     );
 
-    cy.get('section').contains('We found an existing ASI', { timeout: 40000 });
+    cy.get('section').contains('We found an existing ASI', { timeout: 90000 });
     cy.get('[name=deploymentMode]').check('existing');
     cy.get('.asi-select')
         .click()

--- a/jira-e2e-tests/cypress/support/pages/ValidationPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/ValidationPage.ts
@@ -1,5 +1,5 @@
 export const showsValidationPage = (): string => {
-    let serviceUrl
+    let serviceUrl;
 
     cy.location().should((loc: Location) => {
         expect(loc.pathname).to.contain('/plugins/servlet/dc-migration-assistant/validation');
@@ -10,8 +10,8 @@ export const showsValidationPage = (): string => {
         .then((href) => {
             const hval = href.attr('href');
             if (typeof hval === 'string') {
-                serviceUrl = hval
-                cy.log(serviceUrl)
+                serviceUrl = hval;
+                cy.log(serviceUrl);
             }
         });
 
@@ -30,11 +30,14 @@ export const showsValidationPage = (): string => {
         .click({ force: true })
         .should('be.checked');
 
-    cy.get('button').should('contain.text', 'Close the migration app').and('be.enabled').click();
+    cy.get('#dc-migration-assistant-root button')
+        .should('contain.text', 'Close the migration app')
+        .and('be.enabled')
+        .click();
 
     cy.location().should((loc: Location) => {
         expect(loc.pathname).to.contain('/home');
     });
 
-    return serviceUrl
+    return serviceUrl;
 };

--- a/jira-e2e-tests/cypress/support/pages/ValidationPage.ts
+++ b/jira-e2e-tests/cypress/support/pages/ValidationPage.ts
@@ -1,20 +1,12 @@
-export const showsValidationPage = (): string => {
-    let serviceUrl;
+import { AppContext } from '../common';
+
+export const showsValidationPage = () => {
 
     cy.location().should((loc: Location) => {
         expect(loc.pathname).to.contain('/plugins/servlet/dc-migration-assistant/validation');
     });
     cy.get('#dc-migration-assistant-root h1').contains('Step 7 of 7: Validation');
-    cy.get('#dc-migration-assistant-root p > a')
-        .contains('http://')
-        .then((href) => {
-            const hval = href.attr('href');
-            if (typeof hval === 'string') {
-                serviceUrl = hval;
-                cy.log(serviceUrl);
-            }
-        });
-
+    
     cy.get('#dc-migration-assistant-root section h1').contains(
         'To complete the setup of your new deployment'
     );
@@ -32,12 +24,9 @@ export const showsValidationPage = (): string => {
 
     cy.get('#dc-migration-assistant-root button')
         .should('contain.text', 'Close the migration app')
-        .and('be.enabled')
-        .click();
-
-    cy.location().should((loc: Location) => {
-        expect(loc.pathname).to.contain('/home');
-    });
-
-    return serviceUrl;
+        .and('be.enabled');
 };
+
+export const closeMigrationApp = (ctx: AppContext) => {
+  cy.visit(`${ctx.pluginFullUrl}/validation`)
+}

--- a/jira-e2e-tests/cypress/support/waiters.ts
+++ b/jira-e2e-tests/cypress/support/waiters.ts
@@ -8,10 +8,12 @@ export const waitForStatus = (
 ) => {
     cy.request({
         url: route,
-        auth: { user: 'admin', password: Cypress.env('ADMIN_PASSWORD') },
+        auth: { user: 'admin', password: Cypress.env('ADMIN_PASSWORD'), timeout: 10000 },
     }).then((response) => {
         const provisioningStatus: string = getStatus(type, response);
-        cy.log(`run #${iteration}, status ${provisioningStatus}`);
+        cy.log(
+            `run #${iteration}, status ${provisioningStatus}, expected status ${expectedStatus}`
+        );
         if (provisioningStatus === expectedStatus) {
             return;
         } else if (finishedStatuses.includes(provisioningStatus)) {
@@ -19,7 +21,9 @@ export const waitForStatus = (
         } else if (maxRetries < iteration) {
             throw Error(`Maximum amount of retries reached (${maxRetries})`);
         } else {
+            cy.log(`The expected status was not found, wating ${waitPeriodInMs}`);
             cy.wait(waitPeriodInMs);
+            cy.log(`Running the recursion, iteration #${iteration + 1}`);
             waitForStatus(route, expectedStatus, type, iteration + 1, waitPeriodInMs, maxRetries);
         }
     });

--- a/jira-e2e-tests/cypress/yarn.lock
+++ b/jira-e2e-tests/cypress/yarn.lock
@@ -271,7 +271,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cypress/listr-verbose-renderer@0.4.1":
+"@cypress/listr-verbose-renderer@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
   integrity sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
@@ -281,7 +281,7 @@
     date-fns "^1.27.2"
     figures "^1.7.0"
 
-"@cypress/request@2.88.5":
+"@cypress/request@^2.88.5":
   version "2.88.5"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.5.tgz#8d7ecd17b53a849cfd5ab06d5abe7d84976375d7"
   integrity sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==
@@ -307,7 +307,7 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-"@cypress/xvfb@1.2.4":
+"@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
   integrity sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
@@ -606,12 +606,12 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
-"@types/sinonjs__fake-timers@6.0.1":
+"@types/sinonjs__fake-timers@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
   integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
-"@types/sizzle@2.3.2":
+"@types/sizzle@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
@@ -751,7 +751,7 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-arch@2.1.2:
+arch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.2.tgz#0c52bbe7344bb4fa260c443d2cbad9c00ff2f0bf"
   integrity sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==
@@ -919,7 +919,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bluebird@3.7.2:
+bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -1006,7 +1006,7 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cachedir@2.3.0:
+cachedir@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
   integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
@@ -1033,15 +1033,6 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1053,6 +1044,15 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
@@ -1061,7 +1061,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-check-more-types@2.24.0:
+check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
@@ -1095,7 +1095,7 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-table3@0.5.1:
+cli-table3@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
   integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
@@ -1181,12 +1181,12 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@4.1.1:
+commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-common-tags@1.8.0:
+common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
@@ -1265,48 +1265,48 @@ cssstyle@^2.0.0:
   dependencies:
     cssom "~0.3.6"
 
-cypress@^4.10.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.11.0.tgz#054b0b85fd3aea793f186249ee1216126d5f0a7e"
-  integrity sha512-6Yd598+KPATM+dU1Ig0g2hbA+R/o1MAKt0xIejw4nZBVLSplCouBzqeKve6XsxGU6n4HMSt/+QYsWfFcoQeSEw==
+cypress@4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.12.0.tgz#b9d9b16d45be28543edc0e4dc89987bed5bb090b"
+  integrity sha512-ZDngKMwoQ2UYmeSUJikLMZG6t2N7lTHHlzBzh5W0MbPfXSMv36YUgL2ZVD+t4ZLA63WWkvhwxIkDG+WJknBgHw==
   dependencies:
-    "@cypress/listr-verbose-renderer" "0.4.1"
-    "@cypress/request" "2.88.5"
-    "@cypress/xvfb" "1.2.4"
-    "@types/sinonjs__fake-timers" "6.0.1"
-    "@types/sizzle" "2.3.2"
-    arch "2.1.2"
-    bluebird "3.7.2"
-    cachedir "2.3.0"
-    chalk "2.4.2"
-    check-more-types "2.24.0"
-    cli-table3 "0.5.1"
-    commander "4.1.1"
-    common-tags "1.8.0"
-    debug "4.1.1"
-    eventemitter2 "6.4.2"
-    execa "1.0.0"
-    executable "4.1.1"
-    extract-zip "1.7.0"
-    fs-extra "8.1.0"
-    getos "3.2.1"
-    is-ci "2.0.0"
-    is-installed-globally "0.3.2"
-    lazy-ass "1.6.0"
-    listr "0.14.3"
-    lodash "4.17.19"
-    log-symbols "3.0.0"
-    minimist "1.2.5"
-    moment "2.26.0"
-    ospath "1.2.2"
-    pretty-bytes "5.3.0"
-    ramda "0.26.1"
-    request-progress "3.0.0"
-    supports-color "7.1.0"
-    tmp "0.1.0"
-    untildify "4.0.0"
-    url "0.11.0"
-    yauzl "2.10.0"
+    "@cypress/listr-verbose-renderer" "^0.4.1"
+    "@cypress/request" "^2.88.5"
+    "@cypress/xvfb" "^1.2.4"
+    "@types/sinonjs__fake-timers" "^6.0.1"
+    "@types/sizzle" "^2.3.2"
+    arch "^2.1.2"
+    bluebird "^3.7.2"
+    cachedir "^2.3.0"
+    chalk "^2.4.2"
+    check-more-types "^2.24.0"
+    cli-table3 "~0.5.1"
+    commander "^4.1.1"
+    common-tags "^1.8.0"
+    debug "^4.1.1"
+    eventemitter2 "^6.4.2"
+    execa "^1.0.0"
+    executable "^4.1.1"
+    extract-zip "^1.7.0"
+    fs-extra "^8.1.0"
+    getos "^3.2.1"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.3.2"
+    lazy-ass "^1.6.0"
+    listr "^0.14.3"
+    lodash "^4.17.19"
+    log-symbols "^3.0.0"
+    minimist "^1.2.5"
+    moment "^2.27.0"
+    ospath "^1.2.2"
+    pretty-bytes "^5.3.0"
+    ramda "~0.26.1"
+    request-progress "^3.0.0"
+    supports-color "^7.1.0"
+    tmp "~0.1.0"
+    untildify "^4.0.0"
+    url "^0.11.0"
+    yauzl "^2.10.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1329,13 +1329,6 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1347,6 +1340,13 @@ debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -1478,17 +1478,17 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eventemitter2@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.2.tgz#f31f8b99d45245f0edbc5b00797830ff3b388970"
-  integrity sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw==
+eventemitter2@^6.4.2:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.3.tgz#35c563619b13f3681e7eb05cbdaf50f56ba58820"
+  integrity sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==
 
 exec-sh@^0.3.2:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
-execa@1.0.0, execa@^1.0.0:
+execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
   integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
@@ -1517,7 +1517,7 @@ execa@^3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-executable@4.1.1:
+executable@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
   integrity sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==
@@ -1593,7 +1593,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@1.7.0:
+extract-zip@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
   integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
@@ -1708,7 +1708,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@8.1.0:
+fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -1761,7 +1761,7 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getos@3.2.1:
+getos@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/getos/-/getos-3.2.1.tgz#0134d1f4e00eb46144c5a9c0ac4dc087cbb27dc5"
   integrity sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==
@@ -1973,7 +1973,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-ci@2.0.0, is-ci@^2.0.0:
+is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
@@ -2051,7 +2051,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-installed-globally@0.3.2:
+is-installed-globally@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
   integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
@@ -2682,7 +2682,7 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lazy-ass@1.6.0:
+lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
@@ -2734,7 +2734,7 @@ listr-verbose-renderer@^0.5.0:
     date-fns "^1.27.2"
     figures "^2.0.0"
 
-listr@0.14.3:
+listr@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
   integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
@@ -2771,17 +2771,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.19, lodash@^4.17.19:
+lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-log-symbols@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
-  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
-  dependencies:
-    chalk "^2.4.2"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -2789,6 +2782,13 @@ log-symbols@^1.0.2:
   integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
   dependencies:
     chalk "^1.0.0"
+
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -2898,7 +2898,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@1.2.5, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -2918,10 +2918,10 @@ mkdirp@0.x, mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-moment@2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
-  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+moment@^2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
 ms@2.0.0:
   version "2.0.0"
@@ -3098,7 +3098,7 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-ospath@1.2.2:
+ospath@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
@@ -3236,7 +3236,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-pretty-bytes@5.3.0:
+pretty-bytes@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
   integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
@@ -3297,7 +3297,7 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-ramda@0.26.1:
+ramda@~0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
@@ -3367,7 +3367,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request-progress@3.0.0:
+request-progress@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
   integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
@@ -3844,13 +3844,6 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-supports-color@7.1.0, supports-color@^7.0.0, supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -3862,6 +3855,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.0.0, supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-hyperlinks@^2.0.0:
   version "2.1.0"
@@ -3908,7 +3908,7 @@ throttleit@^1.0.0:
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
   integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
 
-tmp@0.1.0:
+tmp@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
@@ -4081,7 +4081,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-untildify@4.0.0:
+untildify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
@@ -4098,7 +4098,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url@0.11.0:
+url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
@@ -4297,7 +4297,7 @@ yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yauzl@2.10.0, yauzl@^2.10.0:
+yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=

--- a/jira-e2e-tests/docker-compose.yml
+++ b/jira-e2e-tests/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       - CYPRESS_AWS_SECRET_ACCESS_KEY=${CYPRESS_AWS_SECRET_ACCESS_KEY}
       - CYPRESS_ADMIN_PASSWORD=${CYPRESS_ADMIN_PASSWORD}
       - CYPRESS_TARGET_TESTSUITE=${CYPRESS_TARGET_TESTSUITE}
+    volumes:
+      - "/tmp/cypress/screenshots:/opt/cypress/screenshots"
+      - "/tmp/cypress/videos:/opt/cypress/videos"
     command: >
       bash -c "
           cd /opt/cypress &&

--- a/jira-e2e-tests/docker-compose.yml
+++ b/jira-e2e-tests/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.5'
 
 services:
-
   postgresql:
     build:
       context: ./postgres
@@ -43,6 +42,7 @@ services:
       '
 
   cypress:
+    ipc: host
     build:
       context: ./cypress
     environment:


### PR DESCRIPTION
* Add Github Actions for the end to end test
* Expose screenshots and videos from the docker container
* Split the large e2e test into separate functions (so we can see what failed)
* Hide typed passwords
* Re-login after long-running actions (provisioning, fs sync)
* Handle failed FS migrated files (e.g. analytics log)
* Increase timeouts to reflect slower Actions environment
