### PR TITLE
NONE: Add e2e tests for releases/* branches

### DIFF
--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: End to end test with production image
         timeout-minutes: 120
-        if: ${{ matrix.profile == 'end2end' && matrix.java == '11' && github.ref == env.MAIN_BRANCH_REF }}
+        if: matrix.profile == 'end2end' && matrix.java == '11' && ( github.ref == env.MAIN_BRANCH_REF || startsWith(github.ref, 'releases/') )
         env:
           JIRA_E2E_LICENSE: ${{ secrets.JIRA_E2E_LICENSE }}
           CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.CYPRESS_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
We should be naming our release branches `releases/XY` and for them we should run the e2e test as well.

Ideally we should automate our release process further.