### PR TITLE
CHET-634: re-use provisioning

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
@@ -20,7 +20,6 @@ import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException
-import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
 import com.atlassian.sal.api.websudo.WebSudoRequired
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import javax.ws.rs.Consumes
@@ -38,7 +37,7 @@ import javax.ws.rs.core.Response
  */
 @Path("/migration")
 @WebSudoRequired
-class MigrationEndpoint(private val migrationService: MigrationService, private val cleanupService: MigrationInfrastructureCleanupService) {
+class MigrationEndpoint(private val migrationService: MigrationService) {
     /**
      * @return A response with the status of the current migration
      */
@@ -112,7 +111,6 @@ class MigrationEndpoint(private val migrationService: MigrationService, private 
     @Path("/reset")
     @Produces(MediaType.APPLICATION_JSON)
     fun resetMigration(): Response {
-        cleanupService.startMigrationInfrastructureCleanup()
         migrationService.resetMigration()
         return Response.ok().build()
     }

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
@@ -20,6 +20,7 @@ import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
 import com.atlassian.sal.api.websudo.WebSudoRequired
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import javax.ws.rs.Consumes
@@ -37,7 +38,7 @@ import javax.ws.rs.core.Response
  */
 @Path("/migration")
 @WebSudoRequired
-class MigrationEndpoint(private val migrationService: MigrationService) {
+class MigrationEndpoint(private val migrationService: MigrationService, private val cleanupService: MigrationInfrastructureCleanupService) {
     /**
      * @return A response with the status of the current migration
      */
@@ -111,6 +112,7 @@ class MigrationEndpoint(private val migrationService: MigrationService) {
     @Path("/reset")
     @Produces(MediaType.APPLICATION_JSON)
     fun resetMigration(): Response {
+        cleanupService.startMigrationInfrastructureCleanup()
         migrationService.resetMigration()
         return Response.ok().build()
     }

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpoint.kt
@@ -113,7 +113,7 @@ class MigrationEndpoint(private val migrationService: MigrationService, private 
     @Produces(MediaType.APPLICATION_JSON)
     fun resetMigration(): Response {
         cleanupService.startMigrationInfrastructureCleanup()
-        migrationService.deleteMigrations()
+        migrationService.resetMigration()
         return Response.ok().build()
     }
 

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
@@ -148,13 +148,13 @@ class MigrationEndpointTest {
 
     @Test
     fun shouldCleanUpInfrastructureAndResetMigration() {
-        every { migrationService.deleteMigrations() } just Runs
+        every { migrationService.resetMigration() } just Runs
         every { cleanupService.startMigrationInfrastructureCleanup() } returns true
 
         val response = sut.resetMigration()
 
         assertThat(response.status, equalTo(Response.Status.OK.statusCode))
-        verify { migrationService.deleteMigrations() }
+        verify { migrationService.resetMigration() }
         verify { cleanupService.startMigrationInfrastructureCleanup() }
     }
 

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
@@ -21,6 +21,7 @@ import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
 import com.atlassian.plugins.rest.common.sal.websudo.WebSudoRequiredException
 import com.atlassian.plugins.rest.common.sal.websudo.WebSudoResourceContext
 import com.atlassian.plugins.rest.common.sal.websudo.WebSudoResourceFilterFactory
@@ -55,6 +56,9 @@ class MigrationEndpointTest {
 
     @MockK
     lateinit var migrationContext: MigrationContext
+
+    @MockK
+    lateinit var cleanupService: MigrationInfrastructureCleanupService
 
     @InjectMockKs
     lateinit var sut: MigrationEndpoint
@@ -143,13 +147,15 @@ class MigrationEndpointTest {
     }
 
     @Test
-    fun shouldResetMigration() {
+    fun shouldCleanUpInfrastructureAndResetMigration() {
         every { migrationService.resetMigration() } just Runs
+        every { cleanupService.startMigrationInfrastructureCleanup() } returns true
 
         val response = sut.resetMigration()
 
         assertThat(response.status, equalTo(Response.Status.OK.statusCode))
         verify { migrationService.resetMigration() }
+        verify { cleanupService.startMigrationInfrastructureCleanup() }
     }
 
     @Test

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/MigrationEndpointTest.kt
@@ -21,7 +21,6 @@ import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException
-import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
 import com.atlassian.plugins.rest.common.sal.websudo.WebSudoRequiredException
 import com.atlassian.plugins.rest.common.sal.websudo.WebSudoResourceContext
 import com.atlassian.plugins.rest.common.sal.websudo.WebSudoResourceFilterFactory
@@ -56,9 +55,6 @@ class MigrationEndpointTest {
 
     @MockK
     lateinit var migrationContext: MigrationContext
-
-    @MockK
-    lateinit var cleanupService: MigrationInfrastructureCleanupService
 
     @InjectMockKs
     lateinit var sut: MigrationEndpoint
@@ -147,15 +143,13 @@ class MigrationEndpointTest {
     }
 
     @Test
-    fun shouldCleanUpInfrastructureAndResetMigration() {
+    fun shouldResetMigration() {
         every { migrationService.resetMigration() } just Runs
-        every { cleanupService.startMigrationInfrastructureCleanup() } returns true
 
         val response = sut.resetMigration()
 
         assertThat(response.status, equalTo(Response.Status.OK.statusCode))
         verify { migrationService.resetMigration() }
-        verify { cleanupService.startMigrationInfrastructureCleanup() }
     }
 
     @Test

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -39,7 +39,6 @@ import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError;
 import com.atlassian.migration.datacenter.spi.exceptions.MigrationAlreadyExistsException;
-import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService;
 import net.java.ao.Query;
 import net.swiftzer.semver.SemVer;
 import org.apache.commons.lang3.SystemUtils;
@@ -64,19 +63,16 @@ public abstract class AWSMigrationService implements MigrationService {
 
     protected ApplicationConfiguration applicationConfiguration;
     protected EventPublisher eventPublisher;
-    private final MigrationInfrastructureCleanupService cleanupService;
 
     /**
      * Creates a new, unstarted AWS Migration
      */
     public AWSMigrationService(ActiveObjects ao,
                                ApplicationConfiguration applicationConfiguration,
-                               EventPublisher eventPublisher,
-                               MigrationInfrastructureCleanupService cleanupService) {
+                               EventPublisher eventPublisher) {
         this.ao = requireNonNull(ao);
         this.applicationConfiguration = applicationConfiguration;
         this.eventPublisher = eventPublisher;
-        this.cleanupService = cleanupService;
     }
 
     @Override
@@ -119,7 +115,6 @@ public abstract class AWSMigrationService implements MigrationService {
     // When we add support for multiple migrations, we need to revisit this and ensure that, on migration cancel, we should remove the active migration, not all migrations.
     @Override
     public void resetMigration() {
-        cleanupService.startMigrationInfrastructureCleanup();
         log.info("Deleting all migrations");
         for (Migration migration : findAllMigrations()) {
             int migrationId = migration.getID();

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationService.java
@@ -114,7 +114,7 @@ public abstract class AWSMigrationService implements MigrationService {
     //Note: Delete migrations deletes all migrations, even `Finished` ones
     // When we add support for multiple migrations, we need to revisit this and ensure that, on migration cancel, we should remove the active migration, not all migrations.
     @Override
-    public void deleteMigrations() {
+    public void resetMigration() {
         log.info("Deleting all migrations");
         for (Migration migration : findAllMigrations()) {
             int migrationId = migration.getID();

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
@@ -31,9 +31,8 @@ import java.nio.file.Path;
 public class AllowAnyTransitionMigrationServiceFacade extends AwsMigrationServiceWrapper implements MigrationService {
     public AllowAnyTransitionMigrationServiceFacade(ActiveObjects activeObjects,
                                                     ApplicationConfiguration applicationConfiguration,
-                                                    EventPublisher eventPublisher,
-                                                    MigrationInfrastructureCleanupService cleanupService) {
-        super(activeObjects, applicationConfiguration, eventPublisher, cleanupService);
+                                                    EventPublisher eventPublisher) {
+        super(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Override

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/AllowAnyTransitionMigrationServiceFacade.java
@@ -24,14 +24,16 @@ import com.atlassian.migration.datacenter.dto.Migration;
 import com.atlassian.migration.datacenter.spi.MigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationStage;
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError;
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService;
 
 import java.nio.file.Path;
 
 public class AllowAnyTransitionMigrationServiceFacade extends AwsMigrationServiceWrapper implements MigrationService {
     public AllowAnyTransitionMigrationServiceFacade(ActiveObjects activeObjects,
                                                     ApplicationConfiguration applicationConfiguration,
-                                                    EventPublisher eventPublisher) {
-        super(activeObjects, applicationConfiguration, eventPublisher);
+                                                    EventPublisher eventPublisher,
+                                                    MigrationInfrastructureCleanupService cleanupService) {
+        super(activeObjects, applicationConfiguration, eventPublisher, cleanupService);
     }
 
     @Override

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
@@ -81,4 +81,8 @@ class ReuseInfrastructureAWSMigrationService
         eventPublisher.publish(MigrationCreatedEvent(applicationConfiguration.pluginVersion))
     }
 
+    override fun finishCurrentMigration() {
+        resetMigration()
+    }
+
 }

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atlassian.migration.datacenter.core.aws
+
+import com.atlassian.activeobjects.external.ActiveObjects
+import com.atlassian.event.api.EventPublisher
+import com.atlassian.migration.datacenter.analytics.events.MigrationCreatedEvent
+import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration
+import com.atlassian.migration.datacenter.dto.Migration
+import com.atlassian.migration.datacenter.dto.MigrationContext
+import com.atlassian.migration.datacenter.spi.MigrationStage
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureDeploymentState
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ReuseInfrastructureAWSMigrationService
+(
+        private val ao: ActiveObjects,
+        applicationConfiguration: ApplicationConfiguration,
+        eventPublisher: EventPublisher,
+        cleanupService: MigrationInfrastructureCleanupService
+) : AwsMigrationServiceWrapper
+(
+        ao,
+        applicationConfiguration,
+        eventPublisher,
+        cleanupService)
+{
+
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(ReuseInfrastructureAWSMigrationService::class.java)
+    }
+
+    /**
+     * Restarts the migration from the FS copy stage, retaining all deployment parameters
+     */
+    override fun resetMigration() {
+        log.info("resetting migration and retaining infrastructure")
+
+        val context = currentContext
+
+        val migration = ao.create(Migration::class.java)
+        migration.stage = MigrationStage.FS_MIGRATION_COPY
+        migration.save()
+
+        val newContext = ao.create(MigrationContext::class.java)
+        context.migration = migration
+        context.startEpoch = System.currentTimeMillis() / 1000L
+
+        newContext.applicationDeploymentId = context.applicationDeploymentId
+        newContext.helperStackDeploymentId = context.helperStackDeploymentId
+        newContext.serviceUrl = context.serviceUrl
+
+        newContext.deploymentMode = context.deploymentMode
+        newContext.deploymentState = InfrastructureDeploymentState.CREATE_COMPLETE
+
+        newContext.migrationDLQueueUrl = context.migrationDLQueueUrl
+        newContext.migrationBucketName = context.migrationBucketName
+        newContext.migrationQueueUrl = context.migrationQueueUrl
+        newContext.migrationStackAsgIdentifier = context.migrationStackAsgIdentifier
+        newContext.fsRestoreSsmDocument = context.fsRestoreSsmDocument
+        newContext.fsRestoreStatusSsmDocument = context.fsRestoreStatusSsmDocument
+        newContext.rdsRestoreSsmDocument = context.rdsRestoreSsmDocument
+
+        context.save()
+
+        eventPublisher.publish(MigrationCreatedEvent(applicationConfiguration.pluginVersion))
+    }
+
+}

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
@@ -32,14 +32,12 @@ class ReuseInfrastructureAWSMigrationService
 (
         private val ao: ActiveObjects,
         applicationConfiguration: ApplicationConfiguration,
-        eventPublisher: EventPublisher,
-        cleanupService: MigrationInfrastructureCleanupService
+        eventPublisher: EventPublisher
 ) : AwsMigrationServiceWrapper
 (
         ao,
         applicationConfiguration,
-        eventPublisher,
-        cleanupService)
+        eventPublisher)
 {
 
     companion object {

--- a/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
+++ b/core/src/main/java/com/atlassian/migration/datacenter/core/aws/ReuseInfrastructureAWSMigrationService.kt
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory
 
 class ReuseInfrastructureAWSMigrationService
 (
-        private val ao: ActiveObjects,
+        ao: ActiveObjects,
         applicationConfiguration: ApplicationConfiguration,
         eventPublisher: EventPublisher
 ) : AwsMigrationServiceWrapper
@@ -52,13 +52,14 @@ class ReuseInfrastructureAWSMigrationService
 
         val context = currentContext
 
-        val migration = ao.create(Migration::class.java)
+        super.resetMigration()
+
+        val migration = super.createMigration()
+
         migration.stage = MigrationStage.FS_MIGRATION_COPY
         migration.save()
 
-        val newContext = ao.create(MigrationContext::class.java)
-        context.migration = migration
-        context.startEpoch = System.currentTimeMillis() / 1000L
+        val newContext = migration.context
 
         newContext.applicationDeploymentId = context.applicationDeploymentId
         newContext.helperStackDeploymentId = context.helperStackDeploymentId
@@ -75,7 +76,7 @@ class ReuseInfrastructureAWSMigrationService
         newContext.fsRestoreStatusSsmDocument = context.fsRestoreStatusSsmDocument
         newContext.rdsRestoreSsmDocument = context.rdsRestoreSsmDocument
 
-        context.save()
+        newContext.save()
 
         eventPublisher.publish(MigrationCreatedEvent(applicationConfiguration.pluginVersion))
     }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
@@ -7,12 +7,13 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.dto.MigrationContext
 import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage.*
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.math.min
 
 
-open class AwsMigrationServiceWrapper(ao: ActiveObjects?, applicationConfiguration: ApplicationConfiguration?, eventPublisher: EventPublisher?) : AWSMigrationService(ao, applicationConfiguration, eventPublisher), MigrationService {
+open class AwsMigrationServiceWrapper(ao: ActiveObjects?, applicationConfiguration: ApplicationConfiguration?, eventPublisher: EventPublisher?, cleanupService: MigrationInfrastructureCleanupService) : AWSMigrationService(ao, applicationConfiguration, eventPublisher, cleanupService), MigrationService {
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(AwsMigrationServiceWrapper::class.java)

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/aws/AwsMigrationServiceWrapper.kt
@@ -7,13 +7,12 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.dto.MigrationContext
 import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.MigrationStage.*
-import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.math.min
 
 
-open class AwsMigrationServiceWrapper(ao: ActiveObjects?, applicationConfiguration: ApplicationConfiguration?, eventPublisher: EventPublisher?, cleanupService: MigrationInfrastructureCleanupService) : AWSMigrationService(ao, applicationConfiguration, eventPublisher, cleanupService), MigrationService {
+open class AwsMigrationServiceWrapper(ao: ActiveObjects?, applicationConfiguration: ApplicationConfiguration?, eventPublisher: EventPublisher?) : AWSMigrationService(ao, applicationConfiguration, eventPublisher), MigrationService {
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(AwsMigrationServiceWrapper::class.java)

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -260,7 +260,7 @@ public class AWSMigrationServiceTest {
 
         assertNumberOfMigrations(2);
 
-        sut.deleteMigrations();
+        sut.resetMigration();
 
         assertNumberOfMigrations(0);
 
@@ -280,7 +280,7 @@ public class AWSMigrationServiceTest {
         assertNumberOfMigrationContexts(1);
         assertNumberOfFileSyncRecords(3);
 
-        sut.deleteMigrations();
+        sut.resetMigration();
 
         assertNumberOfMigrations(0);
         assertNumberOfMigrationContexts(0);

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/aws/AWSMigrationServiceTest.java
@@ -96,14 +96,12 @@ public class AWSMigrationServiceTest {
     private DatabaseExtractor databaseExtractor;
     @Mock
     private EventPublisher eventPublisher;
-    @Mock
-    private MigrationInfrastructureCleanupService cleanupService;
 
     @Before
     public void setup() {
         assertNotNull(entityManager);
         ao = new TestActiveObjects(entityManager);
-        sut = new AwsMigrationServiceWrapper(ao, applicationConfiguration, eventPublisher, cleanupService);
+        sut = new AwsMigrationServiceWrapper(ao, applicationConfiguration, eventPublisher);
         setupEntities();
         when(applicationConfiguration.getPluginVersion()).thenReturn("DUMMY");
         when(databaseExtractorFactory.getExtractor()).thenReturn(databaseExtractor);
@@ -288,14 +286,6 @@ public class AWSMigrationServiceTest {
         assertNumberOfMigrations(0);
         assertNumberOfMigrationContexts(0);
         assertNumberOfFileSyncRecords(0);
-    }
-
-    @Test
-    public void shouldCleanInfraWhenResettingMigration() {
-        initializeAndCreateSingleMigrationWithStage(FS_MIGRATION_COPY);
-        sut.resetMigration();
-
-        verify(cleanupService).startMigrationInfrastructureCleanup();
     }
 
     @Test

--- a/jira-e2e-tests/helpers/run-local
+++ b/jira-e2e-tests/helpers/run-local
@@ -11,16 +11,25 @@ if [[ $jsrc -nt $jtarget ]]; then
     cp $jsrc $jtarget
 fi
 
+SPRING_PROFILES=""
+
 
 source .env
 for arg do
   shift
   if [[ "$arg" == "--allowAnyTransition" ]]; then
-      JVM_SUPPORT_RECOMMENDED_ARGS="-Dspring.profiles.active=allowAnyTransition ${JVM_SUPPORT_RECOMMENDED_ARGS}"
+      SPRING_PROFILES="allowAnyTransition"
+      continue
+  fi
+  if [[ "$arg" == "--retainInfra" ]]; then
+      SPRING_PROFILES="retainInfra"
       continue
   fi
   set -- "$@" "$arg"
 done
+
+JVM_SUPPORT_RECOMMENDED_ARGS="-Dspring.profiles.active=${SPRING_PROFILES}"
+
 export JVM_SUPPORT_RECOMMENDED_ARGS
 
 cd jira-e2e-tests/

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -23,6 +23,7 @@ import com.atlassian.jira.issue.attachment.AttachmentStore;
 import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.JiraConfiguration;
+import com.atlassian.migration.datacenter.core.aws.AWSMigrationService;
 import com.atlassian.migration.datacenter.core.aws.AwsMigrationServiceWrapper;
 import com.atlassian.migration.datacenter.core.aws.CancellableMigrationServiceHandler;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
@@ -264,8 +265,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher, MigrationInfrastructureCleanupService cleanupService) {
-        return new AwsMigrationServiceWrapper(activeObjects, applicationConfiguration, eventPublisher, cleanupService);
+    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new AwsMigrationServiceWrapper(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -23,7 +23,6 @@ import com.atlassian.jira.issue.attachment.AttachmentStore;
 import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.application.JiraConfiguration;
-import com.atlassian.migration.datacenter.core.aws.AWSMigrationService;
 import com.atlassian.migration.datacenter.core.aws.AwsMigrationServiceWrapper;
 import com.atlassian.migration.datacenter.core.aws.CancellableMigrationServiceHandler;
 import com.atlassian.migration.datacenter.core.aws.CfnApi;
@@ -265,8 +264,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
-        return new AwsMigrationServiceWrapper(activeObjects, applicationConfiguration, eventPublisher);
+    public MigrationService migrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher, MigrationInfrastructureCleanupService cleanupService) {
+        return new AwsMigrationServiceWrapper(activeObjects, applicationConfiguration, eventPublisher, cleanupService);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -95,6 +95,7 @@ import com.atlassian.scheduler.SchedulerService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -425,6 +426,8 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
+    @Primary
+    @Profile("!retainInfra")
     public MigrationInfrastructureCleanupService awsMigrationInfrastructureCleanupService(AWSCleanupTaskFactory cleanupTaskFactory) {
         return new AWSMigrationInfrastructureCleanupService(cleanupTaskFactory);
     }

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -425,7 +425,6 @@ public class MigrationAssistantBeanConfiguration {
     }
 
     @Bean
-    @Primary
     public MigrationInfrastructureCleanupService awsMigrationInfrastructureCleanupService(AWSCleanupTaskFactory cleanupTaskFactory) {
         return new AWSMigrationInfrastructureCleanupService(cleanupTaskFactory);
     }

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
@@ -22,7 +22,9 @@ import com.atlassian.migration.datacenter.core.application.ApplicationConfigurat
 import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
 import com.atlassian.migration.datacenter.core.aws.ReuseInfrastructureAWSMigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.infrastructure.InfrastructureCleanupStatus;
 import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -33,14 +35,32 @@ public class MigrationAssistantProfileSpecificConfiguration {
     @Bean
     @Profile("allowAnyTransition")
     @Primary
-    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher, MigrationInfrastructureCleanupService cleanupService) {
-        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher, cleanupService);
+    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher);
     }
 
     @Bean
     @Profile("retainInfra")
     @Primary
-    public MigrationService reuseInfrastructureAWSMigrationService(ActiveObjects ao, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher, MigrationInfrastructureCleanupService cleanupService) {
-        return new ReuseInfrastructureAWSMigrationService(ao, applicationConfiguration, eventPublisher, cleanupService);
+    public MigrationService reuseInfrastructureAWSMigrationService(ActiveObjects ao, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
+        return new ReuseInfrastructureAWSMigrationService(ao, applicationConfiguration, eventPublisher);
+    }
+
+    @Bean
+    @Profile("retainInfra")
+    @Primary
+    public MigrationInfrastructureCleanupService noCleanupService() {
+        return new MigrationInfrastructureCleanupService() {
+            @Override
+            public boolean startMigrationInfrastructureCleanup() {
+                return true;
+            }
+
+            @NotNull
+            @Override
+            public InfrastructureCleanupStatus getMigrationInfrastructureCleanupStatus() {
+                return InfrastructureCleanupStatus.CLEANUP_COMPLETE;
+            }
+        };
     }
 }

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
@@ -33,8 +33,8 @@ public class MigrationAssistantProfileSpecificConfiguration {
     @Bean
     @Profile("allowAnyTransition")
     @Primary
-    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
-        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher);
+    public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher, MigrationInfrastructureCleanupService cleanupService) {
+        return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher, cleanupService);
     }
 
     @Bean

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantProfileSpecificConfiguration.java
@@ -20,7 +20,9 @@ import com.atlassian.activeobjects.external.ActiveObjects;
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.migration.datacenter.core.application.ApplicationConfiguration;
 import com.atlassian.migration.datacenter.core.aws.AllowAnyTransitionMigrationServiceFacade;
+import com.atlassian.migration.datacenter.core.aws.ReuseInfrastructureAWSMigrationService;
 import com.atlassian.migration.datacenter.spi.MigrationService;
+import com.atlassian.migration.datacenter.spi.infrastructure.MigrationInfrastructureCleanupService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -33,5 +35,12 @@ public class MigrationAssistantProfileSpecificConfiguration {
     @Primary
     public MigrationService allowAnyTransitionMigrationService(ActiveObjects activeObjects, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher) {
         return new AllowAnyTransitionMigrationServiceFacade(activeObjects, applicationConfiguration, eventPublisher);
+    }
+
+    @Bean
+    @Profile("retainInfra")
+    @Primary
+    public MigrationService reuseInfrastructureAWSMigrationService(ActiveObjects ao, ApplicationConfiguration applicationConfiguration, EventPublisher eventPublisher, MigrationInfrastructureCleanupService cleanupService) {
+        return new ReuseInfrastructureAWSMigrationService(ao, applicationConfiguration, eventPublisher, cleanupService);
     }
 }

--- a/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
+++ b/spi/src/main/kotlin/com/atlassian/migration/datacenter/spi/MigrationService.kt
@@ -61,9 +61,9 @@ interface MigrationService {
     val currentContext: MigrationContext
 
     /**
-     * Deletes all migrations and associated contexts.
+     * Clears out the current migration to a "not started" state.
      */
-    fun deleteMigrations()
+    fun resetMigration()
 
     /**
      * Tries to transition the migration state from one to another


### PR DESCRIPTION
# Summary

* Create beans which will bypass cleanup of infra at end of migration
* Create beans which will reset migration to FS copy stage at end of migration
* Add configuration to `jira-e2-tests/helpers/run-local` script that runs the app in a mode which retains infrastructure

Companion documentation to this feature: https://aws-partner.atlassian.net/wiki/spaces/DOA/pages/395903049/HOWTO+retain+infrastructure+between+migrations+when+testing+Trebuchet