### PR TITLE
DCD-1070: Bump release version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-utils/pom.xml
+++ b/build-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.atlassian.migration.datacenter</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/filesystem-processor/pom.xml
+++ b/filesystem-processor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
     <artifactId>filesystem-processor</artifactId>
 

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>frontend</artifactId>

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>jira-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.atlassian.migration.datacenter</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.1</version>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Original `1.1.0` release was a bad cut. 

Creating a new release and tag for `1.1.1`. 