### PR TITLE
DCD-1177: XML External Entity (XXE) vulnrability fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.version>1.3.70</kotlin.version>
         <semver.version>1.1.1</semver.version>
-        <jackson.version>2.10.3</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
         <jacoco.version>0.8.5</jacoco.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>


### PR DESCRIPTION
This version bump fixes all of the XXE vulnerabilities currently associated with the code base except for this [one](https://github.com/atlassian-labs/dc-migration-assistant/security/code-scanning/272?query=ref%3Arefs%2Fheads%2Fdcd-1177-xml-external-entity)

At present there is no fix for this see [SNYK-JAVA-DOM4J-174153](https://snyk.io/vuln/SNYK-JAVA-DOM4J-174153)

