### PR TITLE
Additional vulnerability mitigation

### DIFF
--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -2,9 +2,10 @@
 
 name: On branch Snyk security scan
 
-on: push
-  branches:
-    - '!master'   # excludes master
+on:
+  push:
+    branches-ignore:
+      - master
         
 jobs:
   security:

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -1,6 +1,6 @@
 # Snyk on branch security scanning
 
-name: On branch Snyk security scan
+name: Security scan - branch push
 
 on:
   push:

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -14,12 +14,12 @@ jobs:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
-        #continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
+        if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -18,6 +18,10 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --all-projects --exclude=templates --sarif-file-output=snyk.sarif
+      - name: Print the content for the snyk.sarif file
+        if: ${{ always() }
+        run: |
+          cat snyk.sarif
       - name: Upload result to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_V2 }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --all-projects --exclude=templates --sarif-file-output=snyk.sarif
+          args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
         with:

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
+          args: --all-projects --exclude=templates --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_V2 }}
         with:
           args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -17,11 +17,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --all-projects --exclude=templates --sarif-file-output=snyk.sarif
-      - name: Print the content for the snyk.sarif file
-        if: ${{ always() }}
-        run: |
-          cat snyk.sarif
+          args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           args: --all-projects --exclude=templates --sarif-file-output=snyk.sarif
       - name: Print the content for the snyk.sarif file
-        if: ${{ always() }
+        if: ${{ always() }}
         run: |
           cat snyk.sarif
       - name: Upload result to GitHub Code Scanning

--- a/.github/workflows/snyk_security.yml
+++ b/.github/workflows/snyk_security.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
-        continue-on-error: true # To make sure that SARIF upload gets called
+        #continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/snyk_security_master.yml
+++ b/.github/workflows/snyk_security_master.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_V2 }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning

--- a/.github/workflows/snyk_security_master.yml
+++ b/.github/workflows/snyk_security_master.yml
@@ -1,11 +1,21 @@
-# Snyk on branch security scanning
+# Snyk security scan to be run everyday at midnight.
+#
+# As of 03/05/2022 there are no severe security issues
+# associated with master, other than those which have exemptions
+# defined in the respective module .snyk files. 
+#
+# If there are severe issues encountered on master this action 
+# will fail and cause the build to go red until the security issue 
+# is remediated. 
 
-name: On branch Snyk security scan
+name: Master branch Snyk security scan
 
-on: push
+on: push:
   branches:
-    - '!master'   # excludes master
-        
+    - 'master'
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+
 jobs:
   security:
     runs-on: ubuntu-latest
@@ -13,7 +23,6 @@ jobs:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
-        continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/snyk_security_master.yml
+++ b/.github/workflows/snyk_security_master.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/maven-3-jdk-11@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_V2 }}
         with:
           args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning

--- a/.github/workflows/snyk_security_master.yml
+++ b/.github/workflows/snyk_security_master.yml
@@ -10,11 +10,12 @@
 
 name: Master branch Snyk security scan
 
-on: push:
-  branches:
-    - 'master'
-  schedule:
-    - cron: "0 0 * * *" # every day at midnight
+on:
+  push:
+    branches:
+      - master
+    schedule:
+      - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   security:

--- a/.github/workflows/snyk_security_master.yml
+++ b/.github/workflows/snyk_security_master.yml
@@ -8,14 +8,11 @@
 # will fail and cause the build to go red until the security issue 
 # is remediated. 
 
-name: Master branch Snyk security scan
+name: Security scanning - daily on main
 
 on:
-  push:
-    branches:
-      - master
-    schedule:
-      - cron: "0 0 * * *" # every day at midnight
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   security:

--- a/.github/workflows/snyk_security_master.yml
+++ b/.github/workflows/snyk_security_master.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --all-projects --exclude=templates --sarif-file-output=snyk.sarif
+          args: --all-projects --exclude=templates --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
         with:

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-COMFASTERXMLJACKSONDATAFORMAT-1047329:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:16:21.312Z
+  SNYK-JAVA-ORGAPACHETOMCATEMBED-1080637:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:17:07.686Z
+patch: {}

