### PR TITLE
Hotfix update quickstart GitHub url

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,13 +15,11 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-utils/pom.xml
+++ b/build-utils/pom.xml
@@ -15,13 +15,11 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,13 +15,11 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>com.atlassian.migration.datacenter</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/filesystem-processor/pom.xml
+++ b/filesystem-processor/pom.xml
@@ -15,13 +15,12 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>filesystem-processor</artifactId>
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-DEFAULT_QUICKSTART_WITH_VPC_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/master/templates/quickstart-jira-dc-with-vpc.template.yaml
-DEFAULT_QUICKSTART_STANDALONE_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/master/templates/quickstart-jira-dc.template.yaml
+DEFAULT_QUICKSTART_WITH_VPC_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/main/templates/quickstart-jira-dc-with-vpc.template.yaml
+DEFAULT_QUICKSTART_STANDALONE_PARAMETER_URL=https://raw.githubusercontent.com/aws-quickstart/quickstart-atlassian-jira/main/templates/quickstart-jira-dc.template.yaml

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -15,14 +15,12 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>frontend</artifactId>

--- a/jira-e2e-tests/README.md
+++ b/jira-e2e-tests/README.md
@@ -22,7 +22,7 @@ The wrapper Docker image injects a pre-configured Jira database. The database
 has had the license field removed, and in must be injected before use. The
 license can be aquired from several places:
 
-* Members of the DC Deployments team have access to "Jira E2E smoketest license"
+* Members of the DC Deployments team have access to "Trebuchet Jira E2E smoketest license 2"
   in [LastPass](https://lastpass.com).
 * Other Atlassians can generate a license via the [License Encoder
   Service](https://license-encoder-service--app.ap-southeast-2.dev.atl-paas.net/).

--- a/jira-e2e-tests/jira/Dockerfile
+++ b/jira-e2e-tests/jira/Dockerfile
@@ -2,14 +2,12 @@ ARG JIRA_VERSION
 FROM atlassian/jira-software:${JIRA_VERSION}
 
 RUN apt-get update && apt-get install gnupg2 -y -q
-
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends netcat-openbsd \
     && apt-get install -y -q software-properties-common \
-    && apt-get install -y -q  postgresql-client-9.6 postgresql-contrib-9.6 \
+    && apt-get install -y -q postgresql postgresql-client postgresql-contrib \
     && apt-get clean
 
 COPY waitport /usr/local/bin/waitport

--- a/jira-plugin/pom.xml
+++ b/jira-plugin/pom.xml
@@ -15,14 +15,12 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>jira-plugin</artifactId>
@@ -118,7 +116,7 @@
                     <classpathScope>compile</classpathScope>
                     <executable>java</executable>
                     <arguments>
-                        <argument>-classpath</argument><classpath/>
+                        <argument>-classpath</argument><classpath />
                         <argument>com.atlassian.migration.datacenter.build.GenWhitelistKt</argument>
 
                         <argument>com.atlassian.migration.datacenter.analytics.events</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -27,7 +26,7 @@
 
     <groupId>com.atlassian.migration.datacenter</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -518,7 +517,7 @@
         <apache.maven.exec.version>3.0.0</apache.maven.exec.version>
         <ao.version>3.2.2</ao.version>
         <amps.version>8.0.4</amps.version>
-        <amps.jvm.args/>
+        <amps.jvm.args />
         <atlassian.platform.version>5.0.13</atlassian.platform.version>
         <atlassian.plugins.osgi.javaconfig.version>0.2.0</atlassian.plugins.osgi.javaconfig.version>
         <atlassian.plugins.version>5.2.1</atlassian.plugins.version>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -15,13 +15,11 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.atlassian.migration.datacenter</groupId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Amazon changed the default branch for the quicksarts to `main` 🥳 However we didn't correct the URL of our quickstarts so I've done that now. We also released a new version to marketplace so the version has been bumped up (I accidentally skipped a version).