### PR TITLE
Fix some failing tests

### DIFF
--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           cache-name: cache-m2
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-

--- a/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
+++ b/core/src/test/java/com/atlassian/migration/datacenter/core/fs/S3UploaderTest.java
@@ -174,7 +174,7 @@ class S3UploaderTest {
                     throw new RuntimeException(e);
                 }
             }
-        },0, 200, TimeUnit.MILLISECONDS);
+        },0, 50, TimeUnit.MILLISECONDS);
 
         uploader.upload(queue);
         exec.cancel(true);

--- a/jira-e2e-tests/cypress/integration/smoketest.ts
+++ b/jira-e2e-tests/cypress/integration/smoketest.ts
@@ -30,6 +30,9 @@ describe('Plugin installation smoke tests', () => {
     it('Ensure plugin loaded', () => {
         cy.visit(ctx.upmURL);
 
+        // The UPM row isn't in the viewport on load and for some reason cypress won't scroll
+        // to the element when clicking it. We scroll to the bottom of the screen before the click
+        // so that we can guarantee the row appears within the viewport so it can be clicked
         cy.scrollTo('bottom');
 
         cy.get('[data-key="com.atlassian.migration.datacenter.jira-plugin"]', {

--- a/jira-e2e-tests/cypress/integration/smoketest.ts
+++ b/jira-e2e-tests/cypress/integration/smoketest.ts
@@ -36,7 +36,7 @@ describe('Plugin installation smoke tests', () => {
             timeout: 60 * 1000,
         })
             .should('exist')
-            .click('left');
+            .click();
 
         cy.get('.upm-count-enabled').should((el) => {
             expect(el.first()).to.contain('9 of 9 modules enabled');

--- a/jira-e2e-tests/cypress/integration/smoketest.ts
+++ b/jira-e2e-tests/cypress/integration/smoketest.ts
@@ -36,7 +36,7 @@ describe('Plugin installation smoke tests', () => {
             timeout: 60 * 1000,
         })
             .should('exist')
-            .click();
+            .click('left');
 
         cy.get('.upm-count-enabled').should((el) => {
             expect(el.first()).to.contain('9 of 9 modules enabled');

--- a/jira-e2e-tests/cypress/integration/smoketest.ts
+++ b/jira-e2e-tests/cypress/integration/smoketest.ts
@@ -30,11 +30,13 @@ describe('Plugin installation smoke tests', () => {
     it('Ensure plugin loaded', () => {
         cy.visit(ctx.upmURL);
 
+        cy.scrollTo('bottom');
+
         cy.get('[data-key="com.atlassian.migration.datacenter.jira-plugin"]', {
             timeout: 60 * 1000,
         })
             .should('exist')
-            .click({ scrollBehavior: 'bottom' });
+            .click('left');
 
         cy.get('.upm-count-enabled').should((el) => {
             expect(el.first()).to.contain('9 of 9 modules enabled');

--- a/jira-e2e-tests/cypress/integration/smoketest.ts
+++ b/jira-e2e-tests/cypress/integration/smoketest.ts
@@ -34,8 +34,7 @@ describe('Plugin installation smoke tests', () => {
             timeout: 60 * 1000,
         })
             .should('exist')
-            .scrollIntoView()
-            .click();
+            .click({ scrollBehavior: 'bottom' });
 
         cy.get('.upm-count-enabled').should((el) => {
             expect(el.first()).to.contain('9 of 9 modules enabled');

--- a/jira-e2e-tests/cypress/integration/smoketest.ts
+++ b/jira-e2e-tests/cypress/integration/smoketest.ts
@@ -34,6 +34,7 @@ describe('Plugin installation smoke tests', () => {
             timeout: 60 * 1000,
         })
             .should('exist')
+            .scrollIntoView()
             .click();
 
         cy.get('.upm-count-enabled').should((el) => {

--- a/pom.xml
+++ b/pom.xml
@@ -558,7 +558,7 @@
         <soy.version>5.0.0</soy.version>
         <spring.version>5.0.10.RELEASE</spring.version>
         <surefire.version>3.0.0-M5</surefire.version>
-        <testcontainers.version>1.13.0</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <webfragments.version>5.1.0</webfragments.version>
         <woodstox.core.version>6.0.3</woodstox.core.version>
     </properties>


### PR DESCRIPTION
###### This test was failing in GitHub actions probably due to scheduling of the runnable. I've changed the test so that the background thread does the checking and sets a pass condition. This means the upload will always "start" and block until the queue is finished. The condition should get a chance to execute.
---
This task grew a bit with many other failing tests so here is a full summary:

* Update `testcontainers` which was causing failures due to old version with no longer existing `ryuk` image tag
* Fix flaky s3 uploader test by inverting async dependencies so the assertion was in a background thread
* Fix smoke test which failed because DC Migration Assistant app was not visible in viewport in UPM