--- a/api/.snyk
+++ b/api/.snyk
@@ -1,0 +1,28 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-IONETTY-543490:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:25.670Z
+  SNYK-JAVA-IONETTY-543669:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:39.918Z
+  SNYK-JAVA-IONETTY-564897:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:53.690Z
+  SNYK-JAVA-DOM4J-174153:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of
+          atlassian-plugins-api which is supplied by the host application i.e.
+          Jira
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:06:06.763Z
+patch: {}

--- a/core/.snyk
+++ b/core/.snyk
@@ -1,0 +1,49 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-IONETTY-543490:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:25.670Z
+  SNYK-JAVA-IONETTY-543669:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:39.918Z
+  SNYK-JAVA-IONETTY-564897:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:53.690Z
+  SNYK-JAVA-COMMONSCOLLECTIONS-30078:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:09:35.447Z
+  SNYK-JAVA-DOM4J-174153:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of
+          atlassian-plugins-api which is supplied by the host application i.e.
+          Jira
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:09:58.208Z
+  SNYK-JAVA-LOG4J-572732:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:10:16.223Z
+  SNYK-JAVA-XERCES-31585:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:10:30.487Z
+patch: {}

--- a/filesystem-processor/.snyk
+++ b/filesystem-processor/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-COMFASTERXMLJACKSONDATAFORMAT-1047329:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:16:21.312Z
+  SNYK-JAVA-ORGAPACHETOMCATEMBED-1080637:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:17:07.686Z
+patch: {}

--- a/filesystem-processor/pom.xml
+++ b/filesystem-processor/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web-services</artifactId>
+            <version>2.3.0.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/frontend/.snyk
+++ b/frontend/.snyk
@@ -1,0 +1,36 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-LODASHTEMPLATE-1088054:
+    - '*':
+        reason: >-
+          No direct upgrade or patch. Currently using latest version of
+          react-scripts
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T05:07:52.081Z
+  SNYK-JS-SSRI-1085630:
+    - '*':
+        reason: >-
+          Already using latest version (4.46) of webpack 4. This vulnrability is
+          a transitive dependency of webpack 4 as such it cannot be remediated.
+          It may be fixable in webpack 5 although tests show that it isnt.
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T05:30:07.105Z
+  SNYK-JS-SSRI-124639:
+    - '*':
+        reason: >-
+          Already using latest version (4.46) of webpack 4. This vulnrability is
+          a transitive dependency of webpack 4 as such it cannot be remediated.
+          It may be fixable in webpack 5 although tests show that it isnt.
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T05:30:29.801Z
+  SNYK-JS-SSRI-1246392:
+    - '*':
+        reason: >-
+          Already using latest version (4.46) of webpack 4. This vulnrability is
+          a transitive dependency of webpack 4 as such it cannot be remediated.
+          It may be fixable in webpack 5 although tests show that it isnt.
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T05:41:51.460Z
+patch: {}

--- a/jira-plugin/.snyk
+++ b/jira-plugin/.snyk
@@ -1,0 +1,48 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-IONETTY-543490:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:25.670Z
+  SNYK-JAVA-IONETTY-543669:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:39.918Z
+  SNYK-JAVA-IONETTY-564897:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T04:23:53.690Z
+  SNYK-JAVA-COMMONSCOLLECTIONS-30078:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:07:57.897Z
+  SNYK-JAVA-DOM4J-174153:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:08:13.878Z
+  SNYK-JAVA-LOG4J-572732:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:08:28.586Z
+  SNYK-JAVA-XERCES-31585:
+    - '*':
+        reason: >-
+          No direct upgrade or patch - Transitive dependency of jira-api. Tests
+          show that upgrading to latest does not remediate this vulnrability
+        expires: 2021-07-03T00:00:00.000Z
+        created: 2021-05-03T06:08:42.960Z
+patch: {}

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -40,10 +40,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Add exemptions for vulnerabilities relating to transitive dependencies found in; jira-api, atlassian-plugin, webpack, aws sdk. An expiry is also set on these exemptions so that on the 3rd of July 2021 these will no longer be exempt and will need to be re-assessed

As part of this PR an additional Snyk Github action has been added for `master`. This scan will:

- Run everyday at midnight on`master` only
- Fail when any severe vulnerabilities are encountered, meaning action needs to be taken to keep master up to date from a security standpoint