### PR TITLE
CHET-638/9: Move abort and state transition from file migration endpoint to fs partial retry service

### DIFF
--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
@@ -140,14 +140,6 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
     fun retryFileSystemMigration(): Response {
         log.debug("[Retry operation] Retrying file system migration")
 
-        try {
-            log.debug("[Retry operation] Transitioning stage to File system start stage")
-            migrationService.transition(MigrationStage.FS_MIGRATION_COPY)
-        } catch (e: InvalidMigrationStageError) {
-            log.error("[Retry operation] Unable to transition stage to {}", MigrationStage.FS_MIGRATION_COPY, e)
-            return Response.status(Response.Status.BAD_REQUEST).build()
-        }
-
         val isMigrationScheduled = fsMigrationService.scheduleMigration()
 
         log.info("[Retry operation] Retrying FS migration operation success status {}", isMigrationScheduled)

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
@@ -17,9 +17,9 @@ package com.atlassian.migration.datacenter.api.fs
 
 import com.atlassian.migration.datacenter.core.fs.FileSystemMigrationReportManager
 import com.atlassian.migration.datacenter.core.fs.ReportType
+import com.atlassian.migration.datacenter.core.fs.RetryFailedFileMigration
 import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager
-import com.atlassian.migration.datacenter.spi.MigrationService
-import com.atlassian.migration.datacenter.spi.MigrationStage
+import com.atlassian.migration.datacenter.spi.exceptions.FileSystemMigrationFailure
 import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService
 import com.atlassian.sal.api.websudo.WebSudoNotRequired
@@ -45,9 +45,8 @@ import javax.ws.rs.core.Response
 class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigrationService,
                                   private val attachmentSyncManager: AttachmentSyncManager,
                                   private val reportManager: FileSystemMigrationReportManager,
-                                  private val migrationService: MigrationService
-)
-{
+                                  private val retryService: RetryFailedFileMigration
+) {
 
     companion object {
         val log: Logger = LoggerFactory.getLogger(FileSystemMigrationEndpoint::class.java)
@@ -63,21 +62,21 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
         return if (fsMigrationService.isRunning) {
             val report = reportManager.getCurrentReport(ReportType.Filesystem)
             Response
-                .status(Response.Status.CONFLICT)
-                .entity(mapOf("status" to report!!.status))
-                .build()
+                    .status(Response.Status.CONFLICT)
+                    .entity(mapOf("status" to report!!.status))
+                    .build()
         } else try {
             val started = fsMigrationService.scheduleMigration()
             val builder =
-                if (started) Response.status(Response.Status.ACCEPTED) else Response.status(Response.Status.CONFLICT)
+                    if (started) Response.status(Response.Status.ACCEPTED) else Response.status(Response.Status.CONFLICT)
             builder
-                .entity(mapOf("migrationScheduled" to started))
-                .build()
+                    .entity(mapOf("migrationScheduled" to started))
+                    .build()
         } catch (invalidMigrationStageError: InvalidMigrationStageError) {
             Response
-                .status(Response.Status.CONFLICT)
-                .entity(mapOf("error" to invalidMigrationStageError.message))
-                .build()
+                    .status(Response.Status.CONFLICT)
+                    .entity(mapOf("error" to invalidMigrationStageError.message))
+                    .build()
         }
     }
 
@@ -102,19 +101,19 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
     @WebSudoNotRequired // Avoids tripping the websudo redirect until advancing to the next stage. The report should not contain any sensitive information.
     fun getFilesystemMigrationStatus(): Response {
         val report = reportManager.getCurrentReport(ReportType.Filesystem)
-            ?: return Response
-                .status(Response.Status.BAD_REQUEST)
-                .entity(mapOf("error" to "no file system migration exists"))
-                .build()
+                ?: return Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity(mapOf("error" to "no file system migration exists"))
+                        .build()
         return try {
             Response
-                .ok(mapper.writeValueAsString(report))
-                .build()
+                    .ok(mapper.writeValueAsString(report))
+                    .build()
         } catch (e: JsonProcessingException) {
             Response
-                .serverError()
-                .entity("Unable to get file system status. Please contact support and show them this error: ${e.message}")
-                .build()
+                    .serverError()
+                    .entity("Unable to get file system status. Please contact support and show them this error: ${e.message}")
+                    .build()
         }
     }
 
@@ -125,12 +124,12 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
         return try {
             fsMigrationService.abortMigration()
             Response
-                .ok(mapOf("cancelled" to true))
-                .build()
+                    .ok(mapOf("cancelled" to true))
+                    .build()
         } catch (e: InvalidMigrationStageError) {
             Response.status(Response.Status.CONFLICT)
-                .entity(mapOf("error" to "filesystem migration is not in progress"))
-                .build()
+                    .entity(mapOf("error" to "filesystem migration is not in progress"))
+                    .build()
         }
     }
 
@@ -140,11 +139,16 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
     fun retryFileSystemMigration(): Response {
         log.debug("[Retry operation] Retrying file system migration")
 
-        val isMigrationScheduled = fsMigrationService.scheduleMigration()
+        try {
+            retryService.uploadFailedFiles()
+        } catch (e: FileSystemMigrationFailure) {
+            return Response.status(Response.Status.CONFLICT).build()
+        }
 
-        log.info("[Retry operation] Retrying FS migration operation success status {}", isMigrationScheduled)
 
-        return Response.status(if (isMigrationScheduled) Response.Status.ACCEPTED else Response.Status.CONFLICT).build()
+        log.info("[Retry operation] Retrying FS migration operation")
+
+        return Response.status(Response.Status.ACCEPTED).build()
     }
 
     init {

--- a/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
+++ b/api/src/main/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationEndpoint.kt
@@ -139,12 +139,6 @@ class FileSystemMigrationEndpoint(private val fsMigrationService: FilesystemMigr
     @Path("/retry")
     fun retryFileSystemMigration(): Response {
         log.debug("[Retry operation] Retrying file system migration")
-        try {
-            log.debug("[Retry operation] Aborting current migration, if there is a migration in progress")
-            fsMigrationService.abortMigration()
-        } catch (e: InvalidMigrationStageError) {
-            log.error("[Retry operation] Unable to abort a migration. Proceeding with retrying the migration.", e)
-        }
 
         try {
             log.debug("[Retry operation] Transitioning stage to File system start stage")

--- a/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
+++ b/api/src/test/kotlin/com/atlassian/migration/datacenter/api/fs/FileSystemMigrationProgressEndpointTest.kt
@@ -17,8 +17,8 @@ package com.atlassian.migration.datacenter.api.fs
 
 import com.atlassian.migration.datacenter.core.fs.FileSystemMigrationReportManager
 import com.atlassian.migration.datacenter.core.fs.ReportType
+import com.atlassian.migration.datacenter.core.fs.RetryFailedFileMigration
 import com.atlassian.migration.datacenter.core.fs.captor.AttachmentSyncManager
-import com.atlassian.migration.datacenter.spi.MigrationService
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService
 import com.atlassian.migration.datacenter.spi.fs.reporting.FailedFileMigration
 import com.atlassian.migration.datacenter.spi.fs.reporting.FileSystemMigrationReport
@@ -59,7 +59,7 @@ class FileSystemMigrationProgressEndpointTest {
     lateinit var fsMigrationService: FilesystemMigrationService
 
     @MockK
-    lateinit var migrationService: MigrationService
+    lateinit var retryService: RetryFailedFileMigration
 
     @InjectMockKs
     lateinit var endpoint: FileSystemMigrationEndpoint
@@ -156,8 +156,8 @@ class FileSystemMigrationProgressEndpointTest {
 
         assertEquals(Response.Status.BAD_REQUEST.statusCode, response.status)
         assertThat<String?>(
-            response.entity.toString(),
-            Matchers.containsString("no file system migration exists")
+                response.entity.toString(),
+                Matchers.containsString("no file system migration exists")
         )
     }
 

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
@@ -17,21 +17,41 @@
 package com.atlassian.migration.datacenter.core.fs
 
 import com.atlassian.migration.datacenter.core.util.UploadQueue
+import com.atlassian.migration.datacenter.spi.MigrationService
+import com.atlassian.migration.datacenter.spi.MigrationStage
+import com.atlassian.migration.datacenter.spi.exceptions.FileSystemMigrationFailure
+import com.atlassian.migration.datacenter.spi.exceptions.InvalidMigrationStageError
 import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
-class RetryFailedFileMigration(private val reportManager: FileSystemMigrationReportManager, private val uploaderFactory: UploaderFactory, private val fsMigrationService: FilesystemMigrationService) {
+class RetryFailedFileMigration(
+        private val reportManager: FileSystemMigrationReportManager,
+        private val uploaderFactory: UploaderFactory,
+        private val fsMigrationService: FilesystemMigrationService,
+        private val migrationService: MigrationService
+) {
 
     companion object {
         val log: Logger = LoggerFactory.getLogger(RetryFailedFileMigration::class.java)
     }
 
+    @Throws(InvalidMigrationStageError::class)
     fun uploadFailedFiles() {
-        log.debug("[Retry operation] Aborting current file system migration, if there is a migration in progress")
+        try {
+            log.debug("[FS Retry] Aborting current file system migration, if there is a migration in progress")
+            fsMigrationService.abortMigration()
+        } catch (e: InvalidMigrationStageError) {
+            throw FileSystemMigrationFailure("[FS Retry] Error aborting fs migration", e)
+        }
 
-        fsMigrationService.abortMigration()
+        try {
+            log.debug("[FS Retry] Transitioning stage to File system start stage")
+            migrationService.transition(MigrationStage.FS_MIGRATION_COPY)
+        } catch (e: InvalidMigrationStageError) {
+            throw FileSystemMigrationFailure("[FS Retry] Error performing retry state transition", e)
+        }
 
         val report = reportManager.getCurrentReport(ReportType.Filesystem) ?: throw Error("No report")
         val newReport = reportManager.resetReport(ReportType.Filesystem)

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
@@ -68,6 +68,8 @@ class RetryFailedFileMigration(
         val uploader = uploaderFactory.newUploader(report)
 
         uploader.upload(uploadQueue)
+
+        migrationService.transition(MigrationStage.OFFLINE_WARNING)
     }
 
 }

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
@@ -37,14 +37,10 @@ class RetryFailedFileMigration(
         val log: Logger = LoggerFactory.getLogger(RetryFailedFileMigration::class.java)
     }
 
-    @Throws(InvalidMigrationStageError::class)
+    @Throws(FileSystemMigrationFailure::class)
     fun uploadFailedFiles() {
-        try {
-            log.debug("[FS Retry] Aborting current file system migration, if there is a migration in progress")
-            fsMigrationService.abortMigration()
-        } catch (e: InvalidMigrationStageError) {
-            throw FileSystemMigrationFailure("[FS Retry] Error aborting fs migration", e)
-        }
+        log.debug("[FS Retry] Aborting current file system migration, if there is a migration in progress")
+        fsMigrationService.abortMigration()
 
         try {
             log.debug("[FS Retry] Transitioning stage to File system start stage")

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
@@ -63,6 +63,8 @@ class RetryFailedFileMigration(
             newReport.reportFileFound()
         }
 
+        migrationService.transition(MigrationStage.FS_MIGRATION_COPY_WAIT)
+
         val uploader = uploaderFactory.newUploader(report)
 
         uploader.upload(uploadQueue)

--- a/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
+++ b/core/src/main/kotlin/com/atlassian/migration/datacenter/core/fs/RetryFailedFileMigration.kt
@@ -17,11 +17,22 @@
 package com.atlassian.migration.datacenter.core.fs
 
 import com.atlassian.migration.datacenter.core.util.UploadQueue
+import com.atlassian.migration.datacenter.spi.fs.FilesystemMigrationService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
-class RetryFailedFileMigration(private val reportManager: FileSystemMigrationReportManager, private val uploaderFactory: UploaderFactory) {
+class RetryFailedFileMigration(private val reportManager: FileSystemMigrationReportManager, private val uploaderFactory: UploaderFactory, private val fsMigrationService: FilesystemMigrationService) {
+
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(RetryFailedFileMigration::class.java)
+    }
 
     fun uploadFailedFiles() {
+        log.debug("[Retry operation] Aborting current file system migration, if there is a migration in progress")
+
+        fsMigrationService.abortMigration()
+
         val report = reportManager.getCurrentReport(ReportType.Filesystem) ?: throw Error("No report")
         val newReport = reportManager.resetReport(ReportType.Filesystem)
 

--- a/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
+++ b/jira-plugin/src/main/java/com/atlassian/migration/datacenter/configuration/MigrationAssistantBeanConfiguration.java
@@ -69,6 +69,7 @@ import com.atlassian.migration.datacenter.core.fs.DefaultFileSystemMigrationRepo
 import com.atlassian.migration.datacenter.core.fs.DefaultFilesystemUploaderFactory;
 import com.atlassian.migration.datacenter.core.fs.FileSystemMigrationReportManager;
 import com.atlassian.migration.datacenter.core.fs.FilesystemUploaderFactory;
+import com.atlassian.migration.datacenter.core.fs.RetryFailedFileMigration;
 import com.atlassian.migration.datacenter.core.fs.S3FilesystemMigrationService;
 import com.atlassian.migration.datacenter.core.fs.S3UploaderFactory;
 import com.atlassian.migration.datacenter.core.fs.UploaderFactory;
@@ -453,5 +454,10 @@ public class MigrationAssistantBeanConfiguration {
                 s3FinalSyncService,
                 filesystemMigrationService,
                 databaseMigrationService);
+    }
+
+    @Bean
+    public RetryFailedFileMigration retryFailedFileMigration(FileSystemMigrationReportManager reportManager, UploaderFactory uploaderFactory, FilesystemMigrationService fsMigrationService, MigrationService migrationService) {
+        return new RetryFailedFileMigration(reportManager, uploaderFactory, fsMigrationService, migrationService);
     }
 }

--- a/jira-plugin/src/main/resources/templates/dc-migration-assistant.soy
+++ b/jira-plugin/src/main/resources/templates/dc-migration-assistant.soy
@@ -7,7 +7,7 @@
     {webResourceManager_requireResourcesForContext('dc-migration-assistant')}
     <html>
         <head>
-            <title>Hello</title>
+            <title>Data Center Migration/title>
             <meta name="decorator" content="atl.admin"/>
             <meta name="admin.active.section" content="admin_system_menu/advanced_menu_section"/>
             <meta name="activeTab" content="migrationAssistantItem"/>


### PR DESCRIPTION
## Summary

* Move abort of file system migration from file migration API endpoint to new FS migration Retry service
  * Before uploading the failed files, the service will abort the running FS migration
  * Note: Is this the right thing to do? We were doing it before but in my opinion, we shouldn't allow retry while the FS migration is in progress. This is a hypothetical scenario but better safe then sorry imo.
* Move retry transition `FS_MIGRATION_ERROR` ➡️ `FS_MIGRATION_COPY` to file system retry service
* Add missing transition `FS_MIGRATION_COPY` ➡️ `FS_MIGRATION_COPY_WAIT` to file system retry service