### PR TITLE
DCD-1164: Fix java 11 Unit Tests

### DIFF
--- a/.github/workflows/mvn_test.yml
+++ b/.github/workflows/mvn_test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [8]
+        java: [8, 11]
         profile: ["integration", "!integration", "smoketest", "functest", "end2end"]
 
     steps:


### PR DESCRIPTION
The Java 11 unit tests were failing because `CloudformationDeploymentServiceTest#shouldCallHandleFailedDeploymentWhenDeploymentFails` was failing repeatedly. This test was relying on thread jittering to pass so I have refactored it so that it waits until the "deployment" is "completed" before checking the deployment as failed.